### PR TITLE
Emacs 30.1

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -2,9 +2,9 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
   init 30
-  url "https://alpha.gnu.org/gnu/emacs/pretest/emacs-30.1-rc1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1-rc1.tar.xz"
-  sha256 "6bf42484eb70a71d9bd9332f44ef32873062160f41d5561b6a6b21f5f9da1e91"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1.tar.xz"
+  sha256 "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"


### PR DESCRIPTION
Well that didn't take long — [Emacs 30.1 released](https://lists.gnu.org/archive/html/emacs-devel/2025-02/msg00997.html). :)

Notably,

> Emacs 30.1 includes security fixes for a shell injection vulnerability
> in man.el (CVE-2025-1244), and for arbitrary code execution with
> flymake (CVE-2024-53920).  We recommend upgrading immediately.