### PR TITLE
(feat) optimise icons fetching

### DIFF
--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -39,6 +39,7 @@ class EmacsBase < Formula
   def self.inject_icon_options
     ICONS_CONFIG.each do |icon, sha|
       option "with-#{icon}-icon", "Using Emacs #{icon} icon"
+      next if build.without? "#{icon}-icon"
       resource "#{icon}-icon" do
         url (UrlResolver.icon_url icon)
         sha256 sha


### PR DESCRIPTION
Instead of downloading all icons (and I am planning to add 20 more),
download only the specified one. Saves lots of unnecessary IO.