### PR TITLE
Change post-install message for linking to Application

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -112,7 +112,7 @@ class EmacsPlusAT26 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        cp -r #{prefix}/Emacs.app /Applications
     EOS
   end
 

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -209,7 +209,7 @@ class EmacsPlusAT27 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        cp -r #{prefix}/Emacs.app /Applications
 
       If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
       emacs-plus@28 formula respectively.

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -250,7 +250,7 @@ class EmacsPlusAT28 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        cp -r #{prefix}/Emacs.app /Applications
     EOS
   end
 


### PR DESCRIPTION
Aliased applications don't appear in applications lists created by apps like Spotlight and Alfred. Default cask behaviour is to copy the `.app` folder to `/Applications`