### PR TITLE
Fix README's link to issues page.

### DIFF
--- a/README.org
+++ b/README.org
@@ -75,7 +75,7 @@ with any arising issues.
 
 ** Known Issues
 
-Please checkout [[https://github.com/d12frosted/homebrew-emacs-plus/issues?utf8=%E2%9C%93&q=is%253Aissue%2520][Issues]] page for a list of all known issues.
+Please checkout [[https://github.com/d12frosted/homebrew-emacs-plus/issues][Issues]] page for a list of all known issues.
 
 ** Acknowledgements
 


### PR DESCRIPTION
The existing link to the Issues page at the bottom of the README took you to issues page w/ no results because the query string was double url encoded. I just removed the query string all together because as far as I know github defaults to open issues.

I clicked this link a few times tonight and figured I'd save myself and anyone else a few seconds by making this pull request.