### PR TITLE
fix: add **kwargs to formulas for 28, 29, and 30

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -99,7 +99,7 @@ class EmacsPlusAT28 < EmacsBase
   #
   # Initialize
   #
-  def initialize(*args, &block)
+  def initialize(*args, **kwargs, &block)
     a = super
     expand_path
     a

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -94,7 +94,7 @@ class EmacsPlusAT29 < EmacsBase
   #
   # Initialize
   #
-  def initialize(*args, &block)
+  def initialize(*args, **kwargs, &block)
     a = super
     expand_path
     a

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -95,7 +95,7 @@ class EmacsPlusAT30 < EmacsBase
   #
   # Initialize
   #
-  def initialize(*args, &block)
+  def initialize(*args, **kwargs, &block)
     a = super
     expand_path
     a


### PR DESCRIPTION
This PR fixes the problem documented in issue #629 

I only saw the relevant line to fix in the formulae for 28, 29, and 30. Please let me know if there's anything else I need to change.

@emmamm05 FYI just in case you were about to start on your own PR.