### PR TITLE
Known issue note about rust dependency and compile time

### DIFF
--- a/README.org
+++ b/README.org
@@ -83,6 +83,12 @@ with any arising issues.
 
 Please checkout [[https://github.com/d12frosted/homebrew-emacs-plus/issues][Issues]] page for a list of all known issues.
 
+*** Rust Dependency 
+	
+The librsvg dependency requires the rust compiler at build time. Rust can take
+quite a while to build (30+ minutes), so if you don't need SVG rendering support
+use the `--without-librsvg` flag when installing.
+
 ** Screenshots
 
 #+BEGIN_HTML


### PR DESCRIPTION
Hi!

I was following the instructions for spacemacs to install `emacs-plus` and I noticed that the install was taking a while because it was installing rust. I inspected the dep tree with `brew deps --tree --include-build emacs-plus` and I saw that the from-source rust compiler package was a dependency of `librsvg` which can be disabled optionally.

Anyway, I thought I would add a note for others looking around and wondering why the rust compiler is required for this package. 

You might also consider making `librsvg` a `--with` dependency?

Oh, and don't feel obligated to merge this, I just tend to submit PRs instead of issues where there is some trivial solution available.

Thanks!