### PR TITLE
Fix: Remove homebrew's deprecated x11

### DIFF
--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -46,7 +46,6 @@ class EmacsPlusAT27 < EmacsBase
   depends_on "imagemagick" => :recommended
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
-  depends_on :x11 => :optional
 
   if build.with? "x11"
     depends_on "freetype" => :recommended

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -50,6 +50,7 @@ class EmacsPlusAT27 < EmacsBase
   if build.with? "x11"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
+    depends_on "libx11" => :recommended
   end
 
   #

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -39,6 +39,7 @@ class EmacsPlusAT28 < EmacsBase
   if build.with? "x11"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
+    depends_on "libx11" => :recommended
   end
 
   #

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -35,7 +35,6 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "imagemagick" => :recommended
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
-  depends_on :x11 => :optional
 
   if build.with? "x11"
     depends_on "freetype" => :recommended


### PR DESCRIPTION
This removes the deprecated homebrew's X11 dependency.

Closes issue #286