### PR TITLE
Remove libjansson for 30.1+

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -51,7 +51,6 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "gnutls"
   depends_on "librsvg"
   depends_on "little-cms2"
-  depends_on "jansson"
   depends_on "tree-sitter"
   depends_on "webp"
   depends_on "imagemagick" => :optional

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -41,7 +41,6 @@ class EmacsPlusAT31 < EmacsBase
   depends_on "gnutls"
   depends_on "librsvg"
   depends_on "little-cms2"
-  depends_on "jansson"
   depends_on "tree-sitter"
   depends_on "webp"
   depends_on "imagemagick" => :optional


### PR DESCRIPTION
Emacs 30.1 and later no longer use libjansson; the built-in json parser is better and default.

Resolves #793 