### PR TITLE
Turn native comp on by default in emacs 30+

### DIFF
--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -28,7 +28,6 @@ jobs:
         build_opts:
           - ""
           - "--with-xwidgets"
-          - "--with-native-comp"
           - "--with-x11"
 
     env:

--- a/.github/workflows/emacs-31.yml
+++ b/.github/workflows/emacs-31.yml
@@ -28,7 +28,6 @@ jobs:
         build_opts:
           - ""
           - "--with-xwidgets"
-          - "--with-native-comp"
           - "--with-x11"
 
     env:

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -20,7 +20,6 @@ class EmacsPlusAT31 < EmacsBase
   option "with-debug", "Build with debug symbols and debugger friendly optimizations"
   option "with-xwidgets", "Experimental: build with xwidgets support"
   option "with-no-frame-refocus", "Disables frame re-focus (ie. closing one frame does not refocus another one)"
-  option "with-native-comp", "Build with native compilation"
   option "with-compress-install", "Build with compressed install optimization"
 
   #
@@ -48,21 +47,18 @@ class EmacsPlusAT31 < EmacsBase
   depends_on "imagemagick" => :optional
   depends_on "dbus" => :optional
   depends_on "mailutils" => :optional
+  # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
+  depends_on "libgccjit"
+  depends_on "gcc"
+
+  depends_on "gmp" => :build
+  depends_on "libjpeg" => :build
+  depends_on "zlib" => :build
 
   if build.with? "x11"
     depends_on "libxaw"
     depends_on "freetype" => :recommended
     depends_on "fontconfig" => :recommended
-  end
-
-  if build.with? "native-comp"
-    # `libgccjit` and `gcc` are required when Emacs compiles `*.elc` files asynchronously (JIT)
-    depends_on "libgccjit"
-    depends_on "gcc"
-
-    depends_on "gmp" => :build
-    depends_on "libjpeg" => :build
-    depends_on "zlib" => :build
   end
 
   #
@@ -111,12 +107,12 @@ class EmacsPlusAT31 < EmacsBase
       --enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp
       --infodir=#{info}/emacs
       --prefix=#{prefix}
+      --with-native-compilation=aot
     ]
 
     args << "--with-xml2"
     args << "--with-gnutls"
 
-    args << "--with-native-compilation=aot" if build.with? "native-comp"
     args << "--without-compress-install" if build.without? "compress-install"
 
     ENV.append "CFLAGS", "-g -Og" if build.with? "debug"
@@ -126,18 +122,16 @@ class EmacsPlusAT31 < EmacsBase
     ENV.append "LDFLAGS", "-L#{Formula["sqlite"].opt_lib}"
 
     # Necessary for libgccjit library discovery
-    if build.with? "native-comp"
-      gcc_ver = Formula["gcc"].any_installed_version
-      gcc_ver_major = gcc_ver.major
-      gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
+    gcc_ver = Formula["gcc"].any_installed_version
+    gcc_ver_major = gcc_ver.major
+    gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
 
-      ENV.append "CFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "CFLAGS", "-I#{Formula["libgccjit"].include}"
+    ENV.append "CFLAGS", "-I#{Formula["gcc"].include}"
+    ENV.append "CFLAGS", "-I#{Formula["libgccjit"].include}"
 
-      ENV.append "LDFLAGS", "-L#{gcc_lib}"
-      ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
-      ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
-    end
+    ENV.append "LDFLAGS", "-L#{gcc_lib}"
+    ENV.append "LDFLAGS", "-I#{Formula["gcc"].include}"
+    ENV.append "LDFLAGS", "-I#{Formula["libgccjit"].include}"
 
     args <<
       if build.with? "dbus"
@@ -204,7 +198,7 @@ class EmacsPlusAT31 < EmacsBase
 
       # (prefix/"share/emacs/#{version}").install "lisp"
       prefix.install "nextstep/Emacs.app"
-      (prefix/"Emacs.app/Contents").install "native-lisp" if build.with? "native-comp"
+      (prefix/"Emacs.app/Contents").install "native-lisp"
 
       # inject PATH to Info.plist
       inject_path

--- a/README.org
+++ b/README.org
@@ -143,7 +143,6 @@ By default =emacs-plus@31= uses the following features.
 | =--with-xwidgets=         | build [[#xwidgets-webkit][→ with xwidgets]] support                                                |
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
-| =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 
 *** No title bar
 Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30+, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-1][this method]].
@@ -171,7 +170,6 @@ By default =emacs-plus@30= uses the following features.
 | =--with-xwidgets=         | build [[#xwidgets-webkit][→ with xwidgets]] support                                                |
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
 | =--with-imagemagick=      | build with =imagemagick= support                                               |
-| =--with-native-comp=      | build with native compilation aka [[#gccemacs][→ gccemacs]]                                 |
 
 *** No title bar
 Please note, that ~--with-no-titlebar~ is no longer needed in Emacs 30, since the same can be achieved natively using [[https://github.com/d12frosted/homebrew-emacs-plus#emacs-29-1][this method]].

--- a/README.org
+++ b/README.org
@@ -138,7 +138,6 @@ By default =emacs-plus@31= uses the following features.
 | =--with-dbus=             | build with dbus support                                                      |
 | =--with-debug=            | build with debug symbols and debugger friendly optimizations                 |
 | =--with-mailutils=        | build with mailutils support                                                 |
-| =--with-no-frame-refocus= | disables frame re-focus (ie. closing one frame does not refocus another one) |
 | =--with-x11=              | build with x11 support                                                       |
 | =--with-xwidgets=         | build [[#xwidgets-webkit][→ with xwidgets]] support                                                |
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |
@@ -165,7 +164,6 @@ By default =emacs-plus@30= uses the following features.
 | =--with-dbus=             | build with dbus support                                                      |
 | =--with-debug=            | build with debug symbols and debugger friendly optimizations                 |
 | =--with-mailutils=        | build with mailutils support                                                 |
-| =--with-no-frame-refocus= | disables frame re-focus (ie. closing one frame does not refocus another one) |
 | =--with-x11=              | build with x11 support                                                       |
 | =--with-xwidgets=         | build [[#xwidgets-webkit][→ with xwidgets]] support                                                |
 | =--without-cocoa=         | build a non-Cocoa version of Emacs (terminal only)                           |


### PR DESCRIPTION
Emacs changes the default for this flag to 'yes'.  We've been changing that to 'aot' for previous versions.  This carries that opinion forward and removes the opt-in flag.

I have tested this locally.