### PR TITLE
Update no title bars flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -88,7 +88,7 @@ relevant part from output of that command for your convenience.
     Build with mailutils support
   --with-modern-icon
     Using a modern style Emacs icon by @tpanum
-  --with-no-titlebar
+  --with-no-title-bars
     Experimental: build without titlebar
   --with-pdumper
     Experimental: build from pdumper branch and with increased remembered_data size (--HEAD only)


### PR DESCRIPTION
The `--with-no-titlebar` flag seems to be replaced with `--with-no-title-bars`