### PR TITLE
fix conflict between no-titlebar and system-appearance patches

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -200,7 +200,7 @@ class EmacsPlusAT28 < Formula
 
   patch do
     url (PatchUrlResolver.url "emacs-28/system-appearance")
-    sha256 "af45bec511779eaca94d0b11e4822306a84d6bc0264183d3366ed4d84f459d81"
+    sha256 "b4ccc981e461ac12661fc4cf0ad7211a1dcab61dccf4bd4eee49ca5f7d66c496"
   end
 
   def install

--- a/patches/emacs-28/system-appearance.patch
+++ b/patches/emacs-28/system-appearance.patch
@@ -1,4 +1,4 @@
-From 0ba8a54409f44dfac005c4e40175884031f9aab3 Mon Sep 17 00:00:00 2001
+From 9428b506b6ae70dc7551ac0de364726584e536fe Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
 Date: Sat, 27 Jun 2020 18:04:38 +0200
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
@@ -47,14 +47,14 @@ system appearance changes.
 ---
  src/frame.h  |   3 +-
  src/nsfns.m  |  13 +++++-
- src/nsterm.m | 127 ++++++++++++++++++++++++++++++++++++++++++++-------
- 3 files changed, 124 insertions(+), 19 deletions(-)
+ src/nsterm.m | 126 ++++++++++++++++++++++++++++++++++++++++++++-------
+ 3 files changed, 124 insertions(+), 18 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
 index 476bac67fa..cb778d0135 100644
 --- a/src/frame.h
 +++ b/src/frame.h
-@@ -71,7 +71,8 @@ #define EMACS_FRAME_H
+@@ -71,7 +71,8 @@ enum ns_appearance_type
    {
      ns_appearance_system_default,
      ns_appearance_aqua,
@@ -96,10 +96,10 @@ index 628233ea0d..a537d4b629 100644
                       (!NILP (tem) && !EQ (tem, Qunbound)) ? tem : Qnil);
  
 diff --git a/src/nsterm.m b/src/nsterm.m
-index 0e405fc017..5d2292e7eb 100644
+index 0699468dba..7f2b646870 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -2216,13 +2216,25 @@ so some key presses (TAB) are swallowed by the system.  */
+@@ -2203,13 +2203,25 @@ so some key presses (TAB) are swallowed by the system.  */
      return;
  
    if (EQ (new_value, Qdark))
@@ -131,7 +131,7 @@ index 0e405fc017..5d2292e7eb 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -5674,6 +5686,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+@@ -5672,6 +5684,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
  
     ========================================================================== */
  
@@ -139,7 +139,7 @@ index 0e405fc017..5d2292e7eb 100644
  
  @implementation EmacsApp
  
-@@ -5919,6 +5932,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+@@ -5917,6 +5930,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
  	 object:nil];
  #endif
  
@@ -153,7 +153,7 @@ index 0e405fc017..5d2292e7eb 100644
  #ifdef NS_IMPL_COCOA
    /* Some functions/methods in CoreFoundation/Foundation increase the
       maximum number of open files for the process in their first call.
-@@ -5957,6 +5977,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+@@ -5955,6 +5975,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
  #endif
  }
  
@@ -204,7 +204,7 @@ index 0e405fc017..5d2292e7eb 100644
  
  /* Termination sequences:
      C-x C-c:
-@@ -6121,6 +6185,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+@@ -6119,6 +6183,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
    ns_send_appdefined (-1);
  }
  
@@ -219,15 +219,7 @@ index 0e405fc017..5d2292e7eb 100644
  
  
  /* ==========================================================================
-@@ -7566,7 +7638,6 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
-   if (! FRAME_UNDECORATED (f))
-     [self createToolbar: f];
- 
--
-   [win setAppearance];
- 
- #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
-@@ -8984,17 +9055,27 @@ - (void)setAppearance
+@@ -8977,17 +9049,27 @@ - (void)setAppearance
  #define NSAppKitVersionNumber10_10 1343
  #endif
  
@@ -265,7 +257,7 @@ index 0e405fc017..5d2292e7eb 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -9856,6 +9937,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9849,6 +9931,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  


### PR DESCRIPTION
FYI @ngquerol :) I didn't check the logs of the build and thought that it's some flakiness, but in reality it was a conflict :) You are changing some whitespaces in the area affected by titlebar patch.