### PR TITLE
Updates Formula to emacs 29.4 security fix

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -2,9 +2,9 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT29 < EmacsBase
   init 29
-  url "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-29.3.tar.xz"
-  sha256 "c34c05d3ace666ed9c7f7a0faf070fea3217ff1910d004499bd5453233d742a0"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-29.4.tar.xz"
+  sha256 "ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235"
 
   on_macos do
     env :std


### PR DESCRIPTION
@d12frosted 

A security fix was pushed for emacs on June 22nd. This PR brings the Formula in alignment with 29.4.