### PR TITLE
Bump emacs-plus@30 to 30.0.91

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -2,7 +2,7 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
   init 30
-  version "30.0.60"
+  version "30.0.91"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"


### PR DESCRIPTION
Emacs 30.0.91 pretest is available! The [`emacs-30`](https://github.com/emacs-mirror/emacs/commits/emacs-30/) branch has been updated on the `emacs-mirror` repo.

https://lists.gnu.org/archive/html/emacs-devel/2024-09/msg00305.html