### PR TITLE
Add --with-sqlite3 configure flag to enable SQLite support

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -119,6 +119,7 @@ class EmacsPlusAT30 < EmacsBase
 
     args << "--with-xml2"
     args << "--with-gnutls"
+    args << "--with-sqlite3"
 
     args << "--without-compress-install" if build.without? "compress-install"
 


### PR DESCRIPTION
Fixes missing SQLite3 support in Emacs 30.2 build. Despite sqlite being listed as a build dependency with correct CFLAGS/LDFLAGS, Emacs was compiled without SQLite3 support due to missing --with-sqlite3 flag.

This enables packages like org-roam and emacsql to work properly.