### PR TITLE
Fix Linux builds on Homebrew >= 4.4

### DIFF
--- a/.github/workflows/emacs-29.yml
+++ b/.github/workflows/emacs-29.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -63,4 +63,3 @@ jobs:
           name: emacs-plus@29-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@29-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
-

--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         build_opts:
           - ""
           - "--with-xwidgets"
@@ -63,4 +63,3 @@ jobs:
           name: emacs-plus@30-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
           path: |
             ~/Library/Logs/Homebrew/emacs-plus@30-${{ env.runner_os }}${{ env.build_opts }}.tar.gz
-

--- a/.github/workflows/emacs-31.yml
+++ b/.github/workflows/emacs-31.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         build_opts:
           - ""
           - "--with-xwidgets"

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -21,11 +21,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os:
+          - macos-12
+          - ubuntu-latest
         build_opts:
           - ""
           - "--build-from-source"
           - "--with-spacemacs-icon"
+        include:
+          - os: macos-12
+            logs: "~/Library/Logs/Homebrew"
+          - os: ubuntu-latest
+            logs: "~/.cache/Homebrew/Logs"
+            extra_opts: "--without-cocoa"
 
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
@@ -35,8 +43,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        if: matrix.os == 'ubuntu-latest'
+
       - name: Build emacs-plus ${{ matrix.build_opts }}
-        run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }} --verbose
+        run: brew install Aliases/$(readlink Aliases/emacs-plus) ${{ matrix.build_opts }} ${{ matrix.extra_opts }} --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
@@ -48,7 +60,7 @@ jobs:
           echo "build_opts=$BUILD_OPTS" >> "$GITHUB_ENV"
           RUNNER_OS=$(echo "${{ matrix.os }}" | sed 's/ //')
           echo "runner_os=$RUNNER_OS" >> "$GITHUB_ENV"
-          tar -C ~/Library/Logs/Homebrew/emacs-plus@29/ -czvf ~/Library/Logs/Homebrew/emacs-plus-$RUNNER_OS$BUILD_OPTS.tar.gz .
+          tar -C ${{ matrix.logs}}/emacs-plus@29/ -czvf emacs-plus@29-$RUNNER_OS$BUILD_OPTS.tar.gz .
 
       - name: Upload logs
         if: ${{ always() }}

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -22,14 +22,14 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
+          - macos-13
           - ubuntu-latest
         build_opts:
           - ""
           - "--build-from-source"
           - "--with-spacemacs-icon"
         include:
-          - os: macos-12
+          - os: macos-13
             logs: "~/Library/Logs/Homebrew"
           - os: ubuntu-latest
             logs: "~/.cache/Homebrew/Logs"

--- a/.github/workflows/icon-EmacsIcon1.yml
+++ b/.github/workflows/icon-EmacsIcon1.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon2.yml
+++ b/.github/workflows/icon-EmacsIcon2.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon3.yml
+++ b/.github/workflows/icon-EmacsIcon3.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon4.yml
+++ b/.github/workflows/icon-EmacsIcon4.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon5.yml
+++ b/.github/workflows/icon-EmacsIcon5.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon6.yml
+++ b/.github/workflows/icon-EmacsIcon6.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon7.yml
+++ b/.github/workflows/icon-EmacsIcon7.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon8.yml
+++ b/.github/workflows/icon-EmacsIcon8.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-EmacsIcon9.yml
+++ b/.github/workflows/icon-EmacsIcon9.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-c9rgreen-sonoma.yml
+++ b/.github/workflows/icon-c9rgreen-sonoma.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-cacodemon.yml
+++ b/.github/workflows/icon-cacodemon.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-dragon.yml
+++ b/.github/workflows/icon-dragon.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-elrumo1.yml
+++ b/.github/workflows/icon-elrumo1.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-elrumo2.yml
+++ b/.github/workflows/icon-elrumo2.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-emacs-card-blue-deep.yml
+++ b/.github/workflows/icon-emacs-card-blue-deep.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-emacs-card-british-racing-green.yml
+++ b/.github/workflows/icon-emacs-card-british-racing-green.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-emacs-card-carmine.yml
+++ b/.github/workflows/icon-emacs-card-carmine.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-emacs-card-green.yml
+++ b/.github/workflows/icon-emacs-card-green.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-gnu-head.yml
+++ b/.github/workflows/icon-gnu-head.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-memeplex-slim.yml
+++ b/.github/workflows/icon-memeplex-slim.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-memeplex-wide.yml
+++ b/.github/workflows/icon-memeplex-wide.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-alecive-flatwoken.yml
+++ b/.github/workflows/icon-modern-alecive-flatwoken.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-asingh4242.yml
+++ b/.github/workflows/icon-modern-asingh4242.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-azhilin.yml
+++ b/.github/workflows/icon-modern-azhilin.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-bananxan.yml
+++ b/.github/workflows/icon-modern-bananxan.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-black-dragon.yml
+++ b/.github/workflows/icon-modern-black-dragon.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-black-gnu-head.yml
+++ b/.github/workflows/icon-modern-black-gnu-head.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-black-variant.yml
+++ b/.github/workflows/icon-modern-black-variant.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-bokehlicia-captiva.yml
+++ b/.github/workflows/icon-modern-bokehlicia-captiva.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-cg433n.yml
+++ b/.github/workflows/icon-modern-cg433n.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-doom.yml
+++ b/.github/workflows/icon-modern-doom.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-doom3.yml
+++ b/.github/workflows/icon-modern-doom3.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-mzaplotnik.yml
+++ b/.github/workflows/icon-modern-mzaplotnik.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-nuvola.yml
+++ b/.github/workflows/icon-modern-nuvola.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-orange.yml
+++ b/.github/workflows/icon-modern-orange.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-paper.yml
+++ b/.github/workflows/icon-modern-paper.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-papirus.yml
+++ b/.github/workflows/icon-modern-papirus.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-pen-3d.yml
+++ b/.github/workflows/icon-modern-pen-3d.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-pen-black.yml
+++ b/.github/workflows/icon-modern-pen-black.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-pen-lds56.yml
+++ b/.github/workflows/icon-modern-pen-lds56.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-pen.yml
+++ b/.github/workflows/icon-modern-pen.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-purple-flat.yml
+++ b/.github/workflows/icon-modern-purple-flat.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-sexy-v1.yml
+++ b/.github/workflows/icon-modern-sexy-v1.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-sexy-v2.yml
+++ b/.github/workflows/icon-modern-sexy-v2.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-sjrmanning.yml
+++ b/.github/workflows/icon-modern-sjrmanning.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-vscode.yml
+++ b/.github/workflows/icon-modern-vscode.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern-yellow.yml
+++ b/.github/workflows/icon-modern-yellow.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-modern.yml
+++ b/.github/workflows/icon-modern.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-nobu417-big-sur.yml
+++ b/.github/workflows/icon-nobu417-big-sur.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-retro-emacs-logo.yml
+++ b/.github/workflows/icon-retro-emacs-logo.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-retro-gnu-meditate-levitate.yml
+++ b/.github/workflows/icon-retro-gnu-meditate-levitate.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-retro-sink-bw.yml
+++ b/.github/workflows/icon-retro-sink-bw.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-retro-sink.yml
+++ b/.github/workflows/icon-retro-sink.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-savchenkovaleriy-big-sur-3d.yml
+++ b/.github/workflows/icon-savchenkovaleriy-big-sur-3d.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-savchenkovaleriy-big-sur-curvy-3d.yml
+++ b/.github/workflows/icon-savchenkovaleriy-big-sur-curvy-3d.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-savchenkovaleriy-big-sur.yml
+++ b/.github/workflows/icon-savchenkovaleriy-big-sur.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-skamacs.yml
+++ b/.github/workflows/icon-skamacs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/icon-spacemacs.yml
+++ b/.github/workflows/icon-spacemacs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: ${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/online.yml
+++ b/.github/workflows/online.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-13]
 
     steps:
       - name: Tap emacs-plus
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12]
+        os: [macos-13]
 
     steps:
       - name: Build emacs-plus

