### PR TITLE
Added option to use multicolor font patch.

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -30,6 +30,7 @@ class EmacsPlus < Formula
   option "without-modules", "Build without dynamic modules support"
   option "without-spacemacs-icon", "Build without Spacemacs icon by Nasser Alshammari"
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
+  option "with-multicolor-fonts", "Build using patch for enabling multicolor font support."
 
   deprecated_option "cocoa" => "with-cocoa"
   deprecated_option "keep-ctags" => "with-ctags"
@@ -46,6 +47,13 @@ class EmacsPlus < Formula
   if build.with? "x11"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
+  end
+
+  if build.with? "multicolor-fonts"
+    patch do
+      url "https://gist.githubusercontent.com/aatxe/260261daf70865fbf1749095de9172c5/raw/214b50c62450be1cbee9f11cecba846dd66c7d06/patch-multicolor-font.diff"
+      sha256 "5af2587e986db70999d1a791fca58df027ccbabd75f45e4a2af1602c75511a8c"
+    end
   end
 
   def install


### PR DESCRIPTION
This resolves #15 by adding a `--with-multicolor-fonts` option which applies a patch reverting the commit that disabled multicolor font support for macOS.