### PR TITLE
Remove no-frame-refocus-cocoa patch for emacs-plus@30

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -86,7 +86,7 @@ class EmacsPlusAT30 < EmacsBase
   # Patches
   #
 
-  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  opoo "The option --with-no-frame-refocus is not required anymore in emacs-plud@30." if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   local_patch "poll", sha: "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648" if build.with? "poll"

--- a/patches/emacs-30/no-frame-refocus-cocoa.patch
+++ b/patches/emacs-30/no-frame-refocus-cocoa.patch
@@ -1,1 +1,0 @@
-../emacs-28/no-frame-refocus-cocoa.patch


### PR DESCRIPTION
Ref: https://github.com/emacs-mirror/emacs/commit/5427ef23b8b3ef52faf4ab1e8401303220c2d1d1