### PR TITLE
emacs@28: switch to standard env

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -5,6 +5,7 @@ class EmacsPlusAT28 < EmacsBase
   url "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/emacs/emacs-28.1.tar.xz"
   sha256 "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1"
+  env :std
 
   head do
     url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-28"
@@ -30,6 +31,7 @@ class EmacsPlusAT28 < EmacsBase
   # Dependencies
   #
 
+  depends_on "make" => :build
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "pkg-config" => :build
@@ -80,6 +82,7 @@ class EmacsPlusAT28 < EmacsBase
   local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
+  local_patch "fix-MAC_LIBS-inference-on-Intel", sha: "e336dd571732fffb3c71fa31c35084f6529dc1e432f35aed3406f1eae14e5a32" if build.with? "native-comp"
 
   #
   # Install
@@ -98,23 +101,6 @@ class EmacsPlusAT28 < EmacsBase
     args << "--with-gnutls"
 
     args << "--with-native-compilation" if build.with? "native-comp"
-
-    if build.with? "native-comp"
-      gcc_ver = Formula["gcc"].any_installed_version
-      gcc_ver_major = gcc_ver.major
-      gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
-
-      ENV.append "CFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["libgccjit"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["gmp"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["libjpeg"].include}"
-
-      ENV.append "LDFLAGS", "-L#{gcc_lib}"
-      ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["gmp"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["libjpeg"].include}"
-    end
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
 
@@ -167,8 +153,8 @@ class EmacsPlusAT28 < EmacsBase
         end
       end
 
-      system "make"
-      system "make", "install"
+      system "gmake"
+      system "gmake", "install"
 
       icons_dir = buildpath/"nextstep/Emacs.app/Contents/Resources"
       ICONS_CONFIG.each_key do |icon|
@@ -217,8 +203,8 @@ class EmacsPlusAT28 < EmacsBase
         end
       end
 
-      system "make"
-      system "make", "install"
+      system "gmake"
+      system "gmake", "install"
     end
 
     # Follow MacPorts and don't install ctags from Emacs. This allows Vim

--- a/patches/emacs-28/fix-MAC_LIBS-inference-on-Intel.patch
+++ b/patches/emacs-28/fix-MAC_LIBS-inference-on-Intel.patch
@@ -1,0 +1,26 @@
+From ccf4835f5dadbbe2a0c41e29c88fb37029209b42 Mon Sep 17 00:00:00 2001
+From: Boris Buliga <boris@d12frosted.io>
+Date: Thu, 28 Apr 2022 18:22:13 +0300
+Subject: [PATCH] fix MAC_LIBS inference on Intel
+
+---
+ configure.ac | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7c8638a471..dcbb25c063 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4125,8 +4125,7 @@ if test "${with_native_compilation}" != "no"; then
+         if test -n "`$BREW --prefix --installed libgccjit 2>/dev/null`"; then
+           MAC_CFLAGS="-I$(dirname $($BREW ls -v libgccjit | \
+                                                 grep libgccjit.h))"
+-          MAC_LIBS="-L$(dirname $($BREW ls -v libgccjit| \
+-                                            grep libgccjit.so\$))"
++          MAC_LIBS="-L$(dirname $($BREW ls -v libgccjit | grep libgccjit.dylib\$ || $BREW ls -v libgccjit | grep libgccjit.so\$))"
+         fi
+       fi
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
It's the first step towards PATH injection to Emacs.app as it is done
in emacs-plus@29 (see #453).

It has changes from #453, #457, #460 and #462.

Next step would be to actually inject PATH as it is done in #453.