### PR TITLE
emacs-28: make corners round no-titlebar option

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -22,6 +22,7 @@ class EmacsPlusAT28 < EmacsBase
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
   option "with-x11", "Experimental: build with x11 support"
   option "with-no-titlebar", "Experimental: build without titlebar"
+  option "with-no-titlebar-and-round-corners", "Experimental: build without titlebar and round coners"
   option "with-debug", "Build with debug symbols and debugger friendly optimizations"
   option "with-xwidgets", "Experimental: build with xwidgets support"
   option "with-no-frame-refocus", "Disables frame re-focus (ie. closing one frame does not refocus another one)"
@@ -83,6 +84,7 @@ class EmacsPlusAT28 < EmacsBase
   #
 
   local_patch "no-titlebar", sha: "2fa80efc5cda7e96d88a5d145c9313092a6e53d38825c41967c745f08778c41b" if build.with? "no-titlebar"
+  local_patch "no-titlebar-and-round-corners", sha: "ea9dd629ff4ccf36d893e9ab02ced181cd0a3a62fe1973b0fd6d2ed4ab8a3ee7" if build.with? "no-titlebar-and-round-corners"
   local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"

--- a/patches/emacs-28/no-titlebar-and-round-corners.patch
+++ b/patches/emacs-28/no-titlebar-and-round-corners.patch
@@ -1,0 +1,25 @@
+diff --git a/src/nsterm.m b/src/nsterm.m
+index 1643ba5..4feca66 100644
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -434,6 +434,7 @@ - (NSColor *)colorUsingDefaultColorSpace
+ /* These flags will be OR'd or XOR'd with the NSWindow's styleMask
+    property depending on what we're doing.  */
+ #define FRAME_DECORATED_FLAGS (NSWindowStyleMaskTitled              \
++                               | NSFullSizeContentViewWindowMask    \
+                                | NSWindowStyleMaskResizable         \
+                                | NSWindowStyleMaskMiniaturizable    \
+                                | NSWindowStyleMaskClosable)
+@@ -8323,6 +8324,12 @@ - (instancetype) initWithEmacsFrame:(struct frame *)f
+ #endif
+     }
+ 
++ [self setTitlebarAppearsTransparent:YES];
++ [self setTitleVisibility:NSWindowTitleHidden];
++ [[self standardWindowButton:NSWindowCloseButton] setHidden:YES];
++ [[self standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
++ [[self standardWindowButton:NSWindowZoomButton] setHidden:YES];
++
+   return self;
+ }
+ 


### PR DESCRIPTION
Yabai now uses round borders by default https://github.com/koekeishiya/yabai/issues/1460. This make it look weird with the `--with-no-titlebar` option. This code is stolen from https://github.com/d12frosted/homebrew-emacs-plus/issues/320#issuecomment-965053374