### PR TITLE
(ci) stop using brew test

### DIFF
--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -38,9 +38,4 @@ jobs:
         run: brew install ./Formula/emacs-plus@26.rb ${{ matrix.build_opts }}
 
       - name: Test installation
-        if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test ./Formula/emacs-plus@26.rb
-
-      - name: Test installation (--HEAD)
-        if: contains(matrix.build_opts, '--HEAD')
-        run: brew test ./Formula/emacs-plus@26.rb --HEAD
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -47,9 +47,4 @@ jobs:
         run: brew install ./Formula/emacs-plus@27.rb ${{ matrix.build_opts }}
 
       - name: Test installation
-        if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test ./Formula/emacs-plus@27.rb
-
-      - name: Test installation (--HEAD)
-        if: contains(matrix.build_opts, '--HEAD')
-        run: brew test ./Formula/emacs-plus@27.rb --HEAD
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -46,9 +46,4 @@ jobs:
         run: brew install ./Formula/emacs-plus@28.rb ${{ matrix.build_opts }}
 
       - name: Test installation
-        if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test ./Formula/emacs-plus@28.rb
-
-      - name: Test installation (--HEAD)
-        if: contains(matrix.build_opts, '--HEAD')
-        run: brew test ./Formula/emacs-plus@28.rb --HEAD
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -46,9 +46,4 @@ jobs:
         run: brew install ./Formula/emacs-plus@29.rb ${{ matrix.build_opts }}
 
       - name: Test installation
-        if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test ./Formula/emacs-plus@29.rb
-
-      - name: Test installation (--HEAD)
-        if: contains(matrix.build_opts, '--HEAD')
-        run: brew test ./Formula/emacs-plus@29.rb --HEAD
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -36,9 +36,4 @@ jobs:
         run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }}
 
       - name: Test installation
-        if: contains(matrix.build_opts, '--HEAD') == false
-        run: brew test Aliases/$(readlink Aliases/emacs-plus)
-
-      - name: Test installation (--HEAD)
-        if: contains(matrix.build_opts, '--HEAD')
-        run: brew test Aliases/$(readlink Aliases/emacs-plus) --HEAD
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -30,7 +30,7 @@ jobs:
         run: brew install emacs-plus
 
       - name: Test installation
-        run: brew test emacs-plus
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
 
   install:
     runs-on: ${{ matrix.os }}
@@ -43,4 +43,4 @@ jobs:
         run: brew install d12frosted/homebrew-emacs-plus/emacs-plus
 
       - name: Test installation
-        run: brew test emacs-plus
+        run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'


### PR DESCRIPTION
Apparently `brew test` tries to build dependencies of `brew bundle`.
And it seems like it depends on ronn, which is [dead][1]. The worst
part is that ronn depends on rdiscount 2.2.0.2, which fails to build.
Didn't dig too much into it, but [seems like][2] it's also not in high
priority. Homebrew issue tracker is silent and I don't feel safe to
report anything there, so with this commit going to do simple thing -
avoid using `brew test`. Since I don't have `brew` right now, I am
just going to see if `brew --prefix` does what I expect. Will turn it
into real test later.

[1]: https://github.com/rtomayko/ronn/issues/103
[2]: https://github.com/davidfstr/rdiscount/issues/148