### PR TITLE
Compiler optimization flag: -O2

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -60,7 +60,7 @@ class EmacsPlusAT26 < EmacsBase
     imagemagick_lib_path = Formula["imagemagick@6"].opt_lib/"pkgconfig"
     ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
     ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     args << "--with-modules"
     args << "--with-rsvg"

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -95,7 +95,7 @@ class EmacsPlusAT27 < EmacsBase
     args << "--with-gnutls"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     args <<
       if build.with? "dbus"

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -132,7 +132,7 @@ class EmacsPlusAT28 < EmacsBase
     args << "--with-native-compilation" if build.with? "native-comp"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "-I#{Formula["libgccjit"].opt_include}" if build.with? "native-comp"

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -128,7 +128,7 @@ class EmacsPlusAT29 < EmacsBase
     args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
     ENV.append "CPATH", "-I#{Formula["libgccjit"].opt_include}" if build.with? "native-comp"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -133,7 +133,7 @@ class EmacsPlusAT30 < EmacsBase
     args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
     if build.with? "native-comp"

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -133,7 +133,7 @@ class EmacsPlusAT31 < EmacsBase
     args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
-    ENV.append "CFLAGS", "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
+    ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
 
     # Necessary for libgccjit library discovery
     if build.with? "native-comp"


### PR DESCRIPTION
Added `-O2` to `CFLAGS` for some optimizations on the C side.
I've tested in macOS, and used it for a long time in Linux and BSD, both on `amd64` and `i386` architectures, to improve responsiveness.