### PR TITLE
replace `plist` with `service`

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -117,30 +117,11 @@ class EmacsPlusAT26 < EmacsBase
     EOS
   end
 
-  plist_options :manual => "emacs"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/emacs</string>
-          <string>--fg-daemon</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stdout.log</string>
-        <key>StandardErrorPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stderr.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"emacs", "--fg-daemon"]
+    keep_alive true
+    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
+    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -217,30 +217,11 @@ class EmacsPlusAT27 < EmacsBase
     EOS
   end
 
-  plist_options :manual => "emacs"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/emacs</string>
-          <string>--fg-daemon</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stdout.log</string>
-        <key>StandardErrorPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stderr.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"emacs", "--fg-daemon"]
+    keep_alive true
+    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
+    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -263,30 +263,11 @@ class EmacsPlusAT28 < EmacsBase
     EOS
   end
 
-  plist_options :manual => "emacs"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/emacs</string>
-          <string>--fg-daemon</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stdout.log</string>
-        <key>StandardErrorPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stderr.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"emacs", "--fg-daemon"]
+    keep_alive true
+    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
+    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -265,30 +265,11 @@ class EmacsPlusAT29 < EmacsBase
     EOS
   end
 
-  plist_options :manual => "emacs"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/emacs</string>
-          <string>--fg-daemon</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stdout.log</string>
-        <key>StandardErrorPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stderr.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"emacs", "--fg-daemon"]
+    keep_alive true
+    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
+    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -265,30 +265,11 @@ class EmacsPlusAT30 < EmacsBase
     EOS
   end
 
-  plist_options :manual => "emacs"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/emacs</string>
-          <string>--fg-daemon</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stdout.log</string>
-        <key>StandardErrorPath</key>
-        <string>/tmp/homebrew.mxcl.emacs-plus.stderr.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"emacs", "--fg-daemon"]
+    keep_alive true
+    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
+    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
   end
 
   test do


### PR DESCRIPTION
Switch emacs formula from `def plist` to `service do` blocks

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the d12frosted/emacs-plus tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/Formula/emacs-plus@28.rb:266

Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the d12frosted/emacs-plus tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/Formula/emacs-plus@26.rb:120

Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the d12frosted/emacs-plus tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/Formula/emacs-plus@27.rb:220

Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the d12frosted/emacs-plus tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/Formula/emacs-plus@29.rb:268

Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the d12frosted/emacs-plus tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/Formula/emacs-plus@30.rb:268
```