### PR TITLE
RC1 Emacs 30.1

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -2,9 +2,9 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
   init 30
-  url "https://alpha.gnu.org/gnu/emacs/pretest/emacs-30.0.93.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.0.93.tar.xz"
-  sha256 "4e50387505e1e05e83a39672e756ae1b76a24a8c981e7f981aec6e966cd6ff7f"
+  url "https://alpha.gnu.org/gnu/emacs/pretest/emacs-30.1-rc1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1-rc1.tar.xz"
+  sha256 "6bf42484eb70a71d9bd9332f44ef32873062160f41d5561b6a6b21f5f9da1e91"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"


### PR DESCRIPTION
Emacs 30.1 RC1 was [released](https://lists.gnu.org/archive/html/emacs-devel/2025-02/msg00802.html) on February 19th, 2025.