### PR TITLE
fix native-comp branch

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -64,7 +64,7 @@ class EmacsPlusAT28 < EmacsBase
   #
 
   if build.with? "native-comp"
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "feature/native-comp"
+    url "https://github.com/emacs-mirror/emacs.git", :revision => "978afd788fd0496540f715b83f18ed390ca8d5a4"
   else
     url "https://github.com/emacs-mirror/emacs.git"
   end


### PR DESCRIPTION
Fixes #333

Recently `feature/native-comp` stopped working properly. It compiles
well, but the following error occurs when starting `emacs`:

```
emacs: can't find function "F6d656e752d6261722d7570646174652d62756666657273_menu_bar_update_buffers_0" in compilation unit /usr/local/Cellar/emacs-plus@28/28.0.50/Emacs.app/Contents/MacOS/../native-lisp/28.0.50-5c045117/preloaded/menu-bar-4f46ea94-7194396e.eln
```

Last time it worked like charm on 4th of April, 20:02 GMT. And the
error occurred on 5th of April, 00:09 GMT. I could not find anything
on the devel mailing list, so went ahead to find a commit that broke
installation. Since native-comp builds are long, I am going to bisect
on CI.

I am suspecting that the offending commit is
https://github.com/emacs-mirror/emacs/commit/6f8ec1449197f1fcd730df91dddf6f7750284593,
so I am using it's parent to see if it works.

I haven't read it thoroughly, but it seems like we need to change this
block:
https://github.com/d12frosted/homebrew-emacs-plus/blob/master/Formula/emacs-plus%4028.rb#L191-L205