### PR TITLE
Fix native-comp .eln file globbing

### DIFF
--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -35,8 +35,16 @@ jobs:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}
       HOMEBREW_GITHUB_ACTOR: ${{ github.actor }}
+      HOMEBREW_GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
 
     steps:
+      - name: env test
+        run: |
+          echo "HOMEBREW_GITHUB_REF              = $HOMEBREW_GITHUB_REF"
+          echo "HOMEBREW_GITHUB_REPOSITORY       = $HOMEBREW_GITHUB_REPOSITORY"
+          echo "HOMEBREW_GITHUB_ACTOR            = $HOMEBREW_GITHUB_ACTOR"
+          echo "HOMEBREW_GITHUB_REPOSITORY_OWNER = $HOMEBREW_GITHUB_REPOSITORY_OWNER"
+
       - uses: actions/checkout@v2.3.4
 
       - name: Use XCode 12.2 for Big Sur

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -40,7 +40,6 @@ jobs:
     steps:
       - name: env test
         run: |
-          echo "Environment variables"
           echo "HOMEBREW_GITHUB_REF              = $HOMEBREW_GITHUB_REF"
           echo "HOMEBREW_GITHUB_REPOSITORY       = $HOMEBREW_GITHUB_REPOSITORY"
           echo "HOMEBREW_GITHUB_ACTOR            = $HOMEBREW_GITHUB_ACTOR"

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - name: env test
         run: |
+          echo "Environment variables"
           echo "HOMEBREW_GITHUB_REF              = $HOMEBREW_GITHUB_REF"
           echo "HOMEBREW_GITHUB_REPOSITORY       = $HOMEBREW_GITHUB_REPOSITORY"
           echo "HOMEBREW_GITHUB_ACTOR            = $HOMEBREW_GITHUB_ACTOR"

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -196,7 +196,7 @@ class EmacsPlusAT28 < EmacsBase
         # all of the *.eln files end up with the same ID. See:
         # https://github.com/Homebrew/brew/issues/9526 and
         # https://github.com/Homebrew/brew/pull/10075
-        Dir.glob(contents_dir/"native-lisp/*/*.eln").each do |f|
+        Dir.glob(contents_dir/"native-lisp/**/*.eln").each do |f|
           fo = MachO::MachOFile.new(f)
           ohai "Change dylib_id of ELN files before post_install phase"
           fo.dylib_id = "#{contents_dir}/" + f

--- a/Library/UrlResolver.rb
+++ b/Library/UrlResolver.rb
@@ -1,6 +1,6 @@
 class UrlResolver
   def self.repo
-    (ENV["HOMEBREW_GITHUB_ACTOR"] or "d12frosted") + "/" + "homebrew-emacs-plus"
+    (ENV["HOMEBREW_GITHUB_REPOSITORY_OWNER"] or ENV["HOMEBREW_GITHUB_ACTOR"] or "d12frosted") + "/" + "homebrew-emacs-plus"
   end
 
   def self.branch


### PR DESCRIPTION
Since .eln files inside "native-lisp" are now split into folders then the globbing patter has to be adjusted