### PR TITLE
Bump emacs-plus@27 formula to emacs 27.2

### DIFF
--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -2,9 +2,9 @@ require_relative "../Library/EmacsBase"
 require_relative "../Library/UrlResolver"
 
 class EmacsPlusAT27 < EmacsBase
-  url "https://ftp.gnu.org/gnu/emacs/emacs-27.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-27.1.tar.xz"
-  sha256 "4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-27.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-27.2.tar.xz"
+  sha256 "b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9"
 
   head do
     url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-27"


### PR DESCRIPTION
Hey, just bumping the emacs-plus@27 formula to use the 27.2 bugfix release: <https://lists.gnu.org/archive/html/info-gnu/2021-03/msg00008.html>. I'm not a homebrew dev so I'm not sure if there's anything else that needs to be changed besides the source URL & SHA256 sum. Hopefully that's all!