### PR TITLE
Add microphone permission to plist

### DIFF
--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -86,6 +86,8 @@ class EmacsBase < Formula
 
     system "/usr/libexec/PlistBuddy -c 'Add NSCameraUsageDescription string' '#{plist}'"
     system "/usr/libexec/PlistBuddy -c 'Set NSCameraUsageDescription Emacs requires permission to access the Camera.' '#{plist}'"
+    system "/usr/libexec/PlistBuddy -c 'Add NSMicrophoneUsageDescription string' '#{plist}'"
+    system "/usr/libexec/PlistBuddy -c 'Set NSMicrophoneUsageDescription Emacs requires permission to access the Microphone.' '#{plist}'"
     system "touch '#{app}'"
   end
 end


### PR DESCRIPTION
This PR adds the NSMicrophoneUsageDescription key to the plist to allow Emacs microphone access, similar to the camera access [added in this PR](https://github.com/d12frosted/homebrew-emacs-plus/commit/627d2dffa5520b74a4eb6b0efbcc453f76ba2f53). 

This is often useful, for instance, when trying to use the [whisper.el package](https://github.com/natrys/whisper.el).