### PR TITLE
feat: opt-out from path injection

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -4,10 +4,6 @@ class EmacsPlusAT30 < EmacsBase
   init 30
   version "30.0.60"
 
-  on_macos do
-    env :std
-  end
-
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
 
@@ -17,6 +13,7 @@ class EmacsPlusAT30 < EmacsBase
 
   # Opt-out
   option "without-cocoa", "Build a non-Cocoa version of Emacs"
+  option "without-path-injection", "Build without path injection in isolated environment"
 
   # Opt-in
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
@@ -77,6 +74,14 @@ class EmacsPlusAT30 < EmacsBase
   end
 
   #
+  # Environment
+  #
+
+  on_macos do
+    env :std if build.with? "path-injection"
+  end
+
+  #
   # URL
   #
 
@@ -107,7 +112,9 @@ class EmacsPlusAT30 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    expand_path
+    print_path if verbose?
+    expand_path if build.with? "path-injection"
+    print_path if verbose?
     a
   end
 
@@ -116,7 +123,8 @@ class EmacsPlusAT30 < EmacsBase
   #
 
   def install
-    expand_path
+    expand_path if build.with? "path-injection"
+    print_path if verbose?
 
     args = %W[
       --disable-dependency-tracking
@@ -220,7 +228,7 @@ class EmacsPlusAT30 < EmacsBase
       (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
 
       # inject PATH to Info.plist
-      inject_path
+      inject_path if build.with? "path-injection"
 
       # inject description for protected resources usage
       inject_protected_resources_usage_desc

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -4,10 +4,6 @@ class EmacsPlusAT31 < EmacsBase
   init 31
   version "31.0.50"
 
-  on_macos do
-    env :std
-  end
-
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
 
@@ -17,6 +13,7 @@ class EmacsPlusAT31 < EmacsBase
 
   # Opt-out
   option "without-cocoa", "Build a non-Cocoa version of Emacs"
+  option "without-path-injection", "Build without path injection in isolated environment"
 
   # Opt-in
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
@@ -77,6 +74,14 @@ class EmacsPlusAT31 < EmacsBase
   end
 
   #
+  # Environment
+  #
+
+  on_macos do
+    env :std if build.with? "path-injection"
+  end
+
+  #
   # URL
   #
 
@@ -107,7 +112,9 @@ class EmacsPlusAT31 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    expand_path
+    print_path if verbose?
+    expand_path if build.with? "path-injection"
+    print_path if verbose?
     a
   end
 
@@ -116,7 +123,8 @@ class EmacsPlusAT31 < EmacsBase
   #
 
   def install
-    expand_path
+    expand_path if build.with? "path-injection"
+    print_path if verbose?
 
     args = %W[
       --disable-dependency-tracking
@@ -220,7 +228,7 @@ class EmacsPlusAT31 < EmacsBase
       (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
 
       # inject PATH to Info.plist
-      inject_path
+      inject_path if build.with? "path-injection"
 
       # inject description for protected resources usage
       inject_protected_resources_usage_desc

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -67,16 +67,21 @@ class EmacsBase < Formula
     path.append(ENV['PATH'])
     ENV['PATH'] = path.existing
 
-    # TODO: remove this debug info
     if verbose?
-      puts "PATH value was changed to:"
-      path.each_entry { |x|
-        puts x
-      }
+      print_path
       system "which", "tar"
       system "which", "ls"
       system "which", "grep"
     end
+  end
+
+  def print_path
+    path = PATH.new()
+    path.append(ENV['PATH'])
+    puts "PATH value is"
+    path.each_entry { |x|
+      puts "  - #{x}"
+    }
   end
 
   def inject_protected_resources_usage_desc


### PR DESCRIPTION
While I don't like to add more options, unfortunately using super env (which is an implementation means for path injection) causes problems with native compilation and some other things.