### PR TITLE
Fix linking how-to in formula caveats

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -113,7 +113,7 @@ class EmacsPlusAT26 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
     EOS
   end
 

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -210,7 +210,7 @@ class EmacsPlusAT27 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
 
       If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
       emacs-plus@28 formula respectively.

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -259,7 +259,7 @@ class EmacsPlusAT28 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -268,7 +268,7 @@ class EmacsPlusAT29 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -270,7 +270,7 @@ class EmacsPlusAT30 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        ln -s #{prefix}/Emacs.app /Applications
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 


### PR DESCRIPTION
Thanks for packaging emacs for those of us on OS X! You're doing a great service for the community. Your work directly enables me to work on github.com/hail-is/hail, so you're only twice removed from actual biomedical research in service of human health 😄 .

I think this supersedes https://github.com/d12frosted/homebrew-emacs-plus/pull/324 and complements https://github.com/d12frosted/homebrew-emacs-plus/pull/517.

It arguably resolves https://github.com/d12frosted/homebrew-emacs-plus/issues/618 .

FWIW, I used this with my Emacs 29.1-1 install and it works fine. I'd have saved a few minutes if this message was available in the caveats rather than needing to search through a few issues.