### PR TITLE
Fix round-undecorated-frame patch for Emacs 31

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -98,7 +98,7 @@ class EmacsPlusAT31 < EmacsBase
   opoo "The option --with-no-frame-refocus is not required anymore in emacs-plus@31." if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
-  local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
+  local_patch "round-undecorated-frame", sha: "9154621f59f00d58117d199a427c5c081289fd2b691b22d9bdf27efe065f43f0"
 
   #
   # Install

--- a/patches/emacs-31/round-undecorated-frame.patch
+++ b/patches/emacs-31/round-undecorated-frame.patch
@@ -1,1 +1,196 @@
-../emacs-30/round-undecorated-frame.patch
+From 3a5d34b44075ddde1be6e5fe330465cfd7805094 Mon Sep 17 00:00:00 2001
+From: Boris Buliga <boris@d12frosted.io>
+Date: Tue, 26 Nov 2024 23:46:35 +0800
+Subject: [PATCH] provide a way to make undecorated frame with round corners (fixed version for Emacs 31)
+
+---
+ src/frame.c  |  3 +++
+ src/frame.h  |  5 +++++
+ src/nsfns.m  |  6 ++++++
+ src/nsterm.h |  2 ++
+ src/nsterm.m | 54 +++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 5 files changed, 69 insertions(+), 1 deletion(-)
+
+diff --git a/src/frame.c b/src/frame.c
+index 7f4bf274ad9..d98fb10f756 100644
+--- a/src/frame.c
++++ b/src/frame.c
+@@ -972,6 +972,7 @@ make_frame (bool mini_p)
+   f->horizontal_scroll_bars = false;
+   f->want_fullscreen = FULLSCREEN_NONE;
+   f->undecorated = false;
++  f->undecorated_round = false;
+   f->no_special_glyphs = false;
+ #ifndef HAVE_NTGUI
+   f->override_redirect = false;
+@@ -4044,6 +4045,7 @@ static const struct frame_parm_table frame_parms[] =
+   {"tool-bar-position",		SYMBOL_INDEX (Qtool_bar_position)},
+   {"inhibit-double-buffering",  SYMBOL_INDEX (Qinhibit_double_buffering)},
+   {"undecorated",		SYMBOL_INDEX (Qundecorated)},
++  {"undecorated-round",		SYMBOL_INDEX (Qundecorated_round)},
+   {"parent-frame",		SYMBOL_INDEX (Qparent_frame)},
+   {"skip-taskbar",		SYMBOL_INDEX (Qskip_taskbar)},
+   {"no-focus-on-map",		SYMBOL_INDEX (Qno_focus_on_map)},
+@@ -6305,6 +6307,7 @@ syms_of_frame (void)
+   DEFSYM (Qicon, "icon");
+   DEFSYM (Qminibuffer, "minibuffer");
+   DEFSYM (Qundecorated, "undecorated");
++  DEFSYM (Qundecorated_round, "undecorated-round");
+   DEFSYM (Qno_special_glyphs, "no-special-glyphs");
+   DEFSYM (Qparent_frame, "parent-frame");
+   DEFSYM (Qskip_taskbar, "skip-taskbar");
+diff --git a/src/frame.h b/src/frame.h
+index 1d920d1a6bc..bf441c6bb06 100644
+--- a/src/frame.h
++++ b/src/frame.h
+@@ -468,6 +468,9 @@ struct frame
+   /* True if this is an undecorated frame.  */
+   bool_bf undecorated : 1;
+ 
++  /* True if this is an undecorated frame with round corners.  */
++  bool_bf undecorated_round : 1;
++
+ #ifndef HAVE_NTGUI
+   /* True if this is an override_redirect frame.  */
+   bool_bf override_redirect : 1;
+@@ -1245,6 +1248,7 @@ default_pixels_per_inch_y (void)
+ 
+ #if defined (HAVE_WINDOW_SYSTEM)
+ #define FRAME_UNDECORATED(f) ((f)->undecorated)
++#define FRAME_UNDECORATED_ROUND(f) ((f)->undecorated_round)
+ #ifdef HAVE_NTGUI
+ #define FRAME_OVERRIDE_REDIRECT(f) ((void) (f), 0)
+ #else
+@@ -1271,6 +1275,7 @@ default_pixels_per_inch_y (void)
+ #endif
+ #else /* not HAVE_WINDOW_SYSTEM */
+ #define FRAME_UNDECORATED(f) ((void) (f), 0)
++#define FRAME_UNDECORATED_ROUND(f) ((void) (f), 0)
+ #define FRAME_OVERRIDE_REDIRECT(f) ((void) (f), 0)
+ #define FRAME_PARENT_FRAME(f) ((void) (f), NULL)
+ #define FRAME_SKIP_TASKBAR(f) ((void) (f), 0)
+diff --git a/src/nsfns.m b/src/nsfns.m
+index 3c012ca8f05..1fdefaacd77 100644
+--- a/src/nsfns.m
++++ b/src/nsfns.m
+@@ -1102,6 +1102,7 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+   ns_set_tool_bar_position,
+   ns_set_inhibit_double_buffering,
+   ns_set_undecorated,
++  ns_set_undecorated_round,
+   ns_set_parent_frame,
+   0, /* x_set_skip_taskbar */
+   ns_set_no_focus_on_map,
+@@ -1405,6 +1406,11 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+   FRAME_UNDECORATED (f) = !NILP (tem) && !EQ (tem, Qunbound);
+   store_frame_param (f, Qundecorated, FRAME_UNDECORATED (f) ? Qt : Qnil);
+ 
++  tem = gui_display_get_arg (dpyinfo, parms, Qundecorated_round, NULL, NULL,
++                             RES_TYPE_BOOLEAN);
++  FRAME_UNDECORATED_ROUND (f) = !NILP (tem) && !EQ (tem, Qunbound);
++  store_frame_param (f, Qundecorated_round, FRAME_UNDECORATED_ROUND (f) ? Qt : Qnil);
++
+ #ifdef NS_IMPL_COCOA
+   tem = gui_display_get_arg (dpyinfo, parms, Qns_appearance, NULL, NULL,
+                              RES_TYPE_SYMBOL);
+diff --git a/src/nsterm.h b/src/nsterm.h
+index 6c67653705e..f308b3443d9 100644
+--- a/src/nsterm.h
++++ b/src/nsterm.h
+@@ -1226,6 +1226,8 @@ extern void ns_make_frame_invisible (struct frame *f);
+ extern void ns_iconify_frame (struct frame *f);
+ extern void ns_set_undecorated (struct frame *f, Lisp_Object new_value,
+                                 Lisp_Object old_value);
++extern void ns_set_undecorated_round (struct frame *f, Lisp_Object new_value,
++                                      Lisp_Object old_value);
+ extern void ns_set_parent_frame (struct frame *f, Lisp_Object new_value,
+                                  Lisp_Object old_value);
+ extern void ns_set_no_focus_on_map (struct frame *f, Lisp_Object new_value,
+diff --git a/src/nsterm.m b/src/nsterm.m
+index 205b1621399..1e1abef2280 100644
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -1810,6 +1810,44 @@ Hide the window (X11 semantics)
+     }
+ }
+ 
++void
++ns_set_undecorated_round (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
++/* --------------------------------------------------------------------------
++     Set frame F's `undecorated_round' parameter.  If non-nil, F's window-system
++     window is drawn without decorations, title, minimize/maximize boxes
++     and external borders.  This usually means that the window cannot be
++     dragged, resized, iconified, maximized or deleted with the mouse.  If
++     nil, draw the frame with all the elements listed above unless these
++     have been suspended via window manager settings.
++   -------------------------------------------------------------------------- */
++{
++  NSTRACE ("ns_set_undecorated_round");
++
++  if (!EQ (new_value, old_value))
++    {
++      EmacsView *view = (EmacsView *)FRAME_NS_VIEW (f);
++      NSWindow *oldWindow = [view window];
++      NSWindow *newWindow;
++
++      block_input ();
++
++      FRAME_UNDECORATED_ROUND (f) = !NILP (new_value);
++
++      newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
++
++      if ([oldWindow isKeyWindow])
++        [newWindow makeKeyAndOrderFront:NSApp];
++
++      [newWindow setIsVisible:[oldWindow isVisible]];
++      if ([oldWindow isMiniaturized])
++        [newWindow miniaturize:NSApp];
++
++      [oldWindow close];
++
++      unblock_input ();
++    }
++}
++
+ void
+ ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
+ /* --------------------------------------------------------------------------
+@@ -9272,6 +9310,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+ 		 | NSWindowStyleMaskMiniaturizable
+ 		 | NSWindowStyleMaskClosable);
+ 
++  if (FRAME_UNDECORATED_ROUND (f))
++    {
++      styleMask |= NSFullSizeContentViewWindowMask;
++    }
++
+   last_drag_event = nil;
+ 
+   width = FRAME_TEXT_COLS_TO_PIXEL_WIDTH (f, f->text_cols);
+@@ -9355,13 +9398,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+ #endif
+     }
+ 
++  if (FRAME_UNDECORATED_ROUND (f))
++    {
++      [self setTitlebarAppearsTransparent:YES];
++      [self setTitleVisibility:NSWindowTitleHidden];
++      [[self standardWindowButton:NSWindowCloseButton] setHidden:YES];
++      [[self standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
++      [[self standardWindowButton:NSWindowZoomButton] setHidden:YES];
++    }
++
+   return self;
+ }
+ 
+ 
+ - (void)createToolbar: (struct frame *)f
+ {
+-  if (FRAME_UNDECORATED (f)
++  if (FRAME_UNDECORATED (f) || FRAME_UNDECORATED_ROUND (f)
+       || [self styleMask] == NSWindowStyleMaskBorderless
+       || !FRAME_EXTERNAL_TOOL_BAR (f)
+       || [self toolbar] != nil)
+-- 
+2.47.0
+


### PR DESCRIPTION
The round-undecorated-frame patch fails to apply for recent Emacs 31. This MR fixes the issue by regenerating the patch after a manual fix.

NOTE: this MR changes the "FROM" field of the patch. I don't know how to specify that; perhaps we should keep the original author field "Boris Buliga <boris@d12frosted.io>" unchanged.