### PR TITLE
ci: Save and upload Homebrew logs as workflow artifacts

### DIFF
--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -39,3 +39,19 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@26/ -czvf ~/Library/Logs/Homebrew/emacs-plus@26-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus@26${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus@26-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+

--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v3
         with:
-          name: emacs-plus@26${{ env.build_opts }}.tar.gz
+          name: emacs-plus@26-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@26-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
 

--- a/.github/workflows/emacs-26.yml
+++ b/.github/workflows/emacs-26.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build emacs-plus@26 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@26.rb ${{ matrix.build_opts }}
+        run: brew install ./Formula/emacs-plus@26.rb ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -48,3 +48,19 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@27/ -czvf ~/Library/Logs/Homebrew/emacs-plus@27-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus@27${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus@27-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -44,7 +44,7 @@ jobs:
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@27 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@27.rb ${{ matrix.build_opts }}
+        run: brew install ./Formula/emacs-plus@27.rb ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-27.yml
+++ b/.github/workflows/emacs-27.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v3
         with:
-          name: emacs-plus@27${{ env.build_opts }}.tar.gz
+          name: emacs-plus@27-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@27-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
 

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v3
         with:
-          name: emacs-plus@28${{ env.build_opts }}.tar.gz
+          name: emacs-plus@28-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@28-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
 

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -47,3 +47,19 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@28/ -czvf ~/Library/Logs/Homebrew/emacs-plus@28-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus@28${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus@28-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -43,7 +43,7 @@ jobs:
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@28 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@28.rb ${{ matrix.build_opts }}
+        run: brew install ./Formula/emacs-plus@28.rb ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v3
         with:
-          name: emacs-plus@29${{ env.build_opts }}.tar.gz
+          name: emacs-plus@29-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@29-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
 

--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -42,7 +42,7 @@ jobs:
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@29 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@29.rb ${{ matrix.build_opts }}
+        run: brew install ./Formula/emacs-plus@29.rb ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -46,3 +46,19 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@29/ -czvf ~/Library/Logs/Homebrew/emacs-plus@29-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus@29${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus@29-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+

--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -42,7 +42,7 @@ jobs:
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@30 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@30.rb ${{ matrix.build_opts }}
+        run: brew install ./Formula/emacs-plus@30.rb ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -46,3 +46,19 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@30/ -czvf ~/Library/Logs/Homebrew/emacs-plus@30-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus@30${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus@30-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+

--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v3
         with:
-          name: emacs-plus@30${{ env.build_opts }}.tar.gz
+          name: emacs-plus@30-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@30-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
 

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -40,3 +40,18 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          BUILD_OPTS=$(echo "${{ matrix.build_opts }}" | sed 's/ //')
+          echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS$BUILD_OPTS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus-${{ env.runner_os }}${{ env.build_opts }}.tar.gz

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build emacs-plus ${{ matrix.build_opts }}
-        run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }}
+        run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -47,7 +47,7 @@ jobs:
           echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
           RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
           echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
-          tar -C ~/Library/Logs/Homebrew/emacs-plus/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS$BUILD_OPTS.tar.gz .
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@28/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS$BUILD_OPTS.tar.gz .
 
       - name: Upload logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
           echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
-          tar -C ~/Library/Logs/Homebrew/emacs-plus/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS.tar.gz .
+          tar -C ~/Library/Logs/Homebrew/emacs-plus@28/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS.tar.gz .
 
       - name: Upload logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -44,3 +44,16 @@ jobs:
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
+
+      - name: Pack up build logs
+        run: |
+          RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
+          echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
+          tar -C ~/Library/Logs/Homebrew/emacs-plus/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS.tar.gz .
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: emacs-plus-${{ env.runner_os }}.tar.gz
+          path: |
+            ~/Library/Logs/Homebrew/emacs-plus-${{ env.runner_os }}.tar.gz

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Build emacs-plus
-        run: brew install d12frosted/homebrew-emacs-plus/emacs-plus
+        run: brew install d12frosted/homebrew-emacs-plus/emacs-plus --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'


### PR DESCRIPTION
Hopefully this makes it a bit easier to verify correctness of builds in CI, or to debug CI failures.

Homebrew logs will appear as workflow artifacts that are downloadable from the workflow run summary:
<img width="1474" alt="image" src="https://user-images.githubusercontent.com/12765385/236709746-fb75f0e5-3caf-47e6-9f6f-6d99a0d1758e.png">

I've also included the runner OS in the artifact filenames in case the os build matrix is ever expanded.

See also https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts