### PR TITLE
Emacs 31 build fixes

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -15,7 +15,6 @@ class EmacsPlusAT31 < EmacsBase
   option "without-cocoa", "Build a non-Cocoa version of Emacs"
 
   # Opt-in
-  option "with-ctags", "Don't remove the ctags executable that Emacs provides"
   option "with-x11", "Experimental: build with x11 support"
   option "with-debug", "Build with debug symbols and debugger friendly optimizations"
   option "with-xwidgets", "Experimental: build with xwidgets support"
@@ -241,17 +240,6 @@ class EmacsPlusAT31 < EmacsBase
 
       system "gmake"
       system "gmake", "install"
-    end
-
-    # Follow MacPorts and don't install ctags from Emacs. This allows Vim
-    # and Emacs and ctags to play together without violence.
-    if build.without? "ctags"
-      (bin/"ctags").unlink
-      if build.with? "compress-install"
-        (man1/"ctags.1.gz").unlink
-      else
-        (man1/"ctags.1").unlink
-      end
     end
   end
 

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -91,8 +91,8 @@ class EmacsPlusAT31 < EmacsBase
 
   opoo "The option --with-no-frame-refocus is not required anymore in emacs-plus@31." if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
-  local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
-  local_patch "round-undecorated-frame", sha: "14e17d64358eaf2f1d31e49c4743119cdd0698ea0cc19c7a5c0c67d137efd94f"
+  local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
+  local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
 
   #
   # Install

--- a/README.org
+++ b/README.org
@@ -135,7 +135,6 @@ By default =emacs-plus@31= uses the following features.
 
 | Option                  | Description                                                                  |
 |-------------------------+------------------------------------------------------------------------------|
-| =--with-ctags=            | don't remove the ctags executable that Emacs provides                        |
 | =--with-dbus=             | build with dbus support                                                      |
 | =--with-debug=            | build with debug symbols and debugger friendly optimizations                 |
 | =--with-mailutils=        | build with mailutils support                                                 |

