### PR TITLE
Bump emacs@30 from 30.0.50 to 30.0.60

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -2,7 +2,7 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
   init 30
-  version "30.0.50"
+  version "30.0.60"
 
   on_macos do
     env :std


### PR DESCRIPTION
Emacs 30 has updated its version to `30.0.60` since [New branch emacs-30](https://github.com/emacs-mirror/emacs/commit/dd0fc6aff602447d3e62d52a2a3b45b1a5733f28).