### PR TITLE
Add --with-debug option.

### DIFF
--- a/Formula/emacs-plus.rb
+++ b/Formula/emacs-plus.rb
@@ -51,6 +51,8 @@ class EmacsPlus < Formula
          "Don't remove the ctags executable that Emacs provides"
   option "with-x11", "Experimental: build with x11 support"
   option "with-no-titlebar", "Experimental: build without titlebar"
+  option "with-debug",
+         "Build with debug symbols and debugger friendly optimizations"
 
   # Emacs 27.x only
   option "with-xwidgets",
@@ -240,6 +242,10 @@ class EmacsPlus < Formula
       args << "--with-xml2"
     else
       args << "--without-xml2"
+    end
+
+    if build.with? "debug"
+      ENV.append "CFLAGS", "-g -Og"
     end
 
     if build.with? "dbus"


### PR DESCRIPTION
I still get the occasional crashing bug in with Emacs 27, so I like to build with debugging symbols so I can get a better backtrace in the debugger when things go sideways.
