### PR TITLE
gcc and libgccjit are required dependencies for native compilation in 30 and 31

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -66,8 +66,8 @@ class EmacsPlusAT30 < EmacsBase
   end
 
   if build.with? "native-comp"
-    depends_on "libgccjit" => :recommended
-    depends_on "gcc" => :build
+    depends_on "libgccjit"
+    depends_on "gcc"
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -56,8 +56,8 @@ class EmacsPlusAT31 < EmacsBase
   end
 
   if build.with? "native-comp"
-    depends_on "libgccjit" => :recommended
-    depends_on "gcc" => :build
+    depends_on "libgccjit"
+    depends_on "gcc"
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build


### PR DESCRIPTION
Native compilation doesn't actually work if gcc is uninstalled. libgccjit should also be required, rather than recommended I believe. 