### PR TITLE
Make librsvg optional for Emacs 27

### DIFF
--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -40,7 +40,7 @@ class EmacsPlusAT27 < EmacsBase
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
   depends_on "gnutls"
-  depends_on "librsvg"
+  depends_on "librsvg" => :recommended
   depends_on "little-cms2"
   depends_on "jansson"
   depends_on "imagemagick" => :recommended


### PR DESCRIPTION
If you are a M1 based mac, librsvg will fail to install because it depends on Rust. Rust will not support M1 till 1.49.0 Currently, brew attempts to install 1.48.0.

This PR makes librsvg recommended, giving the option for emacs 27 to be installed on M1.