### PR TITLE
Depend on libgccjit and gcc to ensure they're installed at runtime (v28, v29)

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -59,8 +59,10 @@ class EmacsPlusAT28 < EmacsBase
   end
 
   if build.with? "native-comp"
-    depends_on "libgccjit" => :recommended
-    depends_on "gcc" => :build
+    # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
+    depends_on "libgccjit"
+    depends_on "gcc"
+
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -61,8 +61,10 @@ class EmacsPlusAT29 < EmacsBase
   end
 
   if build.with? "native-comp"
-    depends_on "libgccjit" => :recommended
-    depends_on "gcc" => :build
+    # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
+    depends_on "libgccjit"
+    depends_on "gcc"
+
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -66,8 +66,10 @@ class EmacsPlusAT30 < EmacsBase
   end
 
   if build.with? "native-comp"
+    # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
     depends_on "libgccjit"
     depends_on "gcc"
+
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -56,8 +56,10 @@ class EmacsPlusAT31 < EmacsBase
   end
 
   if build.with? "native-comp"
+    # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
     depends_on "libgccjit"
     depends_on "gcc"
+
     depends_on "gmp" => :build
     depends_on "libjpeg" => :build
     depends_on "zlib" => :build


### PR DESCRIPTION
When using the `--with-native-comp` install option, require `libgccjit` and `gcc` as dependencies that are available when running Emacs and the editor compiles `*.elc` files asynchronously (JIT).

Continues #754 for Emacs v28 and v29.

Before the change, the following command produces empty output:

```shell
brew uses --recursive --installed gcc
```

After the change the command produces:

```
d12frosted/emacs-plus/emacs-plus@29
```

Now `brew cleanup -s` doesn't remove the `gcc` formula after installing `emacs-plus@29` (or `@28`). 