### PR TITLE
[ci] Add macOS versions to build matrix

### DIFF
--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -20,9 +20,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-10.15, macos-11.0]
         build_opts:
           - ""
           - "--build-from-source"
@@ -34,6 +35,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Build emacs-plus@26 ${{ matrix.build_opts }}
         run: brew install emacs-plus@26.rb ${{ matrix.build_opts }}

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -20,10 +20,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-10.15, macos-11.0]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -40,6 +41,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -20,10 +20,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-10.15, macos-11.0]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -36,6 +37,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Build emacs-plus@28 ${{ matrix.build_opts }}
         run: brew install emacs-plus@28.rb ${{ matrix.build_opts }}

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -16,9 +16,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-10.15, macos-11.0]
         build_opts:
           - ""
           - "--build-from-source"
@@ -30,6 +31,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Build emacs-plus ${{ matrix.build_opts }}
         uses: nick-invision/retry@v1

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -17,10 +17,17 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11.0]
 
     steps:
       - uses: actions/checkout@v1
+
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Tap emacs-plus
         run: brew tap d12frosted/emacs-plus


### PR DESCRIPTION
**Why this change was necessary**
The GitHub workflows were only testing against `macos-latest`, which
still points to macOS 10.15 Catalina[1]. Now that M1 Macs running
macOS 11.0 Big Sur have reached consumers, Emacs Plus should also
include that OS (and CPU arch) in its CI tests.

**What this change does**
 - Adds macOS 11.0 as an option to the build matrix for every
 workflow.
 - Explicitly names macOS 10.15 (Catalina) as an option to the build
 matrix.
 - Explicitly sets Xcode 12.2 if the OS version is 11.0, since
 previous XCode versions cannot build for Big Sur[2].

**Any side-effects?**
None.

**Additional context/notes/links**
[1] https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
[2] actions/virtual-environments#2056