### PR TITLE
Build script uses HOMEBREW_DEVELOPER to disable formula path check

### DIFF
--- a/build
+++ b/build
@@ -108,4 +108,4 @@ export HOMEBREW_NO_AUTO_UPDATE=true
 
 brew uninstall $PACKAGE 2>/dev/null
 # shellcheck disable=SC2068
-brew install --formula ./$TARGET_FILE $@
+HOMEBREW_DEVELOPER=1 brew install --formula ./$TARGET_FILE $@


### PR DESCRIPTION
Homebrew recently made it more difficult to build formula for developers for some reason. 

https://github.com/Homebrew/brew/commit/e22af1138883c892d585e215c05f63213df41050

This appears to be the way to work around this check.