### PR TITLE
Adding webp support to emacs 30

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -41,6 +41,7 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "little-cms2"
   depends_on "jansson"
   depends_on "tree-sitter"
+  depends_on "webp" => :optional
   depends_on "imagemagick" => :optional
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
@@ -158,6 +159,7 @@ class EmacsPlusAT30 < EmacsBase
 
     args << "--with-modules"
     args << "--with-rsvg"
+    args << "--with-webp" if build.with? "webp"
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -41,7 +41,7 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "little-cms2"
   depends_on "jansson"
   depends_on "tree-sitter"
-  depends_on "webp" => :optional
+  depends_on "webp"
   depends_on "imagemagick" => :optional
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
@@ -159,7 +159,7 @@ class EmacsPlusAT30 < EmacsBase
 
     args << "--with-modules"
     args << "--with-rsvg"
-    args << "--with-webp" if build.with? "webp"
+    args << "--with-webp"
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 

--- a/README.org
+++ b/README.org
@@ -136,7 +136,7 @@ By default =emacs-plus@30= uses the following features.
 
 - Injected =PATH= value from user shell (see separate section explaining this feature).
 - Cocoa version, e.g. builds =Emacs.app=.
-- Unconditional support for =gnutls=, =librsvg=, =libxml2=, =little-cms2= and dynamic modules.
+- Unconditional support for =gnutls=, =librsvg=, =webp=, =libxml2=, =little-cms2= and dynamic modules.
 
 *** Options
 

--- a/README.org
+++ b/README.org
@@ -153,6 +153,7 @@ By default =emacs-plus@30= uses the following features.
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 | =--with-poll=             | build with poll() instead of select() to enable more file descriptors        |
+| =--with-webp=             | build with webp support                                                      |
 
 *** No title bar
 Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-and-emacs-30][this method]].

--- a/README.org
+++ b/README.org
@@ -153,7 +153,6 @@ By default =emacs-plus@30= uses the following features.
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 | =--with-poll=             | build with poll() instead of select() to enable more file descriptors        |
-| =--with-webp=             | build with webp support                                                      |
 
 *** No title bar
 Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-and-emacs-30][this method]].


### PR DESCRIPTION
Since emacs 30 already supports webp natively on mac os.

Detailed information is below:
https://github.com/emacs-mirror/emacs/commit/17d3b70fbfcbb392b9a3e64f1ca05168cd16d3e8