### PR TITLE
Update no title bar method link for Emacs 29+

### DIFF
--- a/README.org
+++ b/README.org
@@ -146,7 +146,7 @@ By default =emacs-plus@31= uses the following features.
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 
 *** No title bar
-Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30+, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-and-emacs-30][this method]].
+Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30+, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-1][this method]].
 
 ** Emacs 30
 
@@ -174,7 +174,7 @@ By default =emacs-plus@30= uses the following features.
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 
 *** No title bar
-Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-and-emacs-30][this method]].
+Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-1][this method]].
 
 ** Emacs 29
 
@@ -202,7 +202,7 @@ By default =emacs-plus@29= uses the following features.
 | =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 
 *** No title bar
-Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 29, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-and-emacs-30][this method]].
+Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 29, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-1][this method]].
 
 ** Features explained
 


### PR DESCRIPTION
Readme update to fix the no title bar "this method" link in 29, 30 and 31 as I guess the title was updated with emacs 31.