### PR TITLE
Add --with-compress-install option (fix Emacs 29 failing to start)

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -19,6 +19,7 @@ class EmacsPlusAT29 < EmacsBase
   option "with-xwidgets", "Experimental: build with xwidgets support"
   option "with-no-frame-refocus", "Disables frame re-focus (ie. closing one frame does not refocus another one)"
   option "with-native-comp", "Build with native compilation"
+  option "with-compress-install", "Build with compressed install optimization"
 
   #
   # Dependencies
@@ -114,6 +115,7 @@ class EmacsPlusAT29 < EmacsBase
     args << "--with-gnutls"
 
     args << "--with-native-compilation" if build.with? "native-comp"
+    args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
 
@@ -229,7 +231,9 @@ class EmacsPlusAT29 < EmacsBase
     # and Emacs and ctags to play together without violence.
     if build.without? "ctags"
       (bin/"ctags").unlink
-      (man1/"ctags.1.gz").unlink
+      if build.with? "compress-install"
+        (man1/"ctags.1.gz").unlink
+      end
     end
   end
 


### PR DESCRIPTION
This is an issue for the Emacs 29 formula only.

See https://github.com/syl20bnr/spacemacs/issues/11585 and
https://mail.gnu.org/archive/html/emacs-devel/2022-08/msg00234.html
for motivation.

It's common for Emacs configs to have a line such as
(setq file-name-handler-alist nil), which optimizes early loading of packages,
until a further point where the variable is restored. Both Spacemacs and Doom
Emacs do this. However, it means anything other than plain text (e. g. compressed
.el.gz files) cannot be understood by Emacs until the value is reset. It used to
due to a bug where compressed files where treated differently regardless of
file-name-alist, but that's recently been fixed, breaking compressed install
such as nix's with a cryptic (void-variable \233) error. 

This PR disables optimization by default and allows a user to opt in to compression, making the optimization work again.
It should probably be mentioned in the manual or emacs-overlay as well.