### PR TITLE
Add patch to fix native-comp MacOS self contains app build issue

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -79,7 +79,9 @@ class EmacsPlusAT28 < EmacsBase
   local_patch "no-titlebar", sha: "990af9b0e0031bd8118f53e614e6b310739a34175a1001fbafc45eeaa4488c0a" if build.with? "no-titlebar"
   local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  local_patch "fix-eln-path-bug", sha: "f7f0beaf484d8b9fc876acbe59cd1494fc59aa1d13ddc1ba84bd96eed1dca750"
   local_patch "system-appearance", sha: "22b541e2893171e45b54593f82a0f5d2c4e62b0e4497fc0351fc89108d6f0084"
+
 
   #
   # Install

--- a/patches/emacs-28/fix-eln-path-bug.patch
+++ b/patches/emacs-28/fix-eln-path-bug.patch
@@ -1,0 +1,28 @@
+>From 0517874eb4bce2cbbcdf58516c43d50b0174c0ec Mon Sep 17 00:00:00 2001
+From: Alan Third <alan@idiocy.org>
+Date: Tue, 29 Jun 2021 22:02:43 +0100
+Subject: [PATCH] Fix NS native comp search path (bug#49270)
+
+* configure.ac (NS_SELF_CONTAINED): We need to make lispdirrel the
+same as lispdir when building a self contained app bundle as they're
+both relative paths.
+---
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index c8920d877e..6e2cda947a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2025,6 +2025,7 @@ AC_DEFUN
+      infodir="\${ns_appresdir}/info"
+      mandir="\${ns_appresdir}/man"
+      lispdir="\${ns_appresdir}/lisp"
++     lispdirrel="\${ns_appresdir}/lisp"
+      test "$locallisppathset" = no && locallisppath="\${ns_appresdir}/site-lisp"
+      INSTALL_ARCH_INDEP_EXTRA=
+   fi
+-- 
+2.29.2
+
+


### PR DESCRIPTION
This fixes an issue that was raised in #364 and a fix provided by @bienjensu in #366. The difference between the two PRs is that this uses an upstream patch on the mailing list, and avoids pinning the commit sha.

I have a feeling this will be a temporary fix and will see a fix upstream later for this. However, as it stands, the builds are broken without either this fix or the pinning fix in #366

> I believe commit 5dd2d50 which moved *.eln files and various paths
> around a bit for macOS builds, has re-introduced an old bug from last
> year. Basically the checksums that makes up part of the *.eln file
> names uses the absolute path of the .el file in question, but for self
> contained .app builds it needs to just use the relative path to the
> app itself.

This applies a patch created and providing by Alan Third via the mailing
list.

Source of this patch can be found on the bug-gnu-emacs mailing list.
https://lists.gnu.org/archive/html/bug-gnu-emacs/2021-06/msg01381.html