### PR TITLE
add m4 as dependency for Emacs 29

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -44,6 +44,7 @@ class EmacsPlusAT29 < EmacsBase
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
   depends_on "xz" => :build
+  depends_on "m4" => :build
   depends_on "gnutls"
   depends_on "librsvg"
   depends_on "little-cms2"


### PR DESCRIPTION
see #728 