### PR TITLE
Fix without-imagemagick option for Emacs 27 in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -106,7 +106,7 @@ Emacs 26 comes without any available options due to [[https://github.com/d12fros
 | =--with-x11=              | build with x11 support                                                       |
 | =--with-xwidgets=         | build [[#xwidgets-webkit][→ with xwidgets]] support                                                |
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
-| =--without-imagemagick@7= | build without =imagemagick= support                                          |
+| =--without-imagemagick=   | build without =imagemagick= support                                          |
 | =--HEAD=                  | build from =emacs-27= branch (only for =emacs-plus@27=)                      |
 
 By default =emacs-plus= builds the Cocoa version of Emacs.


### PR DESCRIPTION
Small fix removing `@7` from `--without-imagemagick` option in the list.