### PR TITLE
Only apply multicolor-font patch if not on HEAD

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -137,9 +137,11 @@ class EmacsPlus < Formula
   end
 
   if build.with? "multicolor-fonts"
-    patch do
-      url "https://gist.githubusercontent.com/aatxe/260261daf70865fbf1749095de9172c5/raw/214b50c62450be1cbee9f11cecba846dd66c7d06/patch-multicolor-font.diff"
-      sha256 "5af2587e986db70999d1a791fca58df027ccbabd75f45e4a2af1602c75511a8c"
+    unless build.head?
+      patch do
+        url "https://gist.githubusercontent.com/aatxe/260261daf70865fbf1749095de9172c5/raw/214b50c62450be1cbee9f11cecba846dd66c7d06/patch-multicolor-font.diff"
+        sha256 "5af2587e986db70999d1a791fca58df027ccbabd75f45e4a2af1602c75511a8c"
+      end
     end
   end
 


### PR DESCRIPTION
Given its inclusion in [a recent change][1], we no longer need to patch the `src/macfont.m` file if installing from `HEAD`.

[1]: https://github.com/emacs-mirror/emacs/commit/28220664714c50996d8318788289e1c69d69b8ab#diff-ee87d80780a3bc650c7aedfb3c1bd372