### PR TITLE
Fix system appearance patches yet again

### DIFF
--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -100,7 +100,7 @@ class EmacsPlusAT27 < EmacsBase
 
   patch do
     url (UrlResolver.patch_url "emacs-27/system-appearance")
-    sha256 "e09078a03a6b55fc5cd0785b138f472dea7bbaf8123dadc04e5122155218c1e1"
+    sha256 "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
   end
 
   patch do

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -83,7 +83,7 @@ class EmacsPlusAT28 < EmacsBase
 
   patch do
     url (UrlResolver.patch_url "emacs-28/system-appearance")
-    sha256 "4b17be19144997c3ae3456a707b4643bb7a6766eb0aec234973f3f0d77b1a893"
+    sha256 "22b541e2893171e45b54593f82a0f5d2c4e62b0e4497fc0351fc89108d6f0084"
   end
 
   def install

--- a/patches/emacs-27/system-appearance.patch
+++ b/patches/emacs-27/system-appearance.patch
@@ -1,7 +1,7 @@
 Patch to make emacs 27 aware of the macOS 10.14+ system appearance changes.
-From 43963fc1a2c37657067710243bfeda6c7dd06a67 Mon Sep 17 00:00:00 2001
+From 51e1c6a119feeffc2e6d61130fed404c5e6b78d5 Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Sun, 8 Nov 2020 19:07:31 +0100
+Date: Wed, 11 Nov 2020 11:38:05 +0100
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
@@ -52,8 +52,8 @@ startup time, Emacs should then always load the appropriate theme.
 ---
  src/frame.h  |   1 +
  src/nsfns.m  |  13 ++++-
- src/nsterm.m | 139 ++++++++++++++++++++++++++++++++++++++++++++++++---
- 3 files changed, 143 insertions(+), 10 deletions(-)
+ src/nsterm.m | 154 ++++++++++++++++++++++++++++++++++++++++++++++++---
+ 3 files changed, 158 insertions(+), 10 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
 index a54b8623e5..46a7c34cb7 100644
@@ -94,7 +94,7 @@ index 0f879fe390..5a4dd3a157 100644
  
    tem = gui_display_get_arg (dpyinfo, parms, Qns_transparent_titlebar,
 diff --git a/src/nsterm.m b/src/nsterm.m
-index 3dd915e370..6dddd01c90 100644
+index 3dd915e370..0e632e8cd9 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
 @@ -2027,16 +2027,35 @@ so some key presses (TAB) are swallowed by the system.  */
@@ -164,7 +164,7 @@ index 3dd915e370..6dddd01c90 100644
  #ifdef NS_IMPL_COCOA
    /* Some functions/methods in CoreFoundation/Foundation increase the
       maximum number of open files for the process in their first call.
-@@ -5849,6 +5881,54 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+@@ -5849,6 +5881,69 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
  #endif
  }
  
@@ -188,38 +188,53 @@ index 3dd915e370..6dddd01c90 100644
 +                          context:context];
 +}
 +
-+- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
-+{
 +#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 +#ifndef NSAppKitVersionNumber10_14
 +#define NSAppKitVersionNumber10_14 1671
 +#endif
-+
++- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
++{
 +  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
 +    return;
 +
 +  NSAppearanceName appearance_name =
-+      [newAppearance bestMatchFromAppearancesWithNames:@[
-+        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
-+      ]];
++    [newAppearance bestMatchFromAppearancesWithNames:@[
++      NSAppearanceNameAqua, NSAppearanceNameDarkAqua
++    ]];
 +
 +  BOOL is_dark_appearance =
 +    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
-+  Lisp_Object effective_appearance = is_dark_appearance ? Qdark : Qlight;
++  Lisp_Object effective_appearance =
 +
-+  Vns_system_appearance = effective_appearance;
++  Vns_system_appearance = is_dark_appearance ? Qdark : Qlight;
++
++  run_system_appearance_change_hook ();
++}
++
++static inline void run_system_appearance_change_hook (void)
++{
++  if (NILP (Vns_system_appearance_change_functions))
++    return;
++
++  block_input ();
++
++  bool owfi = waiting_for_input;
++  waiting_for_input = false;
 +
 +  safe_call2 (Qrun_hook_with_args,
 +              Qns_system_appearance_change_functions,
-+              effective_appearance);
++              Vns_system_appearance);
++  Fredisplay(Qt);
 +
-+  Fredisplay(Qnil);
-+#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++  waiting_for_input = owfi;
++
++  unblock_input ();
 +}
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
  
  /* Termination sequences:
      C-x C-c:
-@@ -6013,6 +6093,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+@@ -6013,6 +6108,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
    ns_send_appdefined (-1);
  }
  
@@ -234,7 +249,7 @@ index 3dd915e370..6dddd01c90 100644
  
  
  /* ==========================================================================
-@@ -7492,12 +7580,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+@@ -7492,12 +7595,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
  #ifndef NSAppKitVersionNumber10_10
  #define NSAppKitVersionNumber10_10 1343
@@ -266,7 +281,7 @@ index 3dd915e370..6dddd01c90 100644
  #endif
  
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
-@@ -9606,6 +9709,26 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9606,6 +9724,26 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  

--- a/patches/emacs-28/system-appearance.patch
+++ b/patches/emacs-28/system-appearance.patch
@@ -1,7 +1,7 @@
 Patch to make emacs 28 aware of the macOS 10.14+ system appearance changes.
-From 8c761f0a4cbd2952958ba3ac17e25ad8719b68d5 Mon Sep 17 00:00:00 2001
+From 3ad6f30e1753a63b6c8b6ddea3ba1ee76bf605f1 Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Sun, 8 Nov 2020 21:53:21 +0100
+Date: Wed, 11 Nov 2020 12:35:47 +0100
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
@@ -38,23 +38,22 @@ macOS >= 10.14.
 
 Here is an example on how to use this new feature:
 
-    (defun my/apply-theme (appearance)
+    (defun my/load-theme (appearance)
       "Load theme, taking current system APPEARANCE into consideration."
       (mapc #'disable-theme custom-enabled-themes)
       (pcase appearance
         ('light (load-theme 'tango t))
         ('dark (load-theme 'tango-dark t))))
 
-    (add-hook 'ns-system-appearance-change-functions #'my/apply-theme)
+    (add-hook 'ns-system-appearance-change-functions #'my/load-theme)
 
-The hook being run on each system appearance change as well as at startup
-time, Emacs should then always load the theme you chose for the current
-appearance.
+The hook being run on each system appearance change as well as at
+startup time, Emacs should then always load the appropriate theme.
 ---
  src/frame.h  |   3 +-
  src/nsfns.m  |  13 ++++-
- src/nsterm.m | 142 +++++++++++++++++++++++++++++++++++++++++++++------
- 3 files changed, 140 insertions(+), 18 deletions(-)
+ src/nsterm.m | 156 +++++++++++++++++++++++++++++++++++++++++++++------
+ 3 files changed, 154 insertions(+), 18 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
 index 16ecfd311c..b0dcb3098e 100644
@@ -102,10 +101,10 @@ index c7956497c4..dcfc66e1dc 100644
                       (!NILP (tem) && !EQ (tem, Qunbound)) ? tem : Qnil);
  
 diff --git a/src/nsterm.m b/src/nsterm.m
-index fa38350a2f..d8c3dcc2e3 100644
+index 4fad521b74..1dea6f6739 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -2192,13 +2192,25 @@ so some key presses (TAB) are swallowed by the system.  */
+@@ -2194,13 +2194,25 @@ so some key presses (TAB) are swallowed by the system.  */
      return;
  
    if (EQ (new_value, Qdark))
@@ -137,7 +136,7 @@ index fa38350a2f..d8c3dcc2e3 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -5737,6 +5749,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+@@ -5739,6 +5751,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
  
     ========================================================================== */
  
@@ -145,7 +144,7 @@ index fa38350a2f..d8c3dcc2e3 100644
  
  @implementation EmacsApp
  
-@@ -5982,6 +5995,18 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+@@ -5984,6 +5997,18 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
  	 object:nil];
  #endif
  
