### PR TITLE
Add option with-xwidgets which brings xwidget webkit for cocoa

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -116,6 +116,9 @@ class EmacsPlus < Formula
     unless build.head?
       odie "--with-wdidgets is supported only on --HEAD"
     end
+    unless build.with? "cocoa"
+      odie "--with-wdidgets is supported only on cocoa via xwidget webkit"
+    end
     patch do
       url "https://gist.githubusercontent.com/fuxialexander/0231e994fd27be6dd87db60339238813/raw/b30c2d3294835f41e2c8afa1e63571531a38f3cf/0_all_webkit.patch"
       sha256 "f35b955aef31537d2ff163ec9bfcc2176dbcd0ea64f05440d98ec2988b82ce25"

--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -113,9 +113,12 @@ class EmacsPlus < Formula
   end
 
   if build.with? "xwidgets"
+    unless build.head?
+      odie "--with-wdidgets is supported only on --HEAD"
+    end
     patch do
-      url "https://gist.githubusercontent.com/irfn/64037e7172c0d28a90e60afd15030572/raw/55ffbc215a8b85fa9a523def29d1ae306d7c2bf0/0_all_webkit.patch"
-      sha256 "731775ea0065cc96861f17d04d5a8b2f620a1e3a9ed7213e42598ac44cfe4b64"
+      url "https://gist.githubusercontent.com/fuxialexander/0231e994fd27be6dd87db60339238813/raw/b30c2d3294835f41e2c8afa1e63571531a38f3cf/0_all_webkit.patch"
+      sha256 "f35b955aef31537d2ff163ec9bfcc2176dbcd0ea64f05440d98ec2988b82ce25"
     end
   end
 

--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -23,7 +23,8 @@ class EmacsPlus < Formula
          "Build without Spacemacs icon by Nasser Alshammari"
   option "without-multicolor-fonts",
          "Build without a patch that enables multicolor font support"
-
+  option "with-xwidgets",
+         "Build with xwidgets"
   # Opt-in
   option "with-ctags",
          "Don't remove the ctags executable that Emacs provides"
@@ -111,6 +112,14 @@ class EmacsPlus < Formula
     end
   end
 
+  if build.with? "xwidgets"
+    patch do
+      url "https://gist.githubusercontent.com/irfn/64037e7172c0d28a90e60afd15030572/raw/55ffbc215a8b85fa9a523def29d1ae306d7c2bf0/0_all_webkit.patch"
+      sha256 "731775ea0065cc96861f17d04d5a8b2f620a1e3a9ed7213e42598ac44cfe4b64"
+    end
+  end
+
+
   resource "modern-icon" do
     url "https://s3.amazonaws.com/emacs-mac-port/Emacs.icns.modern"
     sha256 "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5"
@@ -194,6 +203,7 @@ class EmacsPlus < Formula
     args << "--with-modules" if build.with? "modules"
     args << "--with-rsvg" if build.with? "librsvg"
     args << "--without-pop" if build.with? "mailutils"
+    args << "--with-xwidgets" if build.with? "xwidgets"
 
     if build.head?
       ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"

--- a/README.org
+++ b/README.org
@@ -83,6 +83,8 @@ relevant part from output of that command for your convenience.
 	Using a modern style Emacs icon by @tpanum
 --with-pdumper
 	Experimental: build from pdumper branch and with increased remembered_data size (--HEAD only)
+--with-xwidgets
+    Experimental: Emacs xwidget webkit support for macOS X Cocoa. Does not work with --without-cocoa. (--HEAD only)
 --with-x11
 	Experimental: build with x11 support
 --without-cocoa
@@ -125,6 +127,10 @@ now the code is in the =dumper= branch of the Emacs Git repository.
 In order to use that branch, please use =--with-pdumper --HEAD= options.
 
 Please, take a look at it's usage in [[https://github.com/syl20bnr/spacemacs/blob/develop/EXPERIMENTAL.org#spacemacs-dumps-using-the-portable-dumper][Spacemacs]].
+
+*** Xwidgets (webkit)
+The original [[https://www.emacswiki.org/emacs/EmacsXWidgets][Emacs xwidgets]] builds and works on macOS however must be used with x11 and hence not practical option on macOS. This version enables xwidgets on native macOS X Cocoa via embedding a native webkit window.
+More details can be seen here [[https://github.com/veshboo/emacs][Veshboo's emacs branch]]
 
 ** Emacs configuration
 Emacs is a journey. And for some of you these projects might be inspiring.


### PR DESCRIPTION
This is done by applying @veshboo's work (https://github.com/veshboo/emacs) via an all in one patch created by @fuxialexander in his gist (https://gist.github.com/fuxialexander/0231e994fd27be6dd87db60339238813)

- Have restricted to cocoa and HEAD only since the patch applies on master
- Can possibly be adapted to 26.1 by an updated patch