--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -70,7 +70,7 @@ class EmacsPlusAT26 < EmacsBase
     system "./configure", *args
 
     # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-    if MacOS.version <= :mojave
+    if OS.mac? && MacOS.version <= :mojave
       ohai "Force disabling of aligned_alloc on macOS <= Mojave"
       configure_h_filtered = File.read("src/config.h")
                                  .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -134,7 +134,7 @@ class EmacsPlusAT27 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")
@@ -183,7 +183,7 @@ class EmacsPlusAT27 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -171,7 +171,7 @@ class EmacsPlusAT28 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")
@@ -228,7 +228,7 @@ class EmacsPlusAT28 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -170,7 +170,7 @@ class EmacsPlusAT29 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")
@@ -228,7 +228,7 @@ class EmacsPlusAT29 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -184,7 +184,7 @@ class EmacsPlusAT30 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")
@@ -242,7 +242,7 @@ class EmacsPlusAT30 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -176,7 +176,7 @@ class EmacsPlusAT31 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")
@@ -234,7 +234,7 @@ class EmacsPlusAT31 < EmacsBase
       system "./configure", *args
 
       # Disable aligned_alloc on Mojave. See issue: https://github.com/daviderestivo/homebrew-emacs-head/issues/15
-      if MacOS.version <= :mojave
+      if OS.mac? && MacOS.version <= :mojave
         ohai "Force disabling of aligned_alloc on macOS <= Mojave"
         configure_h_filtered = File.read("src/config.h")
                                    .gsub("#define HAVE_ALIGNED_ALLOC 1", "#undef HAVE_ALIGNED_ALLOC")

--- a/iconset
+++ b/iconset
@@ -91,7 +91,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_GITHUB_REF: \${{ github.head_ref || github.ref }}
       HOMEBREW_GITHUB_REPOSITORY: \${{ github.repository }}


### PR DESCRIPTION
This PR fixes #747 and as far as I can tell is caused by removal of `MacOS` variable [in this PR](https://github.com/Homebrew/brew/pull/18388/files#diff-7e7f927b5a956040b1e5cd4fc54be50d29778145d2cfd57cd1598ed3823e95c0). The PR itself is two commits:
* 8bcf13ee09765c68151ab730f8cca37644ad8d3f is the fix for Linux builds and an update of `emacs.yml` workflow to include barebones linux build 
* b8c09ab17be5ca55b8bfdd35e1a6422350d8d5f5 is an upgrade from macos-12 to macos-13 following GitHub [deprecation of macos-12 runners](https://github.com/actions/runner-images/issues/10721). 
 
I gotta admit I'm not happy I had to include the latter change, but I don't think there's any way to avoid it. Plus Homebrew [no longer supports MacOS 12](https://github.com/Homebrew/brew/pull/18314) so this is mayhaps a good time to upgrade? Let me know if you'd prefer to break these two into separate PRs instead or handle this differently.