### PR TITLE
emacs@29: cleanup native-comp related flags manipulation

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -99,23 +99,6 @@ class EmacsPlusAT29 < EmacsBase
 
     args << "--with-native-compilation" if build.with? "native-comp"
 
-    if build.with? "native-comp"
-      gcc_ver = Formula["gcc"].any_installed_version
-      gcc_ver_major = gcc_ver.major
-      gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
-
-      ENV.append "CFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["libgccjit"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["gmp"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["libjpeg"].include}"
-
-      ENV.append "LDFLAGS", "-L#{gcc_lib}"
-      ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["gmp"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["libjpeg"].include}"
-    end
-
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
 
     args <<


### PR DESCRIPTION
Since `emacs-plus@29` is using standard environment instead of
`superenv` provided by `brew`, Emacs configuration script picks up
these flags automatically.