### PR TITLE
docs: Fix CI status badges and links

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,20 +4,20 @@
 </p>
 <h1 align="center">Emacs Plus</h1>
 <p align="center">
-  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions?query=workflow%3A%22Emacs+30%22">
-    <img src="https://github.com/d12frosted/homebrew-emacs-plus/workflows/Emacs%2030/badge.svg" alt="Emacs 30 CI Status Badge">
+  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-30.yml">
+    <img src="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-30.yml/badge.svg" alt="Emacs 30 CI Status Badge">
   </a>
-  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions?query=workflow%3A%22Emacs+29%22">
-    <img src="https://github.com/d12frosted/homebrew-emacs-plus/workflows/Emacs%2029/badge.svg" alt="Emacs 29 CI Status Badge">
+  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-29.yml">
+    <img src="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-29.yml/badge.svg" alt="Emacs 29 CI Status Badge">
   </a>
-  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions?query=workflow%3A%22Emacs+28%22">
-    <img src="https://github.com/d12frosted/homebrew-emacs-plus/workflows/Emacs%2028/badge.svg" alt="Emacs 28 CI Status Badge">
+  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-28.yml">
+    <img src="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-28.yml/badge.svg" alt="Emacs 28 CI Status Badge">
   </a>
-  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions?query=workflow%3A%22Emacs+27%22">
-    <img src="https://github.com/d12frosted/homebrew-emacs-plus/workflows/Emacs%2027/badge.svg" alt="Emacs 27 CI Status Badge">
+  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-27.yml">
+    <img src="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-27.yml/badge.svg" alt="Emacs 27 CI Status Badge">
   </a>
-  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions?query=workflow%3A%22Emacs+26%22">
-    <img src="https://github.com/d12frosted/homebrew-emacs-plus/workflows/Emacs%2026/badge.svg" alt="Emacs 26 CI Status Badge">
+  <a href="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-26.yml/badge.svg">
+    <img src="https://github.com/d12frosted/homebrew-emacs-plus/actions/workflows/emacs-26.yml/badge.svg" alt="Emacs 26 CI Status Badge">
   </a>
 </p>
 #+end_html


### PR DESCRIPTION
The README status badges were previously incorrectly showing a failed status, when the builds are in fact succeeding. I noticed that the URL format seems to have changed since the time those badges were first added, so I updated them and checked that the rendered previews shows the correct statuses. 👇 

<img width="1114" alt="image" src="https://github.com/d12frosted/homebrew-emacs-plus/assets/12765385/eb17358e-f786-4d19-8d9c-8f76d707630c">
