### PR TITLE
Update "system-appearance" patch and related docs

### DIFF
--- a/README.org
+++ b/README.org
@@ -152,9 +152,10 @@ a different theme to better match the system appearance.
                   ('dark (load-theme 'tango-dark t)))))
 #+end_src
 
-Note that this hook is run early in the startup process, so if you want your
-theme to match the system appearance when Emacs starts, you can register your
-function(s) in your =early-init.el=. The hook is NOT run in TTY Emacs sessions.
+Note that this hook is also run once when Emacs is initialized, so simply
+adding the above to your =init.el= will allow matching the system appearance
+upon startup.
+The hook is NOT run in TTY Emacs sessions.
 
 *** Icons
 

--- a/patches/emacs-27/system-appearance.patch
+++ b/patches/emacs-27/system-appearance.patch
@@ -1,15 +1,12 @@
-From 48f853d2deb2ddb283a64376f28d16bc033e634a Mon Sep 17 00:00:00 2001
+From f1488d050826e1d72866a63314d2dcd3617ff4ba Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Wed, 18 Mar 2020 10:49:28 +0100
+Date: Sat, 27 Jun 2020 18:04:38 +0200
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
 that is called when the system changes its appearance (e.g. from light
-to dark). Users can then implement functions that takes this change
+to dark). Users can then implement functions that take this change
 into account, for instance to load a particular theme.
-
-The frame parameter `ns-appearance', if set, will result in this new
-hook not being called until this parameter is unset.
 
 Minor changes are also made to select the right "dark" appearance
 (NSAppearanceNameDarkAqua) on macOS versions >= 10.14, the previous one
@@ -28,9 +25,10 @@ macOS >= 10.14.
      either `dark' or `light'.
   - (initFrameFromEmacs): Use "dark aqua" appearance on
      macOS >= 10.14.