@@ -164,7 +163,7 @@ index fa38350a2f..d8c3dcc2e3 100644
  #ifdef NS_IMPL_COCOA
    /* Some functions/methods in CoreFoundation/Foundation increase the
       maximum number of open files for the process in their first call.
-@@ -6020,6 +6045,54 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+@@ -6022,6 +6047,68 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
  #endif
  }
  
@@ -188,12 +187,12 @@ index fa38350a2f..d8c3dcc2e3 100644
 +                          context:context];
 +}
 +
-+- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
-+{
 +#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
 +#ifndef NSAppKitVersionNumber10_14
 +#define NSAppKitVersionNumber10_14 1671
 +#endif
++- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
++{
 +
 +  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
 +    return;
@@ -205,21 +204,35 @@ index fa38350a2f..d8c3dcc2e3 100644
 +
 +  BOOL is_dark_appearance =
 +    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
-+  Lisp_Object effective_appearance = is_dark_appearance ? Qdark : Qlight;
++  Vns_system_appearance = is_dark_appearance ? Qdark : Qlight;
 +
-+  Vns_system_appearance = effective_appearance;
++  run_system_appearance_change_hook ();
++}
++
++static inline void run_system_appearance_change_hook (void)
++{
++  if (NILP (Vns_system_appearance_change_functions))
++    return;
++
++  block_input ();
++
++  bool owfi = waiting_for_input;
++  waiting_for_input = false;
 +
 +  safe_call2 (Qrun_hook_with_args,
-+              Qns_system_appearance_change_functions,
-+              effective_appearance);
++          Qns_system_appearance_change_functions,
++          Vns_system_appearance);
++  Fredisplay(Qt);
 +
-+  Fredisplay(Qnil);
-+#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++  waiting_for_input = owfi;
++
++  unblock_input ();
 +}
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
  
  /* Termination sequences:
      C-x C-c:
-@@ -6184,6 +6257,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+@@ -6186,6 +6273,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
    ns_send_appdefined (-1);
  }
  
@@ -234,7 +247,7 @@ index fa38350a2f..d8c3dcc2e3 100644
  
  
  /* ==========================================================================
-@@ -9035,17 +9116,27 @@ - (void)setAppearance
+@@ -9037,17 +9132,27 @@ - (void)setAppearance
  #define NSAppKitVersionNumber10_10 1343
  #endif
  
@@ -272,7 +285,7 @@ index fa38350a2f..d8c3dcc2e3 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -9907,6 +9998,25 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9909,6 +10014,25 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  


### PR DESCRIPTION
Errors (e.g. invalid faces) produced when the
`ns-system-appearance-functions` hook run should not crash Emacs;
Block input and clear `waiting_for_input` flag so that errors that may
arise are just signaled and do not cause Emacs to abort.