### PR TITLE
[WIP] Add no-titlebar support for --HEAD

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -113,12 +113,15 @@ class EmacsPlus < Formula
 
   if build.with? "no-titlebar"
     if build.head?
-      odie "--with-no-titlebar is not supported on --HEAD yet"
-    end
-
-    patch do
-      url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/borderless-frame-on-macOS.patch"
-      sha256 "2059213cc740a49b131a363d6093913fa29f8f67227fc86a82ffe633bbf1a5f5"
+      patch do
+        url "https://gist.githubusercontent.com/jakejx/1538373194edff34f98b328198a7f7dc/raw/0f5ce4b359253f06f94c054e4c717ecf158adb02/27-no-titlebar"
+        sha256 "7059f6eb75365ea7935c51265e2c54956960d2aff5725fc78f3def40b034f90d"
+      end
+    else
+      patch do
+        url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/borderless-frame-on-macOS.patch"
+        sha256 "2059213cc740a49b131a363d6093913fa29f8f67227fc86a82ffe633bbf1a5f5"
+      end
     end
   end
 

--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -26,6 +26,8 @@ class EmacsPlus < Formula
   # Opt-in
   option "with-ctags",
          "Don't remove the ctags executable that Emacs provides"
+  option "with-window-role-fix",
+         "Fix Emacs window role to use AXWindowRole"
 
   # Update list from
   # https://raw.githubusercontent.com/emacsfodder/emacs-icons-project/master/icons.json
@@ -114,14 +116,21 @@ class EmacsPlus < Formula
   if build.with? "no-titlebar"
     if build.head?
       patch do
-        url "https://gist.githubusercontent.com/jakejx/1538373194edff34f98b328198a7f7dc/raw/0f5ce4b359253f06f94c054e4c717ecf158adb02/27-no-titlebar"
-        sha256 "7059f6eb75365ea7935c51265e2c54956960d2aff5725fc78f3def40b034f90d"
+        url "https://raw.githubusercontent.com/jakejx/homebrew-emacs-plus/head-no-title-bar/patches/27-no-titlebar.patch"
+        sha256 "aa1c9be5adfabc5f385628b881cd78bdbd0ce0f0a217b09a9f9638db1981537b"
       end
     else
       patch do
         url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/borderless-frame-on-macOS.patch"
         sha256 "2059213cc740a49b131a363d6093913fa29f8f67227fc86a82ffe633bbf1a5f5"
       end
+    end
+  end
+
+  if build.with? "window-role-fix"
+    patch do
+      url "https://raw.githubusercontent.com/jakejx/homebrew-emacs-plus/head-no-title-bar/patches/fix-window-role.patch"
+      sha256 "1ca5c9415232423d04e93c6829ee28e6b7f649bc424c6f2a739125f0a5257ddd"
     end
   end
 

--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -27,7 +27,7 @@ class EmacsPlus < Formula
   option "with-ctags",
          "Don't remove the ctags executable that Emacs provides"
   option "with-window-role-fix",
-         "Fix Emacs window role to use AXWindowRole"
+         "Experimental: fix Emacs window role to use AXWindowRole"
 
   # Update list from
   # https://raw.githubusercontent.com/emacsfodder/emacs-icons-project/master/icons.json

--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -116,7 +116,7 @@ class EmacsPlus < Formula
   if build.with? "no-titlebar"
     if build.head?
       patch do
-        url "https://raw.githubusercontent.com/jakejx/homebrew-emacs-plus/head-no-title-bar/patches/27-no-titlebar.patch"
+        url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/27-no-titlebar.patch"
         sha256 "aa1c9be5adfabc5f385628b881cd78bdbd0ce0f0a217b09a9f9638db1981537b"
       end
     else
@@ -129,7 +129,7 @@ class EmacsPlus < Formula
 
   if build.with? "window-role-fix"
     patch do
-      url "https://raw.githubusercontent.com/jakejx/homebrew-emacs-plus/head-no-title-bar/patches/fix-window-role.patch"
+      url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/patches/fix-window-role.patch"
       sha256 "1ca5c9415232423d04e93c6829ee28e6b7f649bc424c6f2a739125f0a5257ddd"
     end
   end

