### PR TITLE
Missing tap argument in `initialize` in upstream

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -99,7 +99,7 @@ class EmacsPlusAT28 < EmacsBase
   # Initialize
   #
 
-  def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+  def initialize(name, path, spec, alias_path: nil, force_bottle: false, tap: nil)
     super
     expand_path
   end

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -94,7 +94,7 @@ class EmacsPlusAT29 < EmacsBase
   # Initialize
   #
 
-  def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+  def initialize(name, path, spec, alias_path: nil, force_bottle: false, tap: nil)
     super
     expand_path
   end

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -94,7 +94,7 @@ class EmacsPlusAT30 < EmacsBase
   # Initialize
   #
 
-  def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+  def initialize(name, path, spec, alias_path: nil, force_bottle: false, tap: nil)
     super
     expand_path
   end


### PR DESCRIPTION
See [commit](https://github.com/Homebrew/brew/commit/e191b827cce991f52be36b0a8fc3daed3ef66143#diff-91b7d3ceb5b783bc460ef7957ed4a960e6d5988c20e925ee78a970e37b8b6954R184) change in `initialize` function. Homebrew `4.0.15-97-ge191b82` or newer. 

Related to #566.