### PR TITLE
fix(build): Add grep as build-time dependency

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -36,6 +36,7 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
@@ -160,6 +161,8 @@ class EmacsPlusAT28 < EmacsBase
     args << "--with-xwidgets" if build.with? "xwidgets"
 
     ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -30,6 +30,7 @@ class EmacsPlusAT29 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
@@ -156,6 +157,8 @@ class EmacsPlusAT29 < EmacsBase
     args << "--with-xwidgets" if build.with? "xwidgets"
 
     ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -30,6 +30,7 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "autoconf" => :build
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
+  depends_on "grep" => :build
   depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
@@ -156,6 +157,8 @@ class EmacsPlusAT30 < EmacsBase
     args << "--with-xwidgets" if build.with? "xwidgets"
 
     ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -78,6 +78,7 @@ class EmacsBase < Formula
       }
       system "which", "tar"
       system "which", "ls"
+      system "which", "grep"
     end
   end
 


### PR DESCRIPTION
I found that on my system, I had a different incompatible version of grep from a plan9 installation on my PATH that was superseding the builtin grep on one of my Macs. This explains why the `with-native-comp` build was failing on one of my Macs but not the other - the Mac with the successful emacs-plus@28 `with-native-comp` build only had the built-in version of grep on its PATH.

Adding GNU grep as a build-time dependency will include it in the `gnubin` directory, which is prepended to the PATH in each formula. I've also added an explicit PATH prepending step for each of the GNU build-time dependencies. This indicates the coupling of those dependencies with the `gnubin` PATH prepending.

Possibly related to d12frosted/homebrew-emacs-plus#555 and d12frosted/homebrew-emacs-plus#556