### PR TITLE
Fix: Remove homebrew's deprecated x11

### DIFF
--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -46,7 +46,6 @@ class EmacsPlusAT27 < EmacsBase
   depends_on "imagemagick" => :recommended
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
-  depends_on :x11 => :optional
 
   if build.with? "x11"
     depends_on "freetype" => :recommended

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -50,6 +50,7 @@ class EmacsPlusAT27 < EmacsBase
   if build.with? "x11"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
+    depends_on "libx11" => :recommended
   end
 
   #

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -48,9 +48,9 @@ class EmacsPlusAT27 < EmacsBase
   depends_on "mailutils" => :optional
 
   if build.with? "x11"
+    depends_on "libxaw"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
-    depends_on "libx11" => :recommended
   end
 
   #

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -39,6 +39,7 @@ class EmacsPlusAT28 < EmacsBase
   if build.with? "x11"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
+    depends_on "libx11" => :recommended
   end
 
   #

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -35,7 +35,6 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "imagemagick" => :recommended
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
-  depends_on :x11 => :optional
 
   if build.with? "x11"
     depends_on "freetype" => :recommended

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -37,9 +37,9 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "mailutils" => :optional
 
   if build.with? "x11"
+    depends_on "libxaw"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
-    depends_on "libx11" => :recommended
   end
 
   #


### PR DESCRIPTION
This is basically @benmezger 's work from #287.
I only changed dependency from libx11 to libxaw to avoid an error in [this comment](https://github.com/d12frosted/homebrew-emacs-plus/pull/287#issuecomment-748648280).
