### PR TITLE
feat: add ahead-of-time native compilation flag

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -25,6 +25,7 @@ class EmacsPlusAT29 < EmacsBase
   option "with-xwidgets", "Experimental: build with xwidgets support"
   option "with-no-frame-refocus", "Disables frame re-focus (ie. closing one frame does not refocus another one)"
   option "with-native-comp", "Build with native compilation"
+  option "with-native-comp-aot", "Build with ahead-of-time native compilation"
   option "with-compress-install", "Build with compressed install optimization"
   option "with-poll", "Experimental: use poll() instead of select() to support > 1024 file descriptors`"
 
@@ -57,7 +58,7 @@ class EmacsPlusAT29 < EmacsBase
     depends_on "fontconfig" => :recommended
   end
 
-  if build.with? "native-comp"
+  if build.with? "native-comp" or build.with? "native-comp-aot"
     depends_on "libgccjit" => :recommended
     depends_on "gcc" => :build
     depends_on "gmp" => :build
@@ -73,6 +74,10 @@ class EmacsPlusAT29 < EmacsBase
     unless (build.with? "cocoa") && (build.without? "x11")
       odie "--with-xwidgets is not available when building --with-x11"
     end
+  end
+  
+  if build.with? "native-comp" and build.with? "native-comp-aot"
+    odie "choose either --with-native-comp or --with-native-comp-aot"
   end
 
   #
@@ -122,16 +127,19 @@ class EmacsPlusAT29 < EmacsBase
     args << "--with-xml2"
     args << "--with-gnutls"
 
-    args << "--with-native-compilation" if build.with? "native-comp"
+    args << "--with-native-compilation=yes" if build.with? "native-comp"
+    args << "--with-native-compilation=aot" if build.with? "native-comp-aot"
     args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
     ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
-    # Necessary for libgccjit library discovery
-    ENV.append "CPATH", "-I#{Formula["libgccjit"].opt_include}" if build.with? "native-comp"
-    ENV.append "LIBRARY_PATH", "-L#{Formula["libgccjit"].opt_lib}" if build.with? "native-comp"
-    ENV.append "LDFLAGS", "-L#{Formula["libgccjit"].opt_lib}" if build.with? "native-comp"
+    if build.with? "native-comp" or build.with? "native-comp-aot"
+      # Necessary for libgccjit library discovery
+      ENV.append "CPATH", "-I#{Formula["libgccjit"].opt_include}"
+      ENV.append "LIBRARY_PATH", "-L#{Formula["libgccjit"].opt_lib}"
+      ENV.append "LDFLAGS", "-L#{Formula["libgccjit"].opt_lib}"
+    end
 
     args <<
       if build.with? "dbus"
@@ -200,7 +208,7 @@ class EmacsPlusAT29 < EmacsBase
 
       # (prefix/"share/emacs/#{version}").install "lisp"
       prefix.install "nextstep/Emacs.app"
-      (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
+      (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp" or build.with? "native-comp-aot"
 
       # inject PATH to Info.plist
       inject_path

--- a/README.org
+++ b/README.org
@@ -152,6 +152,7 @@ By default =emacs-plus@30= uses the following features.
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
+| =--with-native-comp-aot=  | build with ahead-of-time native compilation                                  |
 | =--with-poll=             | build with poll() instead of select() to enable more file descriptors        |
 
 *** No title bar
@@ -181,6 +182,7 @@ By default =emacs-plus@29= uses the following features.
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
+| =--with-native-comp-aot=  | build with ahead-of-time native compilation                                  |
 | =--with-poll=             | build with poll() instead of select() to enable more file descriptors        |
 
 *** No title bar


### PR DESCRIPTION
Users can now choose between --with-native-comp or --with-native-comp-aot which will set the --with-native-comp compile flag to `yes` or `aot` respectively.