### PR TITLE
Update emacs 29 to 29.3

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -2,9 +2,9 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT29 < EmacsBase
   init 29
-  url "https://ftp.gnu.org/gnu/emacs/emacs-29.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-29.2.tar.xz"
-  sha256 "7d3d2448988720bf4bf57ad77a5a08bf22df26160f90507a841ba986be2670dc"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-29.3.tar.xz"
+  sha256 "c34c05d3ace666ed9c7f7a0faf070fea3217ff1910d004499bd5453233d742a0"
   env :std
 
   desc "GNU Emacs text editor"


### PR DESCRIPTION
Updated emacs 29 to 29.3 
[Release message](https://lists.gnu.org/archive/html/emacs-devel/2024-03/msg00611.html)