### PR TITLE
formula: add 24bit truecolor support

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -28,6 +28,8 @@ class EmacsPlus < Formula
          "Build without dynamic modules support"
   option "without-spacemacs-icon",
          "Build without Spacemacs icon by Nasser Alshammari"
+  option "with-24bit-color",
+         "Experimental: build with 24 bit color support"
   option "with-ctags",
          "Don't remove the ctags executable that Emacs provides"
   option "without-multicolor-fonts",
@@ -83,6 +85,16 @@ class EmacsPlus < Formula
     patch do
       url "https://gist.githubusercontent.com/jwintz/853f0075cf46770f5ab4f1dbf380ab11/raw/bc30bd2e9a7bf6873f3a3e301d0085bcbefb99b0/emacs_dark_title_bar.patch"
       sha256 "742f7275f3ada695e32735fa02edf91a2ae7b1fa87b7e5f5c6478dd591efa162"
+    end
+  end
+
+  # 24 bit color patch
+  # remove after 26.1 is released
+  # See https://gist.github.com/akorobov/2c9f5796c661304b4d8aa64c89d2cd00
+  if build.with? "24bit-color"
+    patch do
+      url "https://gist.githubusercontent.com/akorobov/2c9f5796c661304b4d8aa64c89d2cd00/raw/2f7d3ae544440b7e2d3a13dd126b491bccee9dbf/emacs-25.2-term-24bit-colors.diff"
+      sha256 "ffe72c57117a6dca10b675cbe3701308683d24b62611048d2e7f80f419820cd0"
     end
   end
 

--- a/README.org
+++ b/README.org
@@ -30,6 +30,8 @@ relevant part from output of that command for your convenience.
 
 #+BEGIN_SRC bash
 ==> Options
+--with-24bit-color
+	Experimental: build with 24 bit color support
 --with-ctags
 	Don't remove the ctags executable that Emacs provides
 --with-dbus


### PR DESCRIPTION
This is based on work of akorobov

See his gist:
https://gist.github.com/akorobov/2c9f5796c661304b4d8aa64c89d2cd00

Note: this does not work out of the box, need a bustom terminfo as
described below:

Upstream commit message/doc

Emacs 26.1 and later support direct color mode in terminals.  If Emacs
finds Terminfo capabilities @samp{setb24} and @samp{setf24}, 24-bit
direct color mode is used.  The capability strings are expected to
take one 24-bit pixel value as argument and transform the pixel to a
string that can be used to send 24-bit colors to the terminal.

There aren't yet any standard terminal type definitions that would
support the capabilities, but Emacs can be invoked with a custom
definition as shown below.

@example
$ cat terminfo-24bit.src

xterm-24bit|xterm with 24-bit direct color mode,
   use=xterm-256color,
   setb24=\E[48:2:%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%dm,
   setf24=\E[38:2:%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%dm,
xterm-24bits|xterm with 24-bit direct color mode,
   use=xterm-256color,
   setb24=\E[48;2;%p1%{65536}%/%d;%p1%{256}%/%{255}%&%d;%p1%{255}%&%dm,
   setf24=\E[38;2;%p1%{65536}%/%d;%p1%{256}%/%{255}%&%d;%p1%{255}%&%dm,

$ tic -x -o ~/.terminfo terminfo-24bit.src

$ TERM=xterm-24bit emacs -nw
@end example

Currently there's no standard way to determine whether a terminal
supports direct color mode.  If such standard arises later on, support
for @samp{setb24} and @samp{setf24} may be removed.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>