### PR TITLE
Update osascript command to set alias name to Emacs.app

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -116,7 +116,7 @@ class EmacsPlusAT26 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications" with properties {name:"Emacs.app"}'
     EOS
   end
 

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -213,7 +213,7 @@ class EmacsPlusAT27 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications" with properties {name:"Emacs.app"}'
 
       If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
       emacs-plus@28 formula respectively.

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -262,7 +262,7 @@ class EmacsPlusAT28 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications" with properties {name:"Emacs.app"}'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -271,7 +271,7 @@ class EmacsPlusAT29 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications" with properties {name:"Emacs.app"}'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -277,7 +277,7 @@ class EmacsPlusAT30 < EmacsBase
         #{prefix}
 
       To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications"'
+        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at POSIX file "/Applications" with properties {name:"Emacs.app"}'
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 


### PR DESCRIPTION
I'm not sure if the original behavior was intentional, but the `osascript` command in the post install message was creating a symlink called `/Applications/Emacs` instead of `/Applications/Emacs.app`, so I had to manually rename it after. I updated the command so it sets the alias name to `Emacs.app`.

(Disclaimer: I don't know AppleScript, I just asked ChatGPT)