--- a/patches/27-no-titlebar.patch
+++ b/patches/27-no-titlebar.patch
@@ -1,0 +1,108 @@
+diff --git a/src/nsterm.m b/src/nsterm.m
+index 6995577920..254d157e4c 100644
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -470,11 +470,9 @@ - (NSColor *)colorUsingDefaultColorSpace
+ 
+ /* These flags will be OR'd or XOR'd with the NSWindow's styleMask
+    property depending on what we're doing.  */
+-#define FRAME_DECORATED_FLAGS (NSWindowStyleMaskTitled              \
+-                               | NSWindowStyleMaskResizable         \
++#define FRAME_UNDECORATED_FLAGS ( NSWindowStyleMaskResizable         \
+                                | NSWindowStyleMaskMiniaturizable    \
+                                | NSWindowStyleMaskClosable)
+-#define FRAME_UNDECORATED_FLAGS NSWindowStyleMaskBorderless
+ 
+ /* TODO: Get rid of need for these forward declarations.  */
+ static void ns_condemn_scroll_bars (struct frame *f);
+@@ -1829,23 +1827,11 @@ Hide the window (X11 semantics)
+     {
+       block_input ();
+ 
+-      if (NILP (new_value))
+-        {
+-          FRAME_UNDECORATED (f) = false;
+-          [window setStyleMask: ((window.styleMask | FRAME_DECORATED_FLAGS)
+-                                  ^ FRAME_UNDECORATED_FLAGS)];
+-
+-          [view createToolbar: f];
+-        }
+-      else
+-        {
+-          [window setToolbar: nil];
+-          /* Do I need to release the toolbar here?  */
++      [window setToolbar: nil];
++      /* Do I need to release the toolbar here?  */
+ 
+-          FRAME_UNDECORATED (f) = true;
+-          [window setStyleMask: ((window.styleMask | FRAME_UNDECORATED_FLAGS)
+-                                 ^ FRAME_DECORATED_FLAGS)];
+-        }
++      FRAME_UNDECORATED (f) = true;
++      [window setStyleMask: (window.styleMask | FRAME_UNDECORATED_FLAGS)];
+ 
+       /* At this point it seems we don't have an active NSResponder,
+          so some key presses (TAB) are swallowed by the system.  */
+@@ -7025,36 +7011,7 @@ - (void) updateFrameSize: (BOOL) delay
+   NSTRACE_MSG  ("Original columns: %d", cols);
+   NSTRACE_MSG  ("Original rows: %d", rows);
+ 
+-  if (! [self isFullscreen])
+-    {
+-      int toolbar_height;
+-#ifdef NS_IMPL_GNUSTEP
+-      // GNUstep does not always update the tool bar height.  Force it.
+-      if (toolbar && [toolbar isVisible])
+-          update_frame_tool_bar (emacsframe);
+-#endif
+-
+-      toolbar_height = FRAME_TOOLBAR_HEIGHT (emacsframe);
+-      if (toolbar_height < 0)
+-        toolbar_height = 35;
+-
+-      extra = FRAME_NS_TITLEBAR_HEIGHT (emacsframe)
+-        + toolbar_height;
+-    }
+-
+-  if (wait_for_tool_bar)
+-    {
+-      /* The toolbar height is always 0 in fullscreen and undecorated
+-         frames, so don't wait for it to become available.  */
+-      if (FRAME_TOOLBAR_HEIGHT (emacsframe) == 0
+-          && FRAME_UNDECORATED (emacsframe) == false
+-          && ! [self isFullscreen])
+-        {
+-          NSTRACE_MSG ("Waiting for toolbar");
+-          return;
+-        }
+-      wait_for_tool_bar = NO;
+-    }
++  wait_for_tool_bar = NO;
+ 
+   neww = (int)wr.size.width - emacsframe->border_width;
+   newh = (int)wr.size.height - extra;
+@@ -7429,11 +7386,9 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+   maximizing_resize = NO;
+ #endif
+ 
+-  win = [[EmacsWindow alloc]
++  win = [[EmacsFSWindow alloc]
+             initWithContentRect: r
+-                      styleMask: (FRAME_UNDECORATED (f)
+-                                  ? FRAME_UNDECORATED_FLAGS
+-                                  : FRAME_DECORATED_FLAGS)
++                      styleMask: FRAME_UNDECORATED_FLAGS
+                         backing: NSBackingStoreBuffered
+                           defer: YES];
+ 
+@@ -7466,10 +7421,6 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+                    NILP (tem) ? "Emacs" : SSDATA (tem)];
+   [win setTitle: name];
+ 
+-  /* toolbar support */
+-  if (! FRAME_UNDECORATED (f))
+-    [self createToolbar: f];
+-
+ #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
+ #ifndef NSAppKitVersionNumber10_10
+ #define NSAppKitVersionNumber10_10 1343

--- a/patches/fix-window-role.patch
+++ b/patches/fix-window-role.patch
@@ -1,0 +1,13 @@
+diff --git a/src/nsterm.m b/src/nsterm.m
+index 6995577920..c39941c8d3 100644
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -8503,7 +8503,7 @@ - (id)accessibilityAttributeValue:(NSString *)attribute
+   NSTRACE ("[EmacsWindow accessibilityAttributeValue:]");
+ 
+   if ([attribute isEqualToString:NSAccessibilityRoleAttribute])
+-    return NSAccessibilityTextFieldRole;
++    return NSAccessibilityWindowRole;
+ 
+   if ([attribute isEqualToString:NSAccessibilitySelectedTextAttribute]
+       && curbuf && ! NILP (BVAR (curbuf, mark_active)))


### PR DESCRIPTION
Hi,

I have updated the no-titlebar patch to work with HEAD. Full credits go to the original author, I simply updated the diff for the correct lines. I have also attempted to fix the window role assigned to Emacs so that it is more well behaved with tiling managers such as yabai. I have only tested for abit but I am hoping that more people can test this build to make sure its working.

Let me know if there is any work to be done before merging, thanks! 😄 