### PR TITLE
Clean up caveats now that emacs-plus@27 is the default

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -6,19 +6,6 @@ class EmacsPlusAT26 < EmacsBase
   mirror "https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz"
   sha256 "4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485"
 
-  if build.head?
-    odie <<~EOS
-      Emacs 27 and Emacs 28 are now separate formulas. Please use
-      emacs-plus@27 or emacs-plus@28.
-
-      $ brew install emacs-plus@27 [options]
-
-      or
-
-      $ brew install emacs-plus@28 [options]
-    EOS
-  end
-
   #
   # Dependencies
   #
@@ -133,9 +120,6 @@ class EmacsPlusAT26 < EmacsBase
 
       To link the application to default Homebrew App location:
         ln -s #{prefix}/Emacs.app /Applications
-
-      If you wish to install Emacs 27 or Emacs 28, use emacs-plus@27 or
-      emacs-plus@28 formula respectively.
     EOS
   end
 

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -232,6 +232,9 @@ class EmacsPlusAT27 < EmacsBase
 
       To link the application to default Homebrew App location:
         ln -s #{prefix}/Emacs.app /Applications
+    
+      If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
+      emacs-plus@28 formula respectively.
     EOS
   end
 


### PR DESCRIPTION
This moves the note for other Emacs versions to the emacs-plus@27 formula because it's now the default. It also removes the warning if you use --head with emacs-plus@26 as this seemed old and potentially not needed any more.