### PR TITLE
Disable focusing on other frame when closing current one

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -55,6 +55,8 @@ class EmacsPlus < Formula
 
   option "with-modern-icon", "Using a modern style Emacs icon by @tpanum"
 
+  option "with-no-frame-refocus", "Disables frame re-focus (ie. closing one frame does not refocus another one)"
+
   # Emacs 26.x and Emacs 27.x experimental stuff
   option "with-x11", "Experimental: build with x11 support"
   option "with-no-titlebar", "Experimental: build without titlebar"
@@ -149,6 +151,12 @@ class EmacsPlus < Formula
     end
   end
 
+  if build.with? "no-frame-refocus"
+    patch do
+      url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/no-frame-refocus-cocoa.patch"
+      sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
+    end
+  end
 
   resource "modern-icon" do
     url "https://s3.amazonaws.com/emacs-mac-port/Emacs.icns.modern"

--- a/patches/no-frame-refocus-cocoa.patch
+++ b/patches/no-frame-refocus-cocoa.patch
@@ -1,0 +1,20 @@
+diff --git a/src/frame.c b/src/frame.c
+index 46bdf22231..08584384f4 100644
+--- a/src/frame.c
++++ b/src/frame.c
+@@ -2000,15 +2000,6 @@ delete_frame (Lisp_Object frame, Lisp_Object force)
+ 		}
+ 	    }
+ 	}
+-#ifdef NS_IMPL_COCOA
+-      else
+-	/* Under NS, there is no system mechanism for choosing a new
+-	   window to get focus -- it is left to application code.
+-	   So the portion of THIS application interfacing with NS
+-	   needs to know about it.  We call Fraise_frame, but the
+-	   purpose is really to transfer focus.  */
+-	Fraise_frame (frame1);
+-#endif
+
+       do_switch_frame (frame1, 0, 1, Qnil);
+       sf = SELECTED_FRAME ();


### PR DESCRIPTION
When closing a frame, Emacs automatically focuses another frame. This re-focus has an additional side-effect: when closing a frame from one desktop/space, the user gets automatically moved to another desktop/space where the refocused frame lives. This can be distracting.

Pull request disables this behavior by introducing the --with-no-frame-refocus install option and thus fixing #119.