### PR TITLE
Add vfork patch

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -84,6 +84,17 @@ class EmacsPlus < Formula
     end
   end
 
+  # vfork patch
+  # remove after 26.1 is released
+  # Backported from https://github.com/emacs-mirror/emacs/commit/a13eaddce2ddbe3ba0b7f4c81715bc0fcdba99f6
+  # See http://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
+  unless build.head?
+    patch do
+      url "https://gist.githubusercontent.com/aaronjensen/f45894ddf431ecbff78b1bcf533d3e6b/raw/6a5cd7f57341aba673234348d8b0d2e776f86719/Emacs-25-OS-X-use-vfork.patch"
+      sha256 "f2fdbc5adab80f1af01ce120cf33e3b0590d7ae29538999287986beb55ec9ada"
+    end
+  end
+
   def install
     args = %W[
       --disable-dependency-tracking

--- a/README.org
+++ b/README.org
@@ -58,6 +58,8 @@ relevant part from output of that command for your convenience.
 	Build without a patch that enables multicolor font support
 --without-spacemacs-icon
 	Build without Spacemacs icon by Nasser Alshammari
+--with-vfork
+  Experimental: Speed up call-process calls in GUI.
 --devel
 	Install development version 25.1.90
 --HEAD


### PR DESCRIPTION
This significantly speeds up `call-process` which is used heavily by magit.
Ultimately, this makes magit, and probably other things more responsive. The
author does not know if this is totally safe. The original comment left
indicated a failure mode that no longer reproduces on OS X 10.11.

This flag should be considered experimental.

See http://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
and https://github.com/magit/magit/issues/2909