### PR TITLE
feat: roll back to superenv yet keep path injection

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -6,10 +6,6 @@ class EmacsPlusAT28 < EmacsBase
   mirror "https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz"
   sha256 "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488"
 
-  on_macos do
-    env :std
-  end
-
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
 
@@ -103,21 +99,10 @@ class EmacsPlusAT28 < EmacsBase
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
 
   #
-  # Initialize
-  #
-  def initialize(*args, **kwargs, &block)
-    a = super
-    expand_env
-    a
-  end
-
-  #
   # Install
   #
 
   def install
-    expand_env
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -167,9 +152,6 @@ class EmacsPlusAT28 < EmacsBase
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -107,7 +107,7 @@ class EmacsPlusAT28 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    expand_path
+    expand_env
     a
   end
 
@@ -116,7 +116,7 @@ class EmacsPlusAT28 < EmacsBase
   #
 
   def install
-    expand_path
+    expand_env
 
     args = %W[
       --disable-dependency-tracking

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -102,7 +102,7 @@ class EmacsPlusAT29 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    expand_path
+    expand_env
     a
   end
 
@@ -111,7 +111,7 @@ class EmacsPlusAT29 < EmacsBase
   #
 
   def install
-    expand_path
+    expand_env
 
     args = %W[
       --disable-dependency-tracking

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -6,10 +6,6 @@ class EmacsPlusAT29 < EmacsBase
   mirror "https://ftpmirror.gnu.org/emacs/emacs-29.4.tar.xz"
   sha256 "ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235"
 
-  on_macos do
-    env :std
-  end
-
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
 
@@ -98,21 +94,10 @@ class EmacsPlusAT29 < EmacsBase
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
 
   #
-  # Initialize
-  #
-  def initialize(*args, **kwargs, &block)
-    a = super
-    expand_env
-    a
-  end
-
-  #
   # Install
   #
 
   def install
-    expand_env
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -163,9 +148,6 @@ class EmacsPlusAT29 < EmacsBase
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -112,9 +112,9 @@ class EmacsPlusAT30 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    print_path if verbose?
-    expand_path if build.with? "path-injection"
-    print_path if verbose?
+    print_env if verbose?
+    expand_env if build.with? "path-injection"
+    print_env if verbose?
     a
   end
 
@@ -123,8 +123,8 @@ class EmacsPlusAT30 < EmacsBase
   #
 
   def install
-    expand_path if build.with? "path-injection"
-    print_path if verbose?
+    expand_env if build.with? "path-injection"
+    print_env if verbose?
 
     args = %W[
       --disable-dependency-tracking

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -13,7 +13,6 @@ class EmacsPlusAT30 < EmacsBase
 
   # Opt-out
   option "without-cocoa", "Build a non-Cocoa version of Emacs"
-  option "without-path-injection", "Build without path injection in isolated environment"
 
   # Opt-in
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
@@ -74,14 +73,6 @@ class EmacsPlusAT30 < EmacsBase
   end
 
   #
-  # Environment
-  #
-
-  on_macos do
-    env :std if build.with? "path-injection"
-  end
-
-  #
   # URL
   #
 
@@ -108,24 +99,10 @@ class EmacsPlusAT30 < EmacsBase
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
 
   #
-  # Initialize
-  #
-  def initialize(*args, **kwargs, &block)
-    a = super
-    print_env if verbose?
-    expand_env if build.with? "path-injection"
-    print_env if verbose?
-    a
-  end
-
-  #
   # Install
   #
 
   def install
-    expand_env if build.with? "path-injection"
-    print_env if verbose?
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -186,9 +163,6 @@ class EmacsPlusAT30 < EmacsBase
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")
@@ -228,7 +202,7 @@ class EmacsPlusAT30 < EmacsBase
       (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
 
       # inject PATH to Info.plist
-      inject_path if build.with? "path-injection"
+      inject_path
 
       # inject description for protected resources usage
       inject_protected_resources_usage_desc

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -13,7 +13,6 @@ class EmacsPlusAT31 < EmacsBase
 
   # Opt-out
   option "without-cocoa", "Build a non-Cocoa version of Emacs"
-  option "without-path-injection", "Build without path injection in isolated environment"
 
   # Opt-in
   option "with-ctags", "Don't remove the ctags executable that Emacs provides"
@@ -74,14 +73,6 @@ class EmacsPlusAT31 < EmacsBase
   end
 
   #
-  # Environment
-  #
-
-  on_macos do
-    env :std if build.with? "path-injection"
-  end
-
-  #
   # URL
   #
 
@@ -108,24 +99,10 @@ class EmacsPlusAT31 < EmacsBase
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
 
   #
-  # Initialize
-  #
-  def initialize(*args, **kwargs, &block)
-    a = super
-    print_env if verbose?
-    expand_env if build.with? "path-injection"
-    print_env if verbose?
-    a
-  end
-
-  #
   # Install
   #
 
   def install
-    expand_env if build.with? "path-injection"
-    print_env if verbose?
-
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -157,8 +134,6 @@ class EmacsPlusAT31 < EmacsBase
       ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
     end
 
-    print_env if verbose?
-
     args <<
       if build.with? "dbus"
         "--with-dbus"
@@ -188,9 +163,6 @@ class EmacsPlusAT31 < EmacsBase
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
-    ENV.prepend_path "PATH", Formula["grep"].opt_libexec/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")
@@ -230,7 +202,7 @@ class EmacsPlusAT31 < EmacsBase
       (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
 
       # inject PATH to Info.plist
-      inject_path if build.with? "path-injection"
+      inject_path
 
       # inject description for protected resources usage
       inject_protected_resources_usage_desc

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -112,9 +112,9 @@ class EmacsPlusAT31 < EmacsBase
   #
   def initialize(*args, **kwargs, &block)
     a = super
-    print_path if verbose?
-    expand_path if build.with? "path-injection"
-    print_path if verbose?
+    print_env if verbose?
+    expand_env if build.with? "path-injection"
+    print_env if verbose?
     a
   end
 
@@ -123,8 +123,8 @@ class EmacsPlusAT31 < EmacsBase
   #
 
   def install
-    expand_path if build.with? "path-injection"
-    print_path if verbose?
+    expand_env if build.with? "path-injection"
+    print_env if verbose?
 
     args = %W[
       --disable-dependency-tracking
@@ -156,6 +156,8 @@ class EmacsPlusAT31 < EmacsBase
       ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
       ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
     end
+
+    print_env if verbose?
 
     args <<
       if build.with? "dbus"

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -34,27 +34,7 @@ class EmacsBase < Formula
     ohai "Injecting PATH value to Emacs.app/Contents/Info.plist"
     app = "#{prefix}/Emacs.app"
     plist = "#{app}/Contents/Info.plist"
-    path_full = PATH.new(ENV['PATH'])
-
-    if verbose?
-      puts "Full PATH, including entries required for build: #{path_full}"
-    end
-
-    # drop shared shims
-    shared_idx = path_full.find_index { |x|
-      x.end_with? "/Library/Homebrew/shims/shared"
-    }
-    if shared_idx
-      path = PATH.new(path_full.drop(shared_idx + 1))
-    end
-
-    # drop super shims
-    super_idx = path_full.find_index { |x|
-      x.end_with? "/Library/Homebrew/shims/mac/super"
-    }
-    if super_idx
-      path = PATH.new(path_full.drop(super_idx + 1))
-    end
+    path = PATH.new(ORIGINAL_PATHS)
 
     puts "Patching plist at #{plist} with following PATH value:"
     path.each_entry { |x|
@@ -68,32 +48,28 @@ class EmacsBase < Formula
     system "touch '#{app}'"
   end
 
-  def expand_env
-    # Expand PATH to include all dependencies and Superenv.bin as
-    # dependencies can override standard tools.
-    path = PATH.new()
-    on_macos do
-      path.append("#{ENV['HOMEBREW_PREFIX']}/Library/Homebrew/shims/mac/super")
-    end
-    # path.append(deps.map { |dep| dep.to_formula.libexec/"gnubin" })
-    path.append(deps.map { |dep| dep.to_formula.opt_bin })
-    path.append(ENV['PATH'])
-    ENV['PATH'] = path.existing
-
-    if verbose?
-      print_env
-      system "which", "tar"
-      system "which", "ls"
-      system "which", "grep"
-    end
-  end
-
   def print_env
-    path = PATH.new()
-    path.append(ENV['PATH'])
-    puts "PATH value is"
-    path.each_entry { |x|
-      puts "  - #{x}"
+    ohai "Environment"
+    ["CC",
+     "CXX",
+     "OBJC",
+     "OBJCXX",
+     "CFLAGS",
+     "CXXFLAGS",
+     "CPPFLAGS",
+     "LDFLAGS",
+     "SDKROOT",
+     "MAKEFLAGS",
+     "CMAKE_PREFIX_PATH",
+     "CMAKE_FRAMEWORK_PATH",
+     "PKG_CONFIG_PATH",
+     "PKG_CONFIG_LIBDIR",
+     "HOMEBREW_GIT",
+     "ACLOCAL_PATH",
+     "PATH",
+     "CPATH",
+    ].each { |key|
+      puts "#{key}: #{ENV[key]}"
     }
   end
 

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -48,6 +48,14 @@ class EmacsBase < Formula
       path = PATH.new(path_full.drop(shared_idx + 1))
     end
 
+    # drop super shims
+    super_idx = path_full.find_index { |x|
+      x.end_with? "/Library/Homebrew/shims/mac/super"
+    }
+    if super_idx
+      path = PATH.new(path_full.drop(super_idx + 1))
+    end
+
     puts "Patching plist at #{plist} with following PATH value:"
     path.each_entry { |x|
       puts x
@@ -64,7 +72,10 @@ class EmacsBase < Formula
     # Expand PATH to include all dependencies and Superenv.bin as
     # dependencies can override standard tools.
     path = PATH.new()
-    path.append(deps.map { |dep| dep.to_formula.libexec/"gnubin" })
+    on_macos do
+      path.append("#{ENV['HOMEBREW_PREFIX']}/Library/Homebrew/shims/mac/super")
+    end
+    # path.append(deps.map { |dep| dep.to_formula.libexec/"gnubin" })
     path.append(deps.map { |dep| dep.to_formula.opt_bin })
     path.append(ENV['PATH'])
     ENV['PATH'] = path.existing

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -40,11 +40,13 @@ class EmacsBase < Formula
       puts "Full PATH, including entries required for build: #{path_full}"
     end
 
-
+    # drop shared shims
     shared_idx = path_full.find_index { |x|
       x.end_with? "/Library/Homebrew/shims/shared"
     }
-    path = PATH.new(path_full.drop(shared_idx + 1))
+    if shared_idx
+      path = PATH.new(path_full.drop(shared_idx + 1))
+    end
 
     puts "Patching plist at #{plist} with following PATH value:"
     path.each_entry { |x|

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -68,7 +68,7 @@ class EmacsBase < Formula
     system "touch '#{app}'"
   end
 
-  def expand_path
+  def expand_env
     # Expand PATH to include all dependencies and Superenv.bin as
     # dependencies can override standard tools.
     path = PATH.new()
@@ -81,14 +81,14 @@ class EmacsBase < Formula
     ENV['PATH'] = path.existing
 
     if verbose?
-      print_path
+      print_env
       system "which", "tar"
       system "which", "ls"
       system "which", "grep"
     end
   end
 
-  def print_path
+  def print_env
     path = PATH.new()
     path.append(ENV['PATH'])
     puts "PATH value is"


### PR DESCRIPTION
It turns out all these tricks we are doing with path are not needed as there is a way to access original path via
`ORIGINAL_PATHS` variable. This means that we can keep the stable super env while still injecting path.

P.S. this kind of like a dev branch