### PR TITLE
Pin the emacs 28 formula to the commit before builds started failing

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -64,7 +64,7 @@ class EmacsPlusAT28 < EmacsBase
   # URL
   #
 
-  url "https://github.com/emacs-mirror/emacs.git"
+  url "https://github.com/emacs-mirror/emacs.git", revision: "4d63a033a726a8da33bda8d18a503e88bfb794fb"
 
   #
   # Icons


### PR DESCRIPTION
This PR would pin the emacs-plus@28 formula to the commit before emacs-mirror/emacs@5dd2d50 to temporarily fix an issue occurring upstream with native-comp builds. Decided to update the main formula, but possibly could add another formula, maybe `emacs-plus@28-pin` or something and remove native comp from the original formula and explain why in the readme. See discussion under #364.