### PR TITLE
Expose macOS native sharing dialog via ns-share

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -107,6 +107,7 @@ class EmacsPlusAT30 < EmacsBase
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
+  local_patch "native-sharing", sha: "75f3e7ca136c3901582d8ee3fb5a9833ba010280e13097048c9dd3405f18a178"
 
   #
   # Install

--- a/patches/emacs-30/native-sharing.patch
+++ b/patches/emacs-30/native-sharing.patch
@@ -1,0 +1,173 @@
+diff --git a/lisp/term/ns-win.el b/lisp/term/ns-win.el
+index 2a29457..84cadff 100644
+--- a/lisp/term/ns-win.el
++++ b/lisp/term/ns-win.el
+@@ -567,6 +567,88 @@ string dropped into the current buffer."
+   (interactive)
+   (ns-show-character-palette))
+ 
++(declare-function ns--share-items "nsfns.m" (items))
++
++(defun ns-share (&optional items)
++  "Share ITEMS (list of files or string) via macOS service.
++
++When ITEMS are missing, derive as follows.
++
++From `dired', ITEMS are based on either of these being active:
++
++  - Marked files (list).
++  - Files in region (list).
++  - File at point (list).
++
++Anywhere else, these being active:
++
++  - Region (string).
++  - Current buffer file (list)."
++  (interactive)
++  (unless items
++    (setq items (ns--shareable-items)))
++  (unless items
++    (user-error "Nothing to share"))
++  (ns--share-items items))
++
++(defun ns--shareable-items ()
++  "Figure out what user wants to share based on context.
++
++From `dired', shared items are based on either of these being active:
++
++  - Marked files
++  - Files in region.
++  - File at point.
++
++Anywhere else, these being active:
++
++  - Region (sent as text).
++  - Current buffer file (if one is available)."
++  (cond ((derived-mode-p 'dired-mode)
++         (or
++          (ns--dired-filenames-in-region)
++          (dired-get-marked-files)))
++        ((use-region-p)
++         (list (buffer-substring-no-properties
++                (region-beginning)
++                (region-end))))
++        ((buffer-file-name)
++         (list (buffer-file-name)))))
++
++(defun ns--dired-filenames-in-region ()
++  "If `dired' buffer, return region files.  nil otherwise."
++  (when (and (equal major-mode 'dired-mode)
++             (use-region-p))
++    (let ((start (region-beginning))
++          (end (region-end))
++          (marked-files (let ((files (dired-get-marked-files)))
++                          (cond ((null (cdr files))
++                                 nil)
++                                ((and (= (length files) 2)
++                                      (eq (car files) t))
++                                 t)
++                                (t
++                                 (not (seq-empty-p files))))))
++          (filenames))
++      (when marked-files
++        (user-error "Mark dired files or select region.  Not both."))
++      (save-excursion
++        (save-restriction
++          (goto-char start)
++          (while (< (point) end)
++            ;; Skip non-file lines.
++            (while (and (< (point) end) (dired-between-files))
++              (forward-line 1))
++            (when (and (dired-get-filename nil t)
++                       ;; Ensure filename is fully selected.
++                       (< (save-excursion
++                            (forward-line 0)
++                            (dired-move-to-filename))
++                          end))
++              (setq filenames (append filenames (list (dired-get-filename nil t)))))
++            (forward-line 1))))
++      filenames)))
++
+ (defun ns-next-frame ()
+   "Switch to next visible frame."
+   (interactive)
+diff --git a/src/nsfns.m b/src/nsfns.m
+index 3c012ca..a0d952b 100644
+--- a/src/nsfns.m
++++ b/src/nsfns.m
+@@ -3772,6 +3772,67 @@ The position is returned as a cons cell (X . Y) of the
+   return Qnil;
+ }
+ 
++static NSPoint
++ns_get_point_relative_coordinates (NSView* view)
++{
++  Lisp_Object coordinate = Fnth (make_fixnum (2), Fposn_at_point (Fpoint (), Qnil));
++
++  int x = ^{
++    Lisp_Object value = Fcar (coordinate);
++    if (NILP (value))
++      {
++        signal_error ("No x coordinate found", coordinate);
++      }
++    return XFIXNUM (value);
++  }();
++
++  int y = ^{
++    Lisp_Object value = Fcdr (coordinate);
++    if (NILP (value))
++    {
++      signal_error ("No y coordinate found", coordinate);
++    }
++    return XFIXNUM (value);
++  }();
++
++  return [view convertPoint:NSMakePoint (x, y) toView:nil];
++}
++
++DEFUN ("ns--share-items",
++       Fns__share_items,
++       Sns__share_items, 1, 1, 0,
++       doc: /* Share a list of items via macOS sharing service. */)
++       (Lisp_Object items)
++{
++  CHECK_LIST (items);
++
++  NSMutableArray *shared = [NSMutableArray array];
++  for (Lisp_Object tail = items; CONSP (tail); tail = XCDR (tail))
++  {
++    Lisp_Object elt = XCAR (tail);
++    if (!(STRINGP (elt)))
++    {
++      signal_error ("Element not a string", elt);
++    }
++    BOOL isDir;
++    if ([[NSFileManager defaultManager] fileExistsAtPath:@(SSDATA(elt)) isDirectory:&isDir]) {
++      [shared addObject:[NSURL fileURLWithPath:@(SSDATA(elt))]];
++      continue;
++    }
++    [shared addObject:@(SSDATA(elt))];
++  }
++
++  struct frame *frame = SELECTED_FRAME ();
++  EmacsView *view = FRAME_NS_VIEW (frame);
++  NSPoint point = ns_get_point_relative_coordinates (view);
++  NSRect displayArea = NSMakeRect (point.x + 15, view.bounds.size.height - point.y + 25, 1, 1);
++  NSSharingServicePicker *picker = [[NSSharingServicePicker alloc] initWithItems:shared];
++
++  [picker showRelativeToRect:displayArea ofView:view preferredEdge:NSRectEdgeMaxY];
++
++  return Qnil;
++}
++
+ /* ==========================================================================
+ 
+     Class implementations
+@@ -4004,6 +4065,7 @@ - (Lisp_Object)lispString
+   defsubr (&Sns_set_mouse_absolute_pixel_position);
+   defsubr (&Sns_mouse_absolute_pixel_position);
+   defsubr (&Sns_show_character_palette);
++  defsubr (&Sns__share_items);
+   defsubr (&Sx_display_mm_width);
+   defsubr (&Sx_display_mm_height);
+   defsubr (&Sx_display_screens);


### PR DESCRIPTION
The PR exposes the macOS native sharing dialog via `ns-share`.

Change unlikely to be accepted upstream [until there's a linux equivalent](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76120), thus proposing to emacs-plus, my favorite build ;)

`ns-share` "does what I mean" ([DWIM](https://en.wikipedia.org/wiki/DWIM)) by operating on either:

- Region text (any buffer other than dired).
- Current buffer file (any buffer other than dired an no region selected).
- Dired marked files
- Dired region files

A couple of sample screenshots:

![share-region-text](https://github.com/user-attachments/assets/0effecd0-3bc1-4cc7-b075-348f0605ccb0)
![share-dired-files](https://github.com/user-attachments/assets/b555ee2c-d570-4115-b166-ec8d590c0377)

