### PR TITLE
Changed brew cask syntax

### DIFF
--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')
-        run: brew cask install xquartz
+        run: brew install --cask xquartz
 
       - name: Build emacs-plus@27 ${{ matrix.build_opts }}
         run: brew install emacs-plus@27.rb ${{ matrix.build_opts }}

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -30,6 +30,7 @@ jobs:
           - "--with-xwidgets"
           - "--with-no-titlebar"
           - "--with-native-comp"
+          - "--with-x11"
 
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
@@ -42,6 +43,10 @@ jobs:
       - name: Use XCode 12.2 for Big Sur
         if: contains(matrix.os, 'macos-11.0')
         run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+        
+      - name: Install xquartz
+        if: contains(matrix.build_opts, '--with-x11')
+        run: brew install --cask xquartz
 
       - name: Build emacs-plus@28 ${{ matrix.build_opts }}
         run: brew install emacs-plus@28.rb ${{ matrix.build_opts }}


### PR DESCRIPTION
The command `brew cask install` is deprecated.
Updated it to `brew install --cask`.
```diff
diff --git a/old.txt b/new.txt
index 84b108c..4da0977 100644
--- a/old.txt
+++ b/new.txt
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')
-        run: brew cask install xquartz
+        run: brew install --cask xquartz
 
       - name: Build emacs-plus@27 ${{ matrix.build_opts }}
         run: brew install emacs-plus@27.rb ${{ matrix.build_opts }}
```