### PR TITLE
fix(native-comp): Add libgccjit paths to build environment

### DIFF
--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -28,7 +28,7 @@ jobs:
         build_opts:
           - ""
           - "--with-xwidgets"
-          # - "--with-native-comp"
+          - "--with-native-comp"
           - "--with-x11"
 
     env:

--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -28,7 +28,7 @@ jobs:
         build_opts:
           - ""
           - "--with-xwidgets"
-          # - "--with-native-comp"
+          - "--with-native-comp"
           - "--with-x11"
 
     env:

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -127,6 +127,10 @@ class EmacsPlusAT28 < EmacsBase
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
+    # Necessary for libgccjit library discovery
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+
     args <<
       if build.with? "dbus"
         "--with-dbus"

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -122,6 +122,10 @@ class EmacsPlusAT29 < EmacsBase
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
+    # Necessary for libgccjit library discovery
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+
     args <<
       if build.with? "dbus"
         "--with-dbus"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -122,6 +122,10 @@ class EmacsPlusAT30 < EmacsBase
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
+    # Necessary for libgccjit library discovery
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+
     args <<
       if build.with? "dbus"
         "--with-dbus"


### PR DESCRIPTION
When installed with Homebrew, libgccjit 12 writes header files to the Homebrew `include` directory and DLLs to Homebrew's `lib/gcc/current` directory. If these locations are not added to `CPATH` and `LIBRARY_PATH`, respectively, the Emacs build toolchain is unable to locate libgccjit, leading to the build failure described in #485.

This change appends those libgccjit paths to CPATH and LIBRARY_PATH for all Emacs versions that support the native compilation build flag.

Resolves: #485