### PR TITLE
Use emacs-28 release branch for emacs-plus@28 build

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -64,7 +64,7 @@ class EmacsPlusAT28 < EmacsBase
   # URL
   #
 
-  url "https://github.com/emacs-mirror/emacs.git"
+  url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-28"
 
   #
   # Icons


### PR DESCRIPTION
See https://mail.gnu.org/archive/html/emacs-devel/2021-09/msg02290.html

Otherwise emacs-plus@28 will install from master, which is Emacs 29.0.50 now.