### PR TITLE
add --with-mps option

### DIFF
--- a/.github/workflows/emacs-31.yml
+++ b/.github/workflows/emacs-31.yml
@@ -30,6 +30,7 @@ jobs:
           - "--with-xwidgets"
           - "--with-native-comp"
           - "--with-x11"
+          - "--with-mps"
 
     env:
       HOMEBREW_EMACS_PLUS_MODE: local

--- a/.github/workflows/emacs-31.yml
+++ b/.github/workflows/emacs-31.yml
@@ -31,7 +31,6 @@ jobs:
           - "--with-xwidgets"
           - "--with-native-comp"
           - "--with-x11"
-          - "--with-mps"
 
     env:
       HOMEBREW_EMACS_PLUS_MODE: local

--- a/.github/workflows/emacs-31.yml
+++ b/.github/workflows/emacs-31.yml
@@ -26,24 +26,35 @@ jobs:
       matrix:
         os: [macos-12]
         build_opts:
+          - "--with-mps"
           - ""
           - "--with-xwidgets"
           - "--with-native-comp"
           - "--with-x11"
-          - "--with-mps"
 
     env:
       HOMEBREW_EMACS_PLUS_MODE: local
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: true
+          test-bot: false
 
+      - name: Enable debug mode
+        run: |
+          echo 'HOMEBREW_DEBUG=1' >> "${GITHUB_ENV}"
+          echo 'HOMEBREW_VERBOSE=1' >> "${GITHUB_ENV}"
+        if: runner.debug
       - name: Install xquartz
         if: contains(matrix.build_opts, '--with-x11')
         run: brew install --cask xquartz
 
       - name: Build emacs-plus@31 ${{ matrix.build_opts }}
-        run: brew install ./Formula/emacs-plus@31.rb ${{ matrix.build_opts }} --verbose
+        run: brew install emacs-plus@31 ${{ matrix.build_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -27,6 +27,7 @@ class EmacsPlusAT31 < EmacsBase
   option "with-native-comp", "Build with native compilation"
   option "with-compress-install", "Build with compressed install optimization"
   option "with-poll", "Experimental: use poll() instead of select() to support > 1024 file descriptors`"
+  option "with-mps", "Build With MPS garbage collector."
 
   #
   # Dependencies
@@ -66,6 +67,12 @@ class EmacsPlusAT31 < EmacsBase
     depends_on "zlib" => :build
   end
 
+  if build.with? "mps"
+    depends_on "libmps" => :recommended
+    # Set the HOMEBREW_EMACS_PLUS_31_BRANCH environment variable
+    ENV["HOMEBREW_EMACS_PLUS_31_BRANCH"] = ENV.fetch("HOMEBREW_EMACS_PLUS_31_BRANCH", "scratch/igc")
+  end
+
   #
   # Incompatible options
   #
@@ -80,10 +87,10 @@ class EmacsPlusAT31 < EmacsBase
   # URL
   #
 
-  if ENV['HOMEBREW_EMACS_PLUS_31_REVISION']
-    url "https://github.com/emacs-mirror/emacs.git", :revision => ENV['HOMEBREW_EMACS_PLUS_31_REVISION']
+  if ENV["HOMEBREW_EMACS_PLUS_31_REVISION"]
+    url "https://github.com/emacs-mirror/emacs.git", :revision => ENV["HOMEBREW_EMACS_PLUS_31_REVISION"]
   else
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "master"
+    url "https://github.com/emacs-mirror/emacs.git", :branch => ENV.fetch("HOMEBREW_EMACS_PLUS_31_BRANCH", nil) or "master"
   end
 
   #
@@ -147,6 +154,14 @@ class EmacsPlusAT31 < EmacsBase
       ENV.append "LDFLAGS", "-L#{gcc_lib}"
       ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
       ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
+    end
+
+    if build.with? "mps"
+      # build with mps
+      args << "--with-mps"
+
+      ENV.append "CFLAGS", "-I#{Formula["libmps"].include}"
+      ENV.append "CFLAGS", "-I#{Formula["libmps"].lib}"
     end
 
     args <<

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -27,7 +27,7 @@ class EmacsPlusAT31 < EmacsBase
   option "with-native-comp", "Build with native compilation"
   option "with-compress-install", "Build with compressed install optimization"
   option "with-poll", "Experimental: use poll() instead of select() to support > 1024 file descriptors`"
-  option "with-mps", "Build With MPS garbage collector."
+  option "with-mps", "Experimental: build With MPS garbage collector."
 
   #
   # Dependencies


### PR DESCRIPTION
build with MPS garbage collector, using scratch/igc branch as default   #706 

```
brew install emacs-plus@31 \
    --with-mps \
    --with-imagemagick  \
    --with-native-comp \
    --with-modern-alecive-flatwoken-icon
```

tip:

set `--with-mps `  will use `scratch/cgi` as default branch.

set `HOMEBREW_EMACS_PLUS_31_BRANCH=scratch/igc` if merged to `other` branch



