### PR TITLE
enable NATIVE_FULL_AOT

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -104,6 +104,7 @@ class EmacsPlusAT28 < EmacsBase
   end
 
   def install
+    make_flags = []
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -132,6 +133,8 @@ class EmacsPlusAT28 < EmacsBase
       ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
       ENV.append "LDFLAGS", "-I#{Formula["gmp"].include}"
       ENV.append "LDFLAGS", "-I#{Formula["libjpeg"].include}"
+
+      make_flags << "NATIVE_FULL_AOT=1"
     end
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
@@ -185,7 +188,7 @@ class EmacsPlusAT28 < EmacsBase
         end
       end
 
-      system "make"
+      system "make", *make_flags
       system "make", "install"
 
       if build.with? "native-comp"


### PR DESCRIPTION
I think to make it unconditional. AFAIK, aside from having longer build time (and CI will help me to see real numbers) I has no other drawbacks. 

Examples:

- [Without full AOT][1] - 24 minutes 42 seconds
- [With full AOT][2] - 49 minutes 15 seconds

  [1]: https://github.com/d12frosted/homebrew-emacs-plus/runs/1617715151?check_suite_focus=true
  [2]: https://github.com/d12frosted/homebrew-emacs-plus/runs/1618405833?check_suite_focus=true