### PR TITLE
Fix emacs-plus@29 install with --with-native-comp and latest libgccjit

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -130,7 +130,7 @@ class EmacsPlusAT29 < EmacsBase
 
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "#{HOMEBREW_PREFIX}/include" if build.with? "native-comp"
-    ENV.append "LIBRARY_PATH", "#{HOMEBREW_PREFIX}/lib/gcc/current" if build.with? "native-comp"
+    ENV.append "LDFLAGS", "-L" + Formula["libgccjit"].opt_lib + "/gcc/current" if build.with? "native-comp"
 
     args <<
       if build.with? "dbus"


### PR DESCRIPTION
This patch fixes #556 