### PR TITLE
Emacs 31 fix-window-role patch is removed

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -90,7 +90,6 @@ class EmacsPlusAT31 < EmacsBase
   #
 
   opoo "The option --with-no-frame-refocus is not required anymore in emacs-plus@31." if build.with? "no-frame-refocus"
-  local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
 

--- a/patches/emacs-31/fix-window-role.patch
+++ b/patches/emacs-31/fix-window-role.patch
@@ -1,1 +1,0 @@
-../emacs-30/fix-window-role.patch


### PR DESCRIPTION
This was applied upstream

Fixes: #818 
Dupe of #819 (but has a single commit, rather than multiple)