### PR TITLE
(ci) update Xcode to 12.5

### DIFF
--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0]
+        os: [macos-11]
         build_opts:
           - ""
           - "--build-from-source"
@@ -34,9 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Use XCode 12.2 for Big Sur
-        if: contains(matrix.os, 'macos-11.0')
-        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+      - name: Use XCode 12.5 for Big Sur
+        if: contains(matrix.os, 'macos-11')
+        run: sudo xcode-select -s "/Applications/Xcode_12.5.app"
 
       - name: Build emacs-plus@26 ${{ matrix.build_opts }}
         run: brew install ./Formula/emacs-plus@26.rb ${{ matrix.build_opts }}

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11.0]
+        os: [macos-11]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -39,9 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Use XCode 12.2 for Big Sur
-        if: contains(matrix.os, 'macos-11.0')
-        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+      - name: Use XCode 12.5 for Big Sur
+        if: contains(matrix.os, 'macos-11')
+        run: sudo xcode-select -s "/Applications/Xcode_12.5.app"
 
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11.0]
+        os: [macos-11]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -38,9 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Use XCode 12.2 for Big Sur
-        if: contains(matrix.os, 'macos-11.0')
-        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+      - name: Use XCode 12.5 for Big Sur
+        if: contains(matrix.os, 'macos-11')
+        run: sudo xcode-select -s "/Applications/Xcode_12.5.app"
 
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0]
+        os: [macos-11]
         build_opts:
           - ""
           - "--build-from-source"
@@ -32,9 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Use XCode 12.2 for Big Sur
-        if: contains(matrix.os, 'macos-11.0')
-        run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
+      - name: Use XCode 12.5 for Big Sur
+        if: contains(matrix.os, 'macos-11')
+        run: sudo xcode-select -s "/Applications/Xcode_12.5.app"
 
       - name: Build emacs-plus ${{ matrix.build_opts }}
         run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }}


### PR DESCRIPTION
All the [workflows](https://github.com/d12frosted/homebrew-emacs-plus/actions) have been failed for a few days. After some investigation, some actions may be required.

- [Support for Xcode 12.2 has been removed](https://github.com/actions/virtual-environments/issues/3555). Thus we'd better switch to a later version such as Xcode 12.4 or 12.5.
- The yaml tag is `macos-11` rather than `macos-11.0`, I don't know whether `macos-11.0` still works.

I have NOT tested the changes by myself since the `macos-11` has been [moved to private pools](https://github.com/actions/virtual-environments/issues/2486) and my fork requires some kinds of special applications to use `macos-11`.