### PR TITLE
emacs-{28,29}: add deps to build PATH

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -34,6 +34,9 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "make" => :build
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
+  depends_on "gnu-tar" => :build
+  depends_on "awk" => :build
+  depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
   depends_on "gnutls"
@@ -85,10 +88,21 @@ class EmacsPlusAT28 < EmacsBase
   local_patch "fix-MAC_LIBS-inference-on-Intel", sha: "e336dd571732fffb3c71fa31c35084f6529dc1e432f35aed3406f1eae14e5a32" if build.with? "native-comp"
 
   #
+  # Initialize
+  #
+
+  def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+    super
+    expand_path
+  end
+
+  #
   # Install
   #
 
   def install
+    expand_path
+
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -27,6 +27,9 @@ class EmacsPlusAT29 < EmacsBase
   depends_on "make" => :build
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
+  depends_on "gnu-tar" => :build
+  depends_on "awk" => :build
+  depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
   depends_on "gnutls"
@@ -82,10 +85,21 @@ class EmacsPlusAT29 < EmacsBase
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
 
   #
+  # Initialize
+  #
+
+  def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+    super
+    expand_path
+  end
+
+  #
   # Install
   #
 
   def install
+    expand_path
+
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -60,4 +60,24 @@ class EmacsBase < Formula
     system "/usr/libexec/PlistBuddy -c 'Print :LSEnvironment' '#{plist}'"
     system "touch '#{app}'"
   end
+
+  def expand_path
+    # Expand PATH to include all dependencies and Superenv.bin as
+    # dependencies can override standard tools.
+    path = PATH.new()
+    path.append(deps.map { |dep| dep.to_formula.libexec/"gnubin" })
+    path.append(deps.map { |dep| dep.to_formula.opt_bin })
+    path.append(ENV['PATH'])
+    ENV['PATH'] = path.existing
+
+    # TODO: remove this debug info
+    if verbose?
+      puts "PATH value was changed to:"
+      path.each_entry { |x|
+        puts x
+      }
+      system "which", "tar"
+      system "which", "ls"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #466 and #465

This kind of nullifies drawbacks of using standard env as it appends
critical stuff the beginning of PATH (e.g. prepends) and still allows
us to access it later to bake it in Emacs.app/Info.plist file.