### PR TITLE
use local patches and icons

### DIFF
--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -39,15 +39,12 @@ jobs:
         run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
 
       - name: Build emacs-plus@26 ${{ matrix.build_opts }}
-        run: brew install emacs-plus@26.rb ${{ matrix.build_opts }}
-        working-directory: Formula
+        run: brew install ./Formula/emacs-plus@26.rb ${{ matrix.build_opts }}
 
       - name: Test installation
         if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test emacs-plus@26.rb
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@26.rb
 
       - name: Test installation (--HEAD)
         if: contains(matrix.build_opts, '--HEAD')
-        run: brew test emacs-plus@26.rb --HEAD
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@26.rb --HEAD

--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -29,9 +29,7 @@ jobs:
           - "--build-from-source"
 
     env:
-      HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
-      HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}
-      HOMEBREW_GITHUB_ACTOR: ${{ github.actor }}
+      HOMEBREW_EMACS_PLUS_MODE: local
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -48,15 +48,12 @@ jobs:
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@27 ${{ matrix.build_opts }}
-        run: brew install emacs-plus@27.rb ${{ matrix.build_opts }}
-        working-directory: Formula
+        run: brew install ./Formula/emacs-plus@27.rb ${{ matrix.build_opts }}
 
       - name: Test installation
         if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test emacs-plus@27.rb
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@27.rb
 
       - name: Test installation (--HEAD)
         if: contains(matrix.build_opts, '--HEAD')
-        run: brew test emacs-plus@27.rb --HEAD
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@27.rb --HEAD

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -34,9 +34,7 @@ jobs:
           - "--HEAD --with-no-titlebar"
 
     env:
-      HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
-      HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}
-      HOMEBREW_GITHUB_ACTOR: ${{ github.actor }}
+      HOMEBREW_EMACS_PLUS_MODE: local
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -41,21 +41,18 @@ jobs:
       - name: Use XCode 12.2 for Big Sur
         if: contains(matrix.os, 'macos-11.0')
         run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
-        
+
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@28 ${{ matrix.build_opts }}
-        run: brew install emacs-plus@28.rb ${{ matrix.build_opts }}
-        working-directory: Formula
+        run: brew install ./Formula/emacs-plus@28.rb ${{ matrix.build_opts }}
 
       - name: Test installation
         if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test emacs-plus@28.rb
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@28.rb
 
       - name: Test installation (--HEAD)
         if: contains(matrix.build_opts, '--HEAD')
-        run: brew test emacs-plus@28.rb --HEAD
-        working-directory: Formula
+        run: brew test ./Formula/emacs-plus@28.rb --HEAD

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -33,9 +33,7 @@ jobs:
           - "--with-x11"
 
     env:
-      HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
-      HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}
-      HOMEBREW_GITHUB_ACTOR: ${{ github.actor }}
+      HOMEBREW_EMACS_PLUS_MODE: local
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -16,15 +16,13 @@ on:
     - cron: "0 */12 * * *"
 
 jobs:
-  build:
+  tap-and-install:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-10.15, macos-11.0]
 
     steps:
-      - uses: actions/checkout@v2.3.4
-
       - name: Use XCode 12.2 for Big Sur
         if: contains(matrix.os, 'macos-11.0')
         run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
@@ -34,6 +32,23 @@ jobs:
 
       - name: Build emacs-plus
         run: brew install emacs-plus
+
+      - name: Test installation
+        run: brew test emacs-plus
+
+  install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11.0]
+
+    steps:
+      - name: Use XCode 12.2 for Big Sur
+        if: contains(matrix.os, 'macos-11.0')
+        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+
+      - name: Build emacs-plus
+        run: brew install d12frosted/homebrew-emacs-plus/emacs-plus
 
       - name: Test installation
         run: brew test emacs-plus

--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
-require_relative "../Library/UrlResolver"
 
 class EmacsPlusAT26 < EmacsBase
+  init 26
   url "https://ftp.gnu.org/gnu/emacs/emacs-26.3.tar.xz"
   mirror "https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz"
   sha256 "4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485"
@@ -29,20 +29,13 @@ class EmacsPlusAT26 < EmacsBase
   # Patches
   #
 
