### PR TITLE
emacs-{28,29}: improve path injection routine

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -170,12 +170,7 @@ class EmacsPlusAT28 < EmacsBase
       prefix.install "nextstep/Emacs.app"
 
       # inject PATH to Info.plist
-      path = ENV['PATH'].split("#{HOMEBREW_PREFIX}/Library/Homebrew/shims/shared:").last
-      system "/usr/libexec/PlistBuddy -c 'Add :LSEnvironment dict' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PATH string' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PATH #{path}' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Print :LSEnvironment' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "touch '#{prefix}/Emacs.app'"
+      inject_path
 
       # Replace the symlink with one that avoids starting Cocoa.
       (bin/"emacs").unlink # Kill the existing symlink
@@ -230,6 +225,10 @@ class EmacsPlusAT28 < EmacsBase
 
       To link the application to default Homebrew App location:
         ln -s #{prefix}/Emacs.app /Applications
+
+      Your PATH value was injected into Emacs.app/Contents/Info.plist
+
+      Report any issues to http://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end
 

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -167,12 +167,7 @@ class EmacsPlusAT29 < EmacsBase
       prefix.install "nextstep/Emacs.app"
 
       # inject PATH to Info.plist
-      path = ENV['PATH'].split("#{HOMEBREW_PREFIX}/Library/Homebrew/shims/shared:").last
-      system "/usr/libexec/PlistBuddy -c 'Add :LSEnvironment dict' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PATH string' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PATH #{path}' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "/usr/libexec/PlistBuddy -c 'Print :LSEnvironment' '#{prefix}/Emacs.app/Contents/Info.plist'"
-      system "touch '#{prefix}/Emacs.app'"
+      inject_path
 
       # Replace the symlink with one that avoids starting Cocoa.
       (bin/"emacs").unlink # Kill the existing symlink
@@ -227,6 +222,10 @@ class EmacsPlusAT29 < EmacsBase
 
       To link the application to default Homebrew App location:
         ln -s #{prefix}/Emacs.app /Applications
+
+      Your PATH value was injected into Emacs.app/Contents/Info.plist
+
+      Report any issues to http://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end
 


### PR DESCRIPTION
1. Move it to a helper function to the EmacsBase class
2. Be more verbose about injection process
3. Use PATH helper provided by brew to simplify manipulations