--- a/patches/emacs-31/round-undecorated-frame.patch
+++ b/patches/emacs-31/round-undecorated-frame.patch
@@ -12,10 +12,10 @@ Subject: [PATCH] provide a way to make undecorated frame with round corners (fix
  5 files changed, 68 insertions(+), 1 deletion(-)
 
 diff --git a/src/frame.c b/src/frame.c
-index 36b314c075e..32e00e36546 100644
+index 550fd336ff9..fd670cfa288 100644
 --- a/src/frame.c
 +++ b/src/frame.c
-@@ -1008,6 +1008,7 @@ make_frame (bool mini_p)
+@@ -1072,6 +1072,7 @@ make_frame (bool mini_p)
    f->horizontal_scroll_bars = false;
    f->want_fullscreen = FULLSCREEN_NONE;
    f->undecorated = false;
@@ -23,7 +23,7 @@ index 36b314c075e..32e00e36546 100644
  #ifndef HAVE_NTGUI
    f->override_redirect = false;
  #endif
-@@ -4304,6 +4305,7 @@ DEFUN ("frame-scale-factor", Fframe_scale_factor, Sframe_scale_factor,
+@@ -4497,6 +4498,7 @@ static const struct frame_parm_table frame_parms[] =
    {"tool-bar-position",		SYMBOL_INDEX (Qtool_bar_position)},
    {"inhibit-double-buffering",  SYMBOL_INDEX (Qinhibit_double_buffering)},
    {"undecorated",		SYMBOL_INDEX (Qundecorated)},
@@ -31,7 +31,7 @@ index 36b314c075e..32e00e36546 100644
    {"parent-frame",		SYMBOL_INDEX (Qparent_frame)},
    {"skip-taskbar",		SYMBOL_INDEX (Qskip_taskbar)},
    {"no-focus-on-map",		SYMBOL_INDEX (Qno_focus_on_map)},
-@@ -6579,6 +6581,7 @@ syms_of_frame (void)
+@@ -6801,6 +6803,7 @@ syms_of_frame (void)
    DEFSYM (Qicon, "icon");
    DEFSYM (Qminibuffer, "minibuffer");
    DEFSYM (Qundecorated, "undecorated");
@@ -40,10 +40,10 @@ index 36b314c075e..32e00e36546 100644
    DEFSYM (Qparent_frame, "parent-frame");
    DEFSYM (Qskip_taskbar, "skip-taskbar");
 diff --git a/src/frame.h b/src/frame.h
-index 9ed2f66be22..7d776f01d28 100644
+index 62b2edcb315..3203528ebfc 100644
 --- a/src/frame.h
 +++ b/src/frame.h
-@@ -445,6 +445,9 @@ #define EMACS_FRAME_H
+@@ -445,6 +445,9 @@ struct frame
    /* True if this is an undecorated frame.  */
    bool_bf undecorated : 1;
  
@@ -53,7 +53,7 @@ index 9ed2f66be22..7d776f01d28 100644
    /* Nonzero if this frame's window does not want to receive input focus
       via mouse clicks or by moving the mouse into it.  */
    bool_bf no_accept_focus : 1;
-@@ -1237,6 +1240,7 @@ FRAME_PARENT_FRAME (struct frame *f)
+@@ -1223,6 +1226,7 @@ FRAME_PARENT_FRAME (struct frame *f)
  }
  
  #define FRAME_UNDECORATED(f) ((f)->undecorated)
@@ -62,10 +62,10 @@ index 9ed2f66be22..7d776f01d28 100644
  #if defined (HAVE_WINDOW_SYSTEM)
  #ifdef HAVE_NTGUI
 diff --git a/src/nsfns.m b/src/nsfns.m
-index 1055a4b37df..03b23e8a2fe 100644
+index b1ed0eff58a..11a4a215c8d 100644
 --- a/src/nsfns.m
 +++ b/src/nsfns.m
-@@ -1102,6 +1102,7 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+@@ -1098,6 +1098,7 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
    ns_set_tool_bar_position,
    ns_set_inhibit_double_buffering,
    ns_set_undecorated,
@@ -73,7 +73,7 @@ index 1055a4b37df..03b23e8a2fe 100644
    ns_set_parent_frame,
    0, /* x_set_skip_taskbar */
    ns_set_no_focus_on_map,
-@@ -1405,6 +1406,11 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+@@ -1401,6 +1402,11 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
    FRAME_UNDECORATED (f) = !NILP (tem) && !EQ (tem, Qunbound);
    store_frame_param (f, Qundecorated, FRAME_UNDECORATED (f) ? Qt : Qnil);
  
@@ -86,10 +86,10 @@ index 1055a4b37df..03b23e8a2fe 100644
    tem = gui_display_get_arg (dpyinfo, parms, Qns_appearance, NULL, NULL,
                               RES_TYPE_SYMBOL);
 diff --git a/src/nsterm.h b/src/nsterm.h
-index 6c67653705e..f308b3443d9 100644
+index 2abf402f8bc..77a900d959f 100644
 --- a/src/nsterm.h
 +++ b/src/nsterm.h
-@@ -1226,6 +1226,8 @@ #define NSAPP_DATA2_RUNFILEDIALOG 11
+@@ -1227,6 +1227,8 @@ extern void ns_make_frame_invisible (struct frame *f);
  extern void ns_iconify_frame (struct frame *f);
  extern void ns_set_undecorated (struct frame *f, Lisp_Object new_value,
                                  Lisp_Object old_value);
@@ -99,7 +99,7 @@ index 6c67653705e..f308b3443d9 100644
                                   Lisp_Object old_value);
  extern void ns_set_no_focus_on_map (struct frame *f, Lisp_Object new_value,
 diff --git a/src/nsterm.m b/src/nsterm.m
-index c705a3c78f4..707f16d8de5 100644
+index 89664ad3f4d..0aa17a7fa10 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
 @@ -1810,6 +1810,44 @@ Hide the window (X11 semantics)
@@ -147,7 +147,7 @@ index c705a3c78f4..707f16d8de5 100644
  void
  ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
  /* --------------------------------------------------------------------------
-@@ -9277,6 +9315,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9360,6 +9398,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  		 | NSWindowStyleMaskMiniaturizable
  		 | NSWindowStyleMaskClosable);
  
@@ -159,7 +159,7 @@ index c705a3c78f4..707f16d8de5 100644
    last_drag_event = nil;
  
    width = FRAME_TEXT_COLS_TO_PIXEL_WIDTH (f, f->text_cols);
-@@ -9360,13 +9403,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9443,13 +9486,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  #endif
      }
  

--- a/patches/emacs-31/system-appearance.patch
+++ b/patches/emacs-31/system-appearance.patch
@@ -1,1 +1,281 @@
-../emacs-30/system-appearance.patch
+Patch to make emacs 28 aware of the macOS 10.14+ system appearance changes.
+
+From 6e73cd55ebfd3b0967357b3c3ead16d2f8539526 Mon Sep 17 00:00:00 2001
+From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
+Date: Wed, 11 Nov 2020 12:35:47 +0100
+Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
+
+This implements a new hook, effective only on macOS >= 10.14 (Mojave),
+that is called when the system changes its appearance (e.g. from light
+to dark). Users can then implement functions that take this change
+into account, for instance to load a particular theme.
+
+Minor changes are also made to select the right "dark" appearance
+(NSAppearanceNameDarkAqua) on macOS versions >= 10.14, the previous one
+(NSAppearanceNameVibrantDark) being deprecated.
+
+* src/frame.h (enum ns_appearance_type): Add new
+"ns_appearance_dark_aqua" case.
+
+* src/nsfns.m (defun x-create-frame): Use "dark aqua" appearance on
+macOS >= 10.14.
+
+* src/nsterm.m:
+  - (ns_set_appearance): Use "dark aqua" appearance on
+     macOS >= 10.14, reset appearance to the system one
+     if `ns-appearance' frame parameter is not set to
+     either `dark' or `light'.
+  - (initFrameFromEmacs): Use "dark aqua" appearance on
+     macOS >= 10.14.
+  - (EmacsApp) Add the `systemDidChangeAppearance' private method,
+    as well as the appropriate Key-Value Observing calls to update
+    the frame's appearance when the system (and thus the app's)
+    appearance changes.
+  - Add `ns-system-appearance-change-functions' hook variable and
+    symbol, to allow users to add functions that react to the
+    change of the system's appearance.
+  - Add `ns-system-appearance' variable, to allow users to consult
+    the current system appearance.
+
+Here is an example on how to use this new feature:
+
+    (defun my/load-theme (appearance)
+      "Load theme, taking current system APPEARANCE into consideration."
+      (mapc #'disable-theme custom-enabled-themes)
+      (pcase appearance
+        ('light (load-theme 'tango t))
+        ('dark (load-theme 'tango-dark t))))
+
+    (add-hook 'ns-system-appearance-change-functions #'my/load-theme)
+
+The hook being run on each system appearance change as well as at
+startup time, Emacs should then always load the appropriate theme.
+---
+ src/frame.h  |   3 +-
+ src/nsterm.m | 153 ++++++++++++++++++++++++++++++++++++++++++++++-----
+ 2 files changed, 141 insertions(+), 15 deletions(-)
+
+diff --git a/src/frame.h b/src/frame.h
+index 62b2edcb315..49b9829a6b1 100644
+--- a/src/frame.h
++++ b/src/frame.h
+@@ -71,7 +71,8 @@ #define EMACS_FRAME_H
+   {
+     ns_appearance_system_default,
+     ns_appearance_aqua,
+-    ns_appearance_vibrant_dark
++    ns_appearance_vibrant_dark,
++    ns_appearance_dark_aqua
+   };
+ #endif
+ #endif /* HAVE_WINDOW_SYSTEM */
+diff --git a/src/nsterm.m b/src/nsterm.m
+index 5514a693c86..ed3be1e2696 100644
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -1935,11 +1935,25 @@ Hide the window (X11 semantics)
+ ns_set_appearance_1 (struct frame *f, Lisp_Object new_value)
+ {
+   if (EQ (new_value, Qdark))
+-    FRAME_NS_APPEARANCE (f) = ns_appearance_vibrant_dark;
+-  else if (EQ (new_value, Qlight))
+-    FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
++    {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++#ifndef NSAppKitVersionNumber10_14
++#define NSAppKitVersionNumber10_14 1671
++#endif
++      if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14)
++        FRAME_NS_APPEARANCE(f) = ns_appearance_dark_aqua;
++      else
++#endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++        FRAME_NS_APPEARANCE(f) = ns_appearance_vibrant_dark;
++    }
++  else if (EQ(new_value, Qlight))
++    {
++      FRAME_NS_APPEARANCE (f) = ns_appearance_aqua;
++    }
+   else
+-    FRAME_NS_APPEARANCE (f) = ns_appearance_system_default;
++    {
++      FRAME_NS_APPEARANCE (f) = ns_appearance_system_default;
++    }
+ }
+ 
+ void
+@@ -5958,6 +5972,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+ 
+    ========================================================================== */
+ 
++static const void *kEmacsAppKVOContext = &kEmacsAppKVOContext;
+ 
+ @implementation EmacsApp
+ 
+@@ -6245,6 +6260,18 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+ 	 object:nil];
+ #endif
+ 
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  [self addObserver:self
++         forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++            options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
++            context:&kEmacsAppKVOContext];
++
++   pending_funcalls = Fcons(list3(Qrun_hook_with_args,
++                                  Qns_system_appearance_change_functions,
++                                  Vns_system_appearance),
++                            pending_funcalls);
++#endif
++
+ #ifdef NS_IMPL_COCOA
+   /* Some functions/methods in CoreFoundation/Foundation increase the
+      maximum number of open files for the process in their first call.
+@@ -6283,6 +6310,68 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+ #endif
+ }
+ 
++- (void)observeValueForKeyPath:(NSString *)keyPath
++                      ofObject:(id)object
++                        change:(NSDictionary *)change
++                       context:(void *)context
++{
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++  if (context == kEmacsAppKVOContext
++      && object == self
++      && [keyPath isEqualToString:
++                    NSStringFromSelector (@selector(effectiveAppearance))])
++    [self systemAppearanceDidChange:
++               [change objectForKey:NSKeyValueChangeNewKey]];
++  else
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++    [super observeValueForKeyPath:keyPath
++                         ofObject:object
++                           change:change
++                          context:context];
++}
++
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++#ifndef NSAppKitVersionNumber10_14
++#define NSAppKitVersionNumber10_14 1671
++#endif
++- (void)systemAppearanceDidChange:(NSAppearance *)newAppearance
++{
++
++  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_14)
++    return;
++
++  NSAppearanceName appearance_name =
++      [newAppearance bestMatchFromAppearancesWithNames:@[
++        NSAppearanceNameAqua, NSAppearanceNameDarkAqua
++      ]];
++
++  BOOL is_dark_appearance =
++    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
++  Vns_system_appearance = is_dark_appearance ? Qdark : Qlight;
++
++  run_system_appearance_change_hook ();
++}
++
++static inline void run_system_appearance_change_hook (void)
++{
++  if (NILP (Vns_system_appearance_change_functions))
++    return;
++
++  block_input ();
++
++  bool owfi = waiting_for_input;
++  waiting_for_input = false;
++
++  safe_calln (Qrun_hook_with_args,
++          Qns_system_appearance_change_functions,
++          Vns_system_appearance);
++  Fredisplay(Qt);
++
++  waiting_for_input = owfi;
++
++  unblock_input ();
++}
++#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
+ 
+ /* Termination sequences:
+     C-x C-c:
+@@ -6455,6 +6544,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+   ns_send_appdefined (-1);
+ }
+ 
++- (void)applicationWillTerminate:(NSNotification *)notification
++{
++  NSTRACE ("[EmacsApp applicationWillTerminate:]");
++
++  [self removeObserver:self
++            forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
++               context:&kEmacsAppKVOContext];
++}
+ 
+ 
+ /* ==========================================================================
+@@ -9971,17 +10068,26 @@ - (void)setAppearance
+ #define NSAppKitVersionNumber10_10 1343
+ #endif
+ 
+-  if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
+-    return;
+-
+-  if (FRAME_NS_APPEARANCE (f) == ns_appearance_vibrant_dark)
+-    appearance =
+-      [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
+-  else if (FRAME_NS_APPEARANCE (f) == ns_appearance_aqua)
+-    appearance =
+-      [NSAppearance appearanceNamed:NSAppearanceNameAqua];
++   if (NSAppKitVersionNumber < NSAppKitVersionNumber10_10)
++     return;
+ 
+-  [self setAppearance:appearance];
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++#ifndef NSAppKitVersionNumber10_14
++#define NSAppKitVersionNumber10_14 1671
++#endif
++   if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14
++       && FRAME_NS_APPEARANCE(f) == ns_appearance_dark_aqua)
++     appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
++   else
++#endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
++     if (FRAME_NS_APPEARANCE(f) == ns_appearance_vibrant_dark)
++       appearance =
++         [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
++     else if (FRAME_NS_APPEARANCE (f) == ns_appearance_aqua)
++       appearance =
++         [NSAppearance appearanceNamed:NSAppearanceNameAqua];
++
++   [self setAppearance:appearance];
+ #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
+ }
+ 
+@@ -11296,6 +11402,25 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+ This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
+   ns_use_mwheel_momentum = YES;
+ 
++ DEFVAR_LISP ("ns-system-appearance", Vns_system_appearance,
++               doc: /* Current system appearance, i.e. `dark' or `light'.
++
++This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
++  Vns_system_appearance = Qnil;
++  DEFSYM(Qns_system_appearance, "ns-system-appearance");
++
++  DEFVAR_LISP ("ns-system-appearance-change-functions",
++               Vns_system_appearance_change_functions,
++     doc: /* List of functions to call when the system appearance changes.
++Each function is called with a single argument, which corresponds to the new
++system appearance (`dark' or `light').
++
++This hook is also run once at startup.
++
++This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
++  Vns_system_appearance_change_functions = Qnil;
++  DEFSYM(Qns_system_appearance_change_functions, "ns-system-appearance-change-functions");
++
+   /* TODO: Move to common code.  */
+   DEFVAR_LISP ("x-toolkit-scroll-bars", Vx_toolkit_scroll_bars,
+ 	       doc: /* SKIP: real doc in xterm.c.  */);
+-- 
+2.48.1


### PR DESCRIPTION
Fixes https://github.com/d12frosted/homebrew-emacs-plus/issues/804

I re-applied the system-appearance patch myself and made the new patches, rather than using the patches provided in the comments in that issue because the patch difference didn't look quite right. 

I tested the system appearance patch by running `emacs -Q` and toggling system appearance and confirming that it switched between a dark frame and a light frame. If that's not the way to test it, it should be tested.