-  - Add `viewDidChangeEffectiveAppearance' implementation,
-    to update the frame's appearance when the system appearance
-    changes. This method is called automatically by macOS.
+  - (EmacsApp) Add the `systemDidChangeAppearance' private method,
+    as well as the appropriate Key-Value Observing calls to update
+    the frame's appearance when the system (and thus the app's)
+    appearance changes.
   - Add `ns-system-appearance-change-functions' hook variable and
     symbol, to allow users to add functions that react to the
     change of the system's appearance.
@@ -43,11 +41,14 @@ Here is an example on how to use this new feature:
             (pcase appearance
                ('light (load-theme 'tango t))
                ('dark (load-theme 'tango-dark t)))))
+
+The hook is executed once at Emacs startup, and then every time the
+system appearance changes.
 ---
  src/frame.h  |   1 +
- src/nsfns.m  |  13 ++++++-
- src/nsterm.m | 102 +++++++++++++++++++++++++++++++++++++++++++++++----
- 3 files changed, 106 insertions(+), 10 deletions(-)
+ src/nsfns.m  |  13 +++++-
+ src/nsterm.m | 122 +++++++++++++++++++++++++++++++++++++++++++++++----
+ 3 files changed, 126 insertions(+), 10 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
 index a54b8623e5..46a7c34cb7 100644
@@ -88,7 +89,7 @@ index 0f879fe390..5a4dd3a157 100644
  
    tem = gui_display_get_arg (dpyinfo, parms, Qns_transparent_titlebar,
 diff --git a/src/nsterm.m b/src/nsterm.m
-index e92e3d5a6f..ee4108dced 100644
+index ac467840a2..0065bf66ab 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
 @@ -2027,16 +2027,35 @@ so some key presses (TAB) are swallowed by the system.  */
@@ -131,7 +132,95 @@ index e92e3d5a6f..ee4108dced 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -7477,12 +7496,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+@@ -5566,6 +5585,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+ 
+    ========================================================================== */
+ 
++static const void *kEmacsAppKVOContext = &kEmacsAppKVOContext;
+ 
+ @implementation EmacsApp
+ 
+@@ -5811,6 +5831,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+ 	 object:nil];
+ #endif
+ 
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  [self addObserver:self
++         forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++            options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
++            context:&kEmacsAppKVOContext];
++#endif
++
+ #ifdef NS_IMPL_COCOA
+   /* Some functions/methods in CoreFoundation/Foundation increase the
+      maximum number of open files for the process in their first call.
+@@ -5849,6 +5876,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+ #endif
+ }
+ 
++- (void)observeValueForKeyPath:(NSString *)keyPath
++                      ofObject:(id)object
++                        change:(NSDictionary *)change
++                       context:(void *)context
++{
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  if (context == kEmacsAppKVOContext
++      && object == self
++      && [keyPath isEqualToString:
++                    NSStringFromSelector (@selector(effectiveAppearance))])
++    [self systemAppearanceDidChange:
++               [change objectForKey:NSKeyValueChangeNewKey]];
++  else
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++    [super observeValueForKeyPath:keyPath
++                         ofObject:object
++                           change:change
++                          context:context];
++}
++
++- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
++{
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++#ifndef NSAppKitVersionNumber10_14
++#define NSAppKitVersionNumber10_14 1671
++#endif
++
++  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
++    return;
++
++  NSAppearanceName appearance_name =
++      [newAppearance bestMatchFromAppearancesWithNames:@[
++        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
++      ]];
++
++  BOOL is_dark_appearance =
++    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
++
++  pending_funcalls = Fcons (list3 (Qrun_hook_with_args,
++                                   Qns_system_appearance_change_functions,
++                                   is_dark_appearance ? Qdark : Qlight),
++                            pending_funcalls);
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++}
+ 
+ /* Termination sequences:
+     C-x C-c:
+@@ -6013,6 +6084,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+   ns_send_appdefined (-1);
+ }
+ 
++- (void)applicationWillTerminate:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp applicationWillTerminate:]");
++
++  [self removeObserver:self
++            forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++               context:&kEmacsAppKVOContext];
++}
+ 
+ 
+ /* ==========================================================================
+@@ -7492,12 +7571,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
  #ifndef NSAppKitVersionNumber10_10
  #define NSAppKitVersionNumber10_10 1343
@@ -159,53 +248,11 @@ index e92e3d5a6f..ee4108dced 100644
 +            win.appearance =
 +                [NSAppearance appearanceNamed:NSAppearanceNameAqua];
 +          }
-+    }
++      }
  #endif
  
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
-@@ -8223,6 +8257,41 @@ - (instancetype)toggleToolbar: (id)sender
-   return self;
- }
- 
-+#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
-+#ifndef NSAppKitVersionNumber10_14
-+#define NSAppKitVersionNumber10_14 1671
-+#endif
-+- (void)viewDidChangeEffectiveAppearance
-+{
-+  NSTRACE ("[EmacsView viewDidChangeEffectiveAppearance:]");
-+
-+  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
-+    return;
-+
-+  // The `ns-appearance' frame parameter overrides the system appearance;
-+  // If it set, do not handle the view's appearance change further.
-+  if (EQ(get_frame_param(emacsframe, Qns_appearance), Qdark)
-+    || EQ(get_frame_param(emacsframe, Qns_appearance), Qlight))
-+    return;
-+
-+  NSAppearanceName appearance =
-+    [[NSApp effectiveAppearance] bestMatchFromAppearancesWithNames:@[
-+      NSAppearanceNameAqua, NSAppearanceNameDarkAqua
-+    ]];
-+
-+  BOOL has_dark_appearance = [appearance
-+                               isEqualToString:NSAppearanceNameDarkAqua];
-+
-+  FRAME_NS_APPEARANCE (emacsframe) =
-+    has_dark_appearance ? ns_appearance_dark_aqua : ns_appearance_aqua;
-+
-+  if (!NILP (Vns_system_appearance_change_functions))
-+    pending_funcalls = Fcons(list3(Qrun_hook_with_args,
-+                                   Qns_system_appearance_change_functions,
-+                                   has_dark_appearance ? Qdark : Qlight),
-+                             pending_funcalls);
-+}
-+#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
- 
- - (void)viewWillDraw
- {
-@@ -9591,6 +9660,23 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9606,6 +9700,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  
@@ -215,12 +262,7 @@ index e92e3d5a6f..ee4108dced 100644
 +Each function is called with a single argument, which corresponds to the new
 +system appearance (`dark' or `light').
 +
-+This hook is also executed once at startup, when the first frame is created.
-+
-+If the parameter `ns-appearance' is set for a frame, this frame's appearance
-+is considered fixed and no system appearance changes will be handled until
-+it is unset; However, global (e.g. `load-theme') changes will still be applied
-+to all frames.
++This hook is also run once at startup.
 +
 +This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
 +  Vns_system_appearance_change_functions = Qnil;
@@ -230,5 +272,5 @@ index e92e3d5a6f..ee4108dced 100644
    DEFVAR_LISP ("x-toolkit-scroll-bars", Vx_toolkit_scroll_bars,
  	       doc: /* SKIP: real doc in xterm.c.  */);
 -- 
-2.25.1
+2.27.0
 

--- a/patches/emacs-28/system-appearance.patch
+++ b/patches/emacs-28/system-appearance.patch
@@ -1,17 +1,12 @@
-From 4d1328764fbd4aa1c4da37f5cd76e4bd4a4ce37c Mon Sep 17 00:00:00 2001
+From 0ba8a54409f44dfac005c4e40175884031f9aab3 Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Fri, 24 Apr 2020 20:25:23 +0200
-Subject: [PATCH] [patch] system-appearance
-
-Author of this patch is Nicolas G. Querol aka ngquerol
+Date: Sat, 27 Jun 2020 18:04:38 +0200
+Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
 that is called when the system changes its appearance (e.g. from light
-to dark). Users can then implement functions that takes this change
+to dark). Users can then implement functions that take this change
 into account, for instance to load a particular theme.
-
-The frame parameter `ns-appearance', if set, will result in this new
-hook not being called until this parameter is set back to `nil'.
 
 Minor changes are also made to select the right "dark" appearance
 (NSAppearanceNameDarkAqua) on macOS versions >= 10.14, the previous one
@@ -30,9 +25,10 @@ macOS >= 10.14.
      either `dark' or `light'.
   - (initFrameFromEmacs): Use "dark aqua" appearance on
      macOS >= 10.14.
-  - Add `viewDidChangeEffectiveAppearance' implementation,
-    to update the frame's appearance when the system appearance
-    changes. This method is called automatically by macOS.
+  - (EmacsApp) Add the `systemDidChangeAppearance' private method,
+    as well as the appropriate Key-Value Observing calls to update
+    the frame's appearance when the system (and thus the app's)
+    appearance changes.
   - Add `ns-system-appearance-change-functions' hook variable and
     symbol, to allow users to add functions that react to the
     change of the system's appearance.
@@ -45,35 +41,34 @@ Here is an example on how to use this new feature:
             (pcase appearance
                ('light (load-theme 'tango t))
                ('dark (load-theme 'tango-dark t)))))
+
+The hook is executed once at Emacs startup, and then every time the
+system appearance changes.
 ---
- src/frame.h  |  7 ++---
- src/nsfns.m  | 11 +++++++-
- src/nsterm.m | 76 ++++++++++++++++++++++++++++++++++++++++++++++++----
- 3 files changed, 85 insertions(+), 9 deletions(-)
+ src/frame.h  |   3 +-
+ src/nsfns.m  |  13 +++++-
+ src/nsterm.m | 127 ++++++++++++++++++++++++++++++++++++++++++++-------
+ 3 files changed, 124 insertions(+), 19 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
-index 476bac67fa..82f2654347 100644
+index 476bac67fa..cb778d0135 100644
 --- a/src/frame.h
 +++ b/src/frame.h
-@@ -69,9 +69,10 @@ enum internal_border_part
- #ifdef NS_IMPL_COCOA
- enum ns_appearance_type
+@@ -71,7 +71,8 @@ #define EMACS_FRAME_H
    {
--    ns_appearance_system_default,
--    ns_appearance_aqua,
+     ns_appearance_system_default,
+     ns_appearance_aqua,
 -    ns_appearance_vibrant_dark
-+   ns_appearance_system_default,
-+   ns_appearance_aqua,
-+   ns_appearance_vibrant_dark,
-+   ns_appearance_dark_aqua
++    ns_appearance_vibrant_dark,
++    ns_appearance_dark_aqua
    };
  #endif
  #endif /* HAVE_WINDOW_SYSTEM */
 diff --git a/src/nsfns.m b/src/nsfns.m
-index 273fb5f759..74dbf63616 100644
+index 628233ea0d..a537d4b629 100644
 --- a/src/nsfns.m
 +++ b/src/nsfns.m
-@@ -1269,14 +1269,23 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+@@ -1269,14 +1269,25 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
    store_frame_param (f, Qundecorated, FRAME_UNDECORATED (f) ? Qt : Qnil);
  
  #ifdef NS_IMPL_COCOA
@@ -82,14 +77,16 @@ index 273fb5f759..74dbf63616 100644
 +#endif
    tem = gui_display_get_arg (dpyinfo, parms, Qns_appearance, NULL, NULL,
                               RES_TYPE_SYMBOL);
-+
    if (EQ (tem, Qdark))
 -    FRAME_NS_APPEARANCE (f) = ns_appearance_vibrant_dark;
-+    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14) {
-+       FRAME_NS_APPEARANCE (f) = ns_appearance_dark_aqua;
-+    } else {
-+      FRAME_NS_APPEARANCE (f) = ns_appearance_vibrant_dark;
-+    }
++    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14)
++      {
++        FRAME_NS_APPEARANCE (f) = ns_appearance_dark_aqua;
++      }
++    else
++      {
++        FRAME_NS_APPEARANCE (f) = ns_appearance_vibrant_dark;
++      }
    else if (EQ (tem, Qlight))
      FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
    else
@@ -99,92 +96,176 @@ index 273fb5f759..74dbf63616 100644
                       (!NILP (tem) && !EQ (tem, Qunbound)) ? tem : Qnil);
  
 diff --git a/src/nsterm.m b/src/nsterm.m
-index aa6c1d286f..84bf04498e 100644
+index 0e405fc017..5d2292e7eb 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -2202,12 +2202,21 @@ so some key presses (TAB) are swallowed by the system.  */
-   if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
+@@ -2216,13 +2216,25 @@ so some key presses (TAB) are swallowed by the system.  */
      return;
  
--  if (EQ (new_value, Qdark))
+   if (EQ (new_value, Qdark))
 -    FRAME_NS_APPEARANCE (f) = ns_appearance_vibrant_dark;
 -  else if (EQ (new_value, Qlight))
-+  if (EQ (new_value, Qdark)) {
+-    FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
++    {
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 +#ifndef NSAppKitVersionNumber10_14
 +#define NSAppKitVersionNumber10_14 1671
 +#endif
-+    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14)
-+      FRAME_NS_APPEARANCE(f) = ns_appearance_dark_aqua;
-+    else
++      if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14)
++        FRAME_NS_APPEARANCE(f) = ns_appearance_dark_aqua;
++      else
 +#endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
-+      FRAME_NS_APPEARANCE(f) = ns_appearance_vibrant_dark;
-+  } else if (EQ(new_value, Qlight)) {
-     FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
--  else
-+  } else {
-     FRAME_NS_APPEARANCE (f) = ns_appearance_system_default;
-+  }
- 
-   [window setAppearance];
++        FRAME_NS_APPEARANCE(f) = ns_appearance_vibrant_dark;
++    }
++  else if (EQ(new_value, Qlight))
++    {
++      FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
++    }
+   else
+-    FRAME_NS_APPEARANCE (f) = ns_appearance_system_default;
+-
+-  [window setAppearance];
++    {
++      FRAME_NS_APPEARANCE (f) = ns_appearance_system_default;
++    }
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
-@@ -8373,6 +8382,37 @@ - (instancetype)toggleToolbar: (id)sender
-   return self;
  }
  
+@@ -5674,6 +5686,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+ 
+    ========================================================================== */
+ 
++static const void *kEmacsAppKVOContext = &kEmacsAppKVOContext;
+ 
+ @implementation EmacsApp
+ 
+@@ -5919,6 +5932,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+ 	 object:nil];
+ #endif
+ 
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  [self addObserver:self
++         forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++            options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
++            context:&kEmacsAppKVOContext];
++#endif
++
+ #ifdef NS_IMPL_COCOA
+   /* Some functions/methods in CoreFoundation/Foundation increase the
+      maximum number of open files for the process in their first call.
+@@ -5957,6 +5977,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+ #endif
+ }
+ 
++- (void)observeValueForKeyPath:(NSString *)keyPath
++                      ofObject:(id)object
++                        change:(NSDictionary *)change
++                       context:(void *)context
++{
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  if (context == kEmacsAppKVOContext
++      && object == self
++      && [keyPath isEqualToString:
++                    NSStringFromSelector (@selector(effectiveAppearance))])
++    [self systemAppearanceDidChange:
++               [change objectForKey:NSKeyValueChangeNewKey]];
++  else
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++    [super observeValueForKeyPath:keyPath
++                         ofObject:object
++                           change:change
++                          context:context];
++}
++
++- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
++{
 +#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 +#ifndef NSAppKitVersionNumber10_14
 +#define NSAppKitVersionNumber10_14 1671
 +#endif
-+- (void)viewDidChangeEffectiveAppearance
-+{
-+  NSTRACE ("[EmacsView viewDidChangeEffectiveAppearance:]");
 +
 +  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
 +    return;
 +
-+  // If the frame's appearance is explicitly set (via the frame parameter
-+  // `ns-appearance'), do nothing.
-+  if (FRAME_NS_APPEARANCE (emacsframe) != ns_appearance_system_default)
-+    return;
++  NSAppearanceName appearance_name =
++      [newAppearance bestMatchFromAppearancesWithNames:@[
++        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
++      ]];
 +
-+  NSAppearanceName appearance =
-+    [[NSApp effectiveAppearance] bestMatchFromAppearancesWithNames:@[
-+      NSAppearanceNameAqua, NSAppearanceNameDarkAqua
-+    ]];
++  BOOL is_dark_appearance =
++    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
 +
-+  BOOL has_dark_appearance = [appearance
-+                               isEqualToString:NSAppearanceNameDarkAqua];
-+
-+  if (!NILP (Vns_system_appearance_change_functions))
-+    pending_funcalls = Fcons(list3(Qrun_hook_with_args,
++  pending_funcalls = Fcons (list3 (Qrun_hook_with_args,
 +                                   Qns_system_appearance_change_functions,
-+                                   has_dark_appearance ? Qdark : Qlight),
-+                             pending_funcalls);
-+}
++                                   is_dark_appearance ? Qdark : Qlight),
++                            pending_funcalls);
 +#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++}
  
- #ifdef NS_DRAW_TO_BUFFER
- - (void)createDrawingBuffer
-@@ -9009,7 +9049,16 @@ - (void)setAppearance
-   if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
-     return;
+ /* Termination sequences:
+     C-x C-c:
+@@ -6121,6 +6185,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+   ns_send_appdefined (-1);
+ }
  
++- (void)applicationWillTerminate:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp applicationWillTerminate:]");
++
++  [self removeObserver:self
++            forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++               context:&kEmacsAppKVOContext];
++}
+ 
+ 
+ /* ==========================================================================
+@@ -7566,7 +7638,6 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+   if (! FRAME_UNDECORATED (f))
+     [self createToolbar: f];
+ 
+-
+   [win setAppearance];
+ 
+ #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
+@@ -8984,17 +9055,27 @@ - (void)setAppearance
+ #define NSAppKitVersionNumber10_10 1343
+ #endif
+ 
+-  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
+-    return;
+-
 -  if (FRAME_NS_APPEARANCE (f) == ns_appearance_vibrant_dark)
+-    appearance =
+-      [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
+-  else if (FRAME_NS_APPEARANCE (f) == ns_appearance_aqua)
+-    appearance =
+-      [NSAppearance appearanceNamed:NSAppearanceNameAqua];
++   if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
++     return;
+ 
+-  [self setAppearance:appearance];
++   if (FRAME_NS_APPEARANCE (f) == ns_appearance_vibrant_dark)
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 +#ifndef NSAppKitVersionNumber10_14
 +#define NSAppKitVersionNumber10_14 1671
 +#endif
-+  if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14
-+       && FRAME_NS_APPEARANCE(f) == ns_appearance_dark_aqua)
-+     appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
-+  else
++     if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14
++         && FRAME_NS_APPEARANCE(f) == ns_appearance_dark_aqua)
++       appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
++     else
 +#endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
-+  if (FRAME_NS_APPEARANCE(f) == ns_appearance_vibrant_dark)
-     appearance =
-       [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
-   else if (FRAME_NS_APPEARANCE (f) == ns_appearance_aqua)
-@@ -9878,6 +9927,23 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
++       if (FRAME_NS_APPEARANCE(f) == ns_appearance_vibrant_dark)
++         appearance =
++           [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
++       else if (FRAME_NS_APPEARANCE (f) == ns_appearance_aqua)
++         appearance =
++           [NSAppearance appearanceNamed:NSAppearanceNameAqua];
++
++   [self setAppearance:appearance];
+ #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
+ }
+ 
+@@ -9856,6 +9937,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  
@@ -194,12 +275,7 @@ index aa6c1d286f..84bf04498e 100644
 +Each function is called with a single argument, which corresponds to the new
 +system appearance (`dark' or `light').
 +
-+This hook is also executed once at startup, when the first frame is created.
-+
-+If the parameter `ns-appearance' is set for a frame, this frame's appearance
-+is considered fixed and no system appearance changes will be handled until
-+it is unset; However, global (e.g. `load-theme') changes will still be applied
-+to all frames.
++This hook is also run once at startup.
 +
 +This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
 +  Vns_system_appearance_change_functions = Qnil;
@@ -209,5 +285,5 @@ index aa6c1d286f..84bf04498e 100644
    DEFVAR_LISP ("x-toolkit-scroll-bars", Vx_toolkit_scroll_bars,
  	       doc: /* SKIP: real doc in xterm.c.  */);
 -- 
-2.26.2
+2.27.0
 


### PR DESCRIPTION
The implementation of this feature now relies on Key-Value Observing to
detect system appearance changes, rather than the
viewDidChangeEffectiveApperance:` NSView method.

The old implementation ran the `ns-system-appearance-change-functions`
hook every time a new NSView was created, so in Emacs terms, every time
a new frame or child frame was created. KVO on the NSApp (EmacsApp)
instance allows handling this change at the application level rather
than the view level.
The hook is also always run now, even if it is empty; This has the
benefit of removing the requirement of adding functions to the hook in
`early-init.el` (instead of `init.el`) in order for them to be run when
Emacs starts.

Fixes #240.