### PR TITLE
Update emacs-plus@30 dependencies

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -51,7 +51,7 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "gnutls"
   depends_on "librsvg"
   depends_on "little-cms2"
-  depends_on "tree-sitter@0.25"
+  depends_on "homebrew/core/tree-sitter@0.25"
   depends_on "webp"
   depends_on "imagemagick" => :optional
   depends_on "dbus" => :optional


### PR DESCRIPTION
`ts_language_version` is deprecated in version 0.26 so use 0.25.

I'm currently without a working `emacs` - I'll fix the commits when it works.