-  patch do
-    url (UrlResolver.patch_url "emacs-26/multicolor-fonts")
-    sha256 "7597514585c036c01d848b1b2cc073947518522ba6710640b1c027ff47c99ca7"
-  end
+  local_patch "multicolor-fonts", sha: "7597514585c036c01d848b1b2cc073947518522ba6710640b1c027ff47c99ca7"
+  local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  local_patch "fix-unexec", sha: "a1fcfe8020301733a3846cf85b072b461b66e26d15b0154b978afb7a4ec3346b"
 
-  patch do
-    url (UrlResolver.patch_url "emacs-26/fix-window-role")
-    sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-26/fix-unexec")
-    sha256 "a1fcfe8020301733a3846cf85b072b461b66e26d15b0154b978afb7a4ec3346b"
-  end
+  #
+  # Install
+  #
 
   def install
     args = %W[

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
-require_relative "../Library/UrlResolver"
 
 class EmacsPlusAT27 < EmacsBase
+  init 27
   url "https://ftp.gnu.org/gnu/emacs/emacs-27.2.tar.xz"
   mirror "https://ftpmirror.gnu.org/emacs/emacs-27.2.tar.xz"
   sha256 "b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9"
@@ -67,49 +67,17 @@ class EmacsPlusAT27 < EmacsBase
   # Patches
   #
 
-  if build.with? "no-titlebar"
-    patch do
-      url (UrlResolver.patch_url "emacs-27/no-titlebar")
-      sha256 "fdf8dde63c2e1c4cb0b02354ce7f2102c5f8fd9e623f088860aee8d41d7ad38f"
-    end
-  end
+  local_patch "no-titlebar", sha: "fdf8dde63c2e1c4cb0b02354ce7f2102c5f8fd9e623f088860aee8d41d7ad38f" if build.with? "no-titlebar"
+  local_patch "xwidgets_webkit_in_cocoa", sha: "683b09c5f91d1ed3a550d10f409647e4ed236d4352464d15baef871546622e40" if build.with? "xwidgets"
+  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  local_patch "system-appearance", sha: "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
+  local_patch "ligatures-freeze-fix", sha: "782a222505ceea31f9032ed55e24dcbd0357b1178b916b536d3eb222c9dc1225"
+  local_patch "arm", sha: "344fee330fec4071e29c900093fdf1e2d8a7328df1c75b17e6e9d9a954835741" if build.stable?
 
-  if build.with? "xwidgets"
-    patch do
-      url (UrlResolver.patch_url "emacs-27/xwidgets_webkit_in_cocoa")
-      sha256 "683b09c5f91d1ed3a550d10f409647e4ed236d4352464d15baef871546622e40"
-    end
-  end
-
-  if build.with? "no-frame-refocus"
-    patch do
-      url (UrlResolver.patch_url "emacs-27/no-frame-refocus-cocoa")
-      sha256 "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd"
-    end
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-27/fix-window-role")
-    sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-27/system-appearance")
-    sha256 "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-27/ligatures-freeze-fix")
-    sha256 "782a222505ceea31f9032ed55e24dcbd0357b1178b916b536d3eb222c9dc1225"
-  end
-
-  stable do
-    # fix code signing on ARM
-    patch do
-      url (UrlResolver.patch_url "emacs-27/arm")
-      sha256 "344fee330fec4071e29c900093fdf1e2d8a7328df1c75b17e6e9d9a954835741"
-    end
-  end
+  #
+  # Install
+  #
 
   def install
     args = %W[
@@ -242,7 +210,7 @@ class EmacsPlusAT27 < EmacsBase
 
       To link the application to default Homebrew App location:
         ln -s #{prefix}/Emacs.app /Applications
-    
+
       If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
       emacs-plus@28 formula respectively.
     EOS

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
-require_relative "../Library/UrlResolver"
 
 class EmacsPlusAT28 < EmacsBase
+  init 28
   version "28.0.50"
 
   #
@@ -75,29 +75,14 @@ class EmacsPlusAT28 < EmacsBase
   # Patches
   #
 
-  if build.with? "no-titlebar"
-    patch do
-      url (UrlResolver.patch_url "emacs-28/no-titlebar")
-      sha256 "990af9b0e0031bd8118f53e614e6b310739a34175a1001fbafc45eeaa4488c0a"
-    end
-  end
+  local_patch "no-titlebar", sha: "990af9b0e0031bd8118f53e614e6b310739a34175a1001fbafc45eeaa4488c0a" if build.with? "no-titlebar"
+  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  local_patch "system-appearance", sha: "22b541e2893171e45b54593f82a0f5d2c4e62b0e4497fc0351fc89108d6f0084"
 
-  if build.with? "no-frame-refocus"
-    patch do
-      url (UrlResolver.patch_url "emacs-28/no-frame-refocus-cocoa")
-      sha256 "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd"
-    end
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-28/fix-window-role")
-    sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
-  end
-
-  patch do
-    url (UrlResolver.patch_url "emacs-28/system-appearance")
-    sha256 "22b541e2893171e45b54593f82a0f5d2c4e62b0e4497fc0351fc89108d6f0084"
-  end
+  #
+  # Install
+  #
 
   def install
     args = %W[

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -1,68 +1,85 @@
 require_relative "UrlResolver"
 
+class CopyDownloadStrategy < AbstractFileDownloadStrategy
+  def initialize(url, name, version, **meta)
+    @cached_location = Pathname.new url
+  end
+end
+
+ICONS_CONFIG = {
+  "EmacsIcon1"                      => "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0",
+  "EmacsIcon2"                      => "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963",
+  "EmacsIcon3"                      => "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf",
+  "EmacsIcon4"                      => "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135",
+  "EmacsIcon5"                      => "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778",
+  "EmacsIcon6"                      => "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0",
+  "EmacsIcon7"                      => "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c",
+  "EmacsIcon8"                      => "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0",
+  "EmacsIcon9"                      => "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e",
+  "cacodemon"                       => "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728",
+  "elrumo1"                         => "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42",
+  "elrumo2"                         => "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4",
+  "emacs-card-blue-deep"            => "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9",
+  "emacs-card-british-racing-green" => "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5",
+  "emacs-card-carmine"              => "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9",
+  "emacs-card-green"                => "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7",
+  "gnu-head"                        => "b5899aaa3589b54c6f31aa081daf29d303047aa07b5ca1d0fd7f9333a829b6d3",
+  "modern"                          => "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5",
+  "modern-alecive-flatwoken"        => "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd",
+  "modern-asingh4242"               => "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4",
+  "modern-azhilin"                  => "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a",
+  "modern-bananxan"                 => "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc",
+  "modern-black-dragon"             => "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a",
+  "modern-black-gnu-head"           => "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b",
+  "modern-black-variant"            => "b066ee684e68519950bcca06f631a49fbd1f5a463d49114e5063b3a5f1654d0c",
+  "modern-bokehlicia-captiva"       => "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238",
+  "modern-cg433n"                   => "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd",
+  "modern-doom"                     => "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b",
+  "modern-doom3"                    => "02e8535317b70c0674c608ed3b8bfee4badc8d1f4a96b99d980744c185948d24",
+  "modern-mzaplotnik"               => "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6",
+  "modern-nuvola"                   => "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997",
+  "modern-orange"                   => "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43",
+  "modern-paper"                    => "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a",
+  "modern-papirus"                  => "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b",
+  "modern-pen"                      => "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b",
+  "modern-pen-3d"                   => "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b",
+  "modern-pen-black"                => "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27",
+  "modern-pen-lds56"                => "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0",
+  "modern-purple-flat"              => "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6",
+  "modern-sexy-v1"                  => "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820",
+  "modern-sexy-v2"                  => "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6",
+  "modern-sjrmanning"               => "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9",
+  "modern-vscode"                   => "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057",
+  "modern-yellow"                   => "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d",
+  "retro-emacs-logo"                => "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97",
+  "retro-gnu-meditate-levitate"     => "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998",
+  "retro-sink"                      => "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc",
+  "retro-sink-bw"                   => "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571",
+  "spacemacs"                       => "b3db8b7cfa4bc5bce24bc4dc1ede3b752c7186c7b54c09994eab5ec4eaa48900",
+  "nobu417-big-sur"                 => "e9ec41167c38842a3f6555d3142909211a2aa7e3ff91621b9a576b3847d3b565",
+}.freeze
+
 class EmacsBase < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
 
-  ICONS_CONFIG = {
-    "EmacsIcon1"                      => "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0",
-    "EmacsIcon2"                      => "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963",
-    "EmacsIcon3"                      => "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf",
-    "EmacsIcon4"                      => "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135",
-    "EmacsIcon5"                      => "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778",
-    "EmacsIcon6"                      => "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0",
-    "EmacsIcon7"                      => "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c",
-    "EmacsIcon8"                      => "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0",
-    "EmacsIcon9"                      => "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e",
-    "cacodemon"                       => "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728",
-    "elrumo1"                         => "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42",
-    "elrumo2"                         => "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4",
-    "emacs-card-blue-deep"            => "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9",
-    "emacs-card-british-racing-green" => "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5",
-    "emacs-card-carmine"              => "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9",
-    "emacs-card-green"                => "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7",
-    "gnu-head"                        => "b5899aaa3589b54c6f31aa081daf29d303047aa07b5ca1d0fd7f9333a829b6d3",
-    "modern"                          => "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5",
-    "modern-alecive-flatwoken"        => "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd",
-    "modern-asingh4242"               => "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4",
-    "modern-azhilin"                  => "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a",
-    "modern-bananxan"                 => "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc",
-    "modern-black-dragon"             => "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a",
-    "modern-black-gnu-head"           => "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b",
-    "modern-black-variant"            => "b066ee684e68519950bcca06f631a49fbd1f5a463d49114e5063b3a5f1654d0c",
-    "modern-bokehlicia-captiva"       => "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238",
-    "modern-cg433n"                   => "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd",
-    "modern-doom"                     => "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b",
-    "modern-doom3"                    => "02e8535317b70c0674c608ed3b8bfee4badc8d1f4a96b99d980744c185948d24",
-    "modern-mzaplotnik"               => "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6",
-    "modern-nuvola"                   => "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997",
-    "modern-orange"                   => "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43",
-    "modern-paper"                    => "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a",
-    "modern-papirus"                  => "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b",
-    "modern-pen"                      => "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b",
-    "modern-pen-3d"                   => "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b",
-    "modern-pen-black"                => "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27",
-    "modern-pen-lds56"                => "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0",
-    "modern-purple-flat"              => "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6",
-    "modern-sexy-v1"                  => "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820",
-    "modern-sexy-v2"                  => "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6",
-    "modern-sjrmanning"               => "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9",
-    "modern-vscode"                   => "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057",
-    "modern-yellow"                   => "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d",
-    "retro-emacs-logo"                => "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97",
-    "retro-gnu-meditate-levitate"     => "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998",
-    "retro-sink"                      => "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc",
-    "retro-sink-bw"                   => "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571",
-    "spacemacs"                       => "b3db8b7cfa4bc5bce24bc4dc1ede3b752c7186c7b54c09994eab5ec4eaa48900",
-    "nobu417-big-sur"                 => "e9ec41167c38842a3f6555d3142909211a2aa7e3ff91621b9a576b3847d3b565",
-  }.freeze
+  def self.init version
+    @@urlResolver = UrlResolver.new(version, ENV["HOMEBREW_EMACS_PLUS_MODE"] || "remote")
+  end
+
+  def self.local_patch(name, sha:)
+    patch do
+      url (@@urlResolver.patch_url name), :using => CopyDownloadStrategy
+      sha256 sha
+    end
+  end
 
   def self.inject_icon_options
     ICONS_CONFIG.each do |icon, sha|
       option "with-#{icon}-icon", "Using Emacs #{icon} icon"
       next if build.without? "#{icon}-icon"
       resource "#{icon}-icon" do
-        url (UrlResolver.icon_url icon)
+        url (@@urlResolver.icon_url icon), :using => CopyDownloadStrategy
         sha256 sha
       end
     end

--- a/Library/UrlResolver.rb
+++ b/Library/UrlResolver.rb
@@ -1,22 +1,18 @@
 class UrlResolver
-  def self.repo
-    (ENV["HOMEBREW_GITHUB_ACTOR"] or "d12frosted") + "/" + "homebrew-emacs-plus"
+  def initialize(version, mode)
+    @version = version
+    @formula_name = "emacs-plus@#{version}"
+    @formula_dir =
+      mode == "local" ?
+        Dir.pwd :
+        (Formula[@formula_name].path.to_s.delete_suffix "/Formula/#@formula_name.rb")
   end
 
-  def self.branch
-    ref = ENV["HOMEBREW_GITHUB_REF"]
-    if ref
-      ref.sub("refs/heads/", "")
-    else
-      "master"
-    end
+  def patch_url name
+    "#@formula_dir/patches/emacs-#@version/#{name}.patch"
   end
 
-  def self.patch_url(name)
-    "https://raw.githubusercontent.com/#{repo}/#{branch}/patches/#{name}.patch"
-  end
-
-  def self.icon_url(name)
-    "https://raw.githubusercontent.com/#{repo}/#{branch}/icons/#{name}.icns"
+  def icon_url name
+    "#@formula_dir/icons/#{name}.icns"
   end
 end

--- a/build
+++ b/build
@@ -7,16 +7,16 @@
 #   $ ./build 25 --without-spacemacs-icon --HEAD
 #
 
-SOURCE_FILE_26=emacs-plus@26.rb
+SOURCE_FILE_26=Formula/emacs-plus@26.rb
 SOURCE_NAME_26=EmacsPlusAT26
 
-SOURCE_FILE_27=emacs-plus@27.rb
+SOURCE_FILE_27=Formula/emacs-plus@27.rb
 SOURCE_NAME_27=EmacsPlusAT27
 
-SOURCE_FILE_28=emacs-plus@28.rb
+SOURCE_FILE_28=Formula/emacs-plus@28.rb
 SOURCE_NAME_28=EmacsPlusAT28
 
-TARGET_FILE=emacs-plus-local.rb
+TARGET_FILE=Formula/emacs-plus-local.rb
 TARGET_NAME=EmacsPlusLocal
 
 PACKAGE=emacs-plus-local
@@ -62,25 +62,23 @@ case $VERSION in
     ;;
 esac
 
-cd Formula && {
-  cp "$SOURCE_FILE" "$TARGET_FILE"
+cp "$SOURCE_FILE" "$TARGET_FILE"
 
-  sed -i -e "s/class $SOURCE_NAME/class $TARGET_NAME/g" "$TARGET_FILE"
+sed -i -e "s/class $SOURCE_NAME/class $TARGET_NAME/g" "$TARGET_FILE"
 
-  case $VERSION in
-    26)
-      SOURCE_FILE=$SOURCE_FILE_26
-      SOURCE_NAME=$SOURCE_NAME_26
-      old_sha=cb589861c8a697869107d1cbacc9cc920a8e7257b5c371b7e590b05e7e04c92c
-      new_sha=1e056907643ab81b340cd5c65832c2a3d9066116606bc822da1c08cf34913c38
-      sed -i -e "s/$old_sha/$new_sha/g" "$TARGET_FILE"
-      ;;
-  esac
+case $VERSION in
+  26)
+    SOURCE_FILE=$SOURCE_FILE_26
+    SOURCE_NAME=$SOURCE_NAME_26
+    old_sha=cb589861c8a697869107d1cbacc9cc920a8e7257b5c371b7e590b05e7e04c92c
+    new_sha=1e056907643ab81b340cd5c65832c2a3d9066116606bc822da1c08cf34913c38
+    sed -i -e "s/$old_sha/$new_sha/g" "$TARGET_FILE"
+    ;;
+esac
 
-  export HOMEBREW_EMACS_PLUS_MODE
-  HOMEBREW_EMACS_PLUS_MODE=local
+export HOMEBREW_EMACS_PLUS_MODE
+HOMEBREW_EMACS_PLUS_MODE=local
 
-  brew uninstall $PACKAGE 2>/dev/null
-  # shellcheck disable=SC2068
-  brew install $TARGET_FILE $@
-}
+brew uninstall $PACKAGE 2>/dev/null
+# shellcheck disable=SC2068
+brew install ./$TARGET_FILE $@

--- a/build
+++ b/build
@@ -77,8 +77,8 @@ cd Formula && {
       ;;
   esac
 
-  export HOMEBREW_GITHUB_REF
-  HOMEBREW_GITHUB_REF=$(git rev-parse --abbrev-ref HEAD)
+  export HOMEBREW_EMACS_PLUS_MODE
+  HOMEBREW_EMACS_PLUS_MODE=local
 
   brew uninstall $PACKAGE 2>/dev/null
   # shellcheck disable=SC2068


### PR DESCRIPTION
So instead of trying to figure out where to download patches and icons
from, simply use them directly from the tap. Depending on the use case
it should be taken either from the homebrew directory or from working
directory.

This change is important because:

1. Any contributor (including collaborators) can modify/add patches and
   icons and CI will use modified/new versions. See #341 and #339.

2. Since files are not downloaded separately, formula installation
   becomes much faster and there is no huge penalty on adding more and
   more icons (there is some penalty when you clone the tap, but it
   works faster than sequential curl).

3. Since there is no download cache anymore, users should not run into
   SHA mismatch errors anymore. When using default downloading
   mechanism users run into SHA mismatch errors when we change any
   resource since homebrew has no versioning instrument for resources.