### PR TITLE
Fix grep build breakage

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -130,6 +130,7 @@ class EmacsPlusAT28 < EmacsBase
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
     ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
+    ENV.append "LDFLAGS", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -36,6 +36,7 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -128,8 +128,8 @@ class EmacsPlusAT28 < EmacsBase
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
-    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
-    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -30,6 +30,7 @@ class EmacsPlusAT29 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
@@ -157,6 +158,8 @@ class EmacsPlusAT29 < EmacsBase
     args << "--with-xwidgets" if build.with? "xwidgets"
 
     ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -124,8 +124,8 @@ class EmacsPlusAT29 < EmacsBase
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
-    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
-    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -126,6 +126,7 @@ class EmacsPlusAT29 < EmacsBase
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
     ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
+    ENV.append "LDFLAGS", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -126,6 +126,7 @@ class EmacsPlusAT30 < EmacsBase
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
     ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
+    ENV.append "LDFLAGS", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -124,8 +124,8 @@ class EmacsPlusAT30 < EmacsBase
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
-    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
-    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+    ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include", ":" if build.with? "native-comp"
+    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current", ":" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -30,6 +30,7 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -78,6 +78,7 @@ class EmacsBase < Formula
       }
       system "which", "tar"
       system "which", "ls"
+      system "which", "grep"
     end
   end
 


### PR DESCRIPTION
# Main change

I found that on my system, I had a different incompatible version of grep from a
plan9 installation on my `PATH` that was superseding the builtin grep on one of my
Macs. This explains why the `with-native-comp` build was [failing on one of my
Macs but not the other](https://github.com/d12frosted/homebrew-emacs-plus/issues/555#issuecomment-1527665327) - the Mac with the successful emacs-plus@28
`with-native-comp` build only had the built-in version of grep on its PATH.

Adding GNU grep as a build-time dependency will include it in the `gnubin`
directory, which is prepended to the PATH in each formula. I've also added an
explicit PATH prepending step for each of the GNU build-time dependencies. This
indicates the coupling of those dependencies with the `gnubin` PATH prepending.

The smoking gun in the `0.6.configure` logs is:

```
usage: grep [-bchiLlnsv] [-e pattern] [-f patternfile] [file ...]
dirname: missing operand
```

I've added extra logging to `Library/EmacsBase.rb` to indicate which version of grep is being used at build-time.

Related to https://github.com/d12frosted/homebrew-emacs-plus/issues/555 and https://github.com/d12frosted/homebrew-emacs-plus/issues/556

# Other related fixes for `gcc` lib linkage consistency
* Adds a fix for appending `gcc`'s libs to `CPATH` and `LIBRARY_PATH` with a colon. 
* Appends `gcc/current` to `LDFLAGS`.