### PR TITLE
Update title bar patch sha256

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -75,7 +75,7 @@ class EmacsPlus < Formula
 
     patch do
       url "https://gitlab.com/brds/GNU-Emacs-OS-X-no-title-bar/raw/master/GNU-Emacs-25.1-OS-X-no-title-bar.patch"
-      sha256 "51b9bbe4c731e7f5b391fdae98cf5c946b77e45b8dc25317cdd00e4180c72241"
+      sha256 "d098240657791aa1da9ed93f96a2168d11660db816e0253a63b8a5fac2f7d399"
     end
   end
 


### PR DESCRIPTION
The patch changed slightly. It doesn't actually work on 25.2 as far as I can tell, so it still needs some work to actually be functional now that this repo points to 25.2.

In other words, this may not be worth accepting. I may have some time tomorrow to get the patch working w/ 25.2