### PR TITLE
fix(emacs-30&native-comp): remove unnecessary symbolic links of native-lisp

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -281,9 +281,6 @@ class EmacsPlusAT30 < EmacsBase
     Dir.glob(emacs_info_dir/"*.info") do |info_filename|
       system "install-info", "--info-dir=#{emacs_info_dir}", info_filename
     end
-    if build.with? "native-comp"
-      ln_sf "#{Dir[opt_prefix/"lib/emacs/*"].first}/native-lisp", "#{opt_prefix}/Emacs.app/Contents/native-lisp"
-    end
   end
 
   def caveats

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -281,9 +281,6 @@ class EmacsPlusAT31 < EmacsBase
     Dir.glob(emacs_info_dir/"*.info") do |info_filename|
       system "install-info", "--info-dir=#{emacs_info_dir}", info_filename
     end
-    if build.with? "native-comp"
-      ln_sf "#{Dir[opt_prefix/"lib/emacs/*"].first}/native-lisp", "#{opt_prefix}/Emacs.app/Contents/native-lisp"
-    end
   end
 
   def caveats


### PR DESCRIPTION
This PR most likely resolves a potential issue in #686. According to [CODE](https://github.com/d12frosted/homebrew-emacs-plus/blob/af4df5166b357668f8207fbdff46a802633f1a5d/Formula/emacs-plus%4030.rb#L220), the `native-lisp` files have already been created, but #686 performed an unnecessary operation —— As seen in the screenshot, an unnecessary symbolic link was created.

<img width="629" alt="screenshot" src="https://github.com/d12frosted/homebrew-emacs-plus/assets/87799207/90257708-a305-4d23-8d0e-652c562a0112">
