### PR TITLE
Update post-install instructions to mv

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -115,8 +115,8 @@ class EmacsPlusAT26 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
     EOS
   end
 

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -212,8 +212,8 @@ class EmacsPlusAT27 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
 
       If you wish to install Emacs 26 or Emacs 28, use emacs-plus@26 or
       emacs-plus@28 formula respectively.

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -257,8 +257,8 @@ class EmacsPlusAT28 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -271,8 +271,8 @@ class EmacsPlusAT29 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -275,8 +275,8 @@ class EmacsPlusAT30 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -267,8 +267,8 @@ class EmacsPlusAT31 < EmacsBase
       Emacs.app was installed to:
         #{prefix}
 
-      To link the application to default Homebrew App location:
-        osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'
+      To get Emacs to show up in Spotlight, move the app to the /Applications folder:
+        mv "#{prefix}/Emacs" /Applications/Emacs.app
 
       Your PATH value was injected into Emacs.app/Contents/Info.plist
 


### PR DESCRIPTION
Is there a reason to alias the app instead of moving it? I tried this and emacs seems to still work fine and shows up in Spotlight this time.

Fixes #801