### PR TITLE
Remove native-comp dylibid workaround

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -168,20 +168,6 @@ class EmacsPlusAT28 < EmacsBase
       end
 
       system "make"
-
-      if build.with? "native-comp"
-        # Change .eln files dylib ID to avoid that after the post-install phase
-        # all of the *.eln files end up with the same ID. See:
-        # https://github.com/Homebrew/brew/issues/9526 and
-        # https://github.com/Homebrew/brew/pull/10075
-        Dir.glob(buildpath/"native-lisp/**/*.eln").each do |f|
-          fo = MachO::MachOFile.new(f)
-          ohai "Change dylib_id of ELN files before post_install phase"
-          fo.dylib_id = "#{buildpath}/" + f
-          fo.write!
-        end
-      end
-
       system "make", "install"
 
       icons_dir = buildpath/"nextstep/Emacs.app/Contents/Resources"


### PR DESCRIPTION
Remove native-comp dylibid workaround since a fix has been made available in emacs upstream repo https://github.com/emacs-mirror/emacs/commit/6c007668b38f06824004da466e97a96533f6344b.

More info can be found in the original bug report: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=45934