### PR TITLE
community: add patch to improve async process read performance

### DIFF
--- a/community/patches/aggressive-read-buffering/README.md
+++ b/community/patches/aggressive-read-buffering/README.md
@@ -1,0 +1,32 @@
+# aggressive-read-buffering
+
+Improve processing large quantities of data from tty/pty reads on macOS
+
+## Compatibility
+
+- Emacs versions: 29, 30, 31
+
+## Maintainer
+
+aport
+
+## Usage
+
+Add to your `~/.config/emacs-plus/build.yml`:
+
+```yaml
+patches:
+  - aggressive-read-buffering
+```
+
+Then rebuild Emacs:
+
+```bash
+brew reinstall emacs-plus@30
+```
+
+## Patch Files
+
+- `emacs-29.patch` - Patch for Emacs 29
+- `emacs-30.patch` - Patch for Emacs 30
+- `emacs-31.patch` - Patch for Emacs 31

--- a/community/patches/aggressive-read-buffering/emacs-29.patch
+++ b/community/patches/aggressive-read-buffering/emacs-29.patch
@@ -1,0 +1,33 @@
+diff --git a/src/sysdep.c b/src/sysdep.c
+index ef2dc127e2a..dce6db45010 100644
+--- a/src/sysdep.c
++++ b/src/sysdep.c
+@@ -2540,6 +2540,28 @@ emacs_intr_read (int fd, void *buf, ptrdiff_t nbyte, bool interruptible)
+     }
+   while (result < 0 && errno == EINTR);
+ 
++  /* On macOS the maximum buffer size for a tty/pty is 1024 bytes. If
++     we've asked for more, continue reading data in a loop until we've
++     read NBYTE bytes or there is no more data.  Add a short delay
++     between reads to give the writer an opportunity to put more
++     data. This significantly improves the performance of
++     read_process_output() when receiving large quanities of data.  */
++  if ((result == 1024) && (nbyte > result) && isatty(fd))
++    {
++      ssize_t n;
++
++      do
++	{
++	  usleep (25);
++	  if (interruptible)
++	    maybe_quit ();
++	  n = read (fd, buf + result, nbyte - result);
++	  if (n > 0)
++	    result += n;
++	}
++      while ((n < 0 && errno == EINTR) || (n > 0));
++    }
++
+   return result;
+ }
+ 

--- a/community/patches/aggressive-read-buffering/emacs-30.patch
+++ b/community/patches/aggressive-read-buffering/emacs-30.patch
@@ -1,0 +1,33 @@
+diff --git a/src/sysdep.c b/src/sysdep.c
+index 92f6f732e23..f388ac96438 100644
+--- a/src/sysdep.c
++++ b/src/sysdep.c
+@@ -2775,6 +2775,28 @@ emacs_intr_read (int fd, void *buf, ptrdiff_t nbyte, bool interruptible)
+     }
+   while (result < 0 && errno == EINTR);
+ 
++  /* On macOS the maximum buffer size for a tty/pty is 1024 bytes. If
++     we've asked for more, continue reading data in a loop until we've
++     read NBYTE bytes or there is no more data.  Add a short delay
++     between reads to give the writer an opportunity to put more
++     data. This significantly improves the performance of
++     read_process_output() when receiving large quanities of data.  */
++  if ((result == 1024) && (nbyte > result) && isatty(fd))
++    {
++      ssize_t n;
++
++      do
++	{
++	  usleep (25);
++	  if (interruptible)
++	    maybe_quit ();
++	  n = read (fd, buf + result, nbyte - result);
++	  if (n > 0)
++	    result += n;
++	}
++      while ((n < 0 && errno == EINTR) || (n > 0));
++    }
++
+   return result;
+ }
+ 

--- a/community/patches/aggressive-read-buffering/emacs-31.patch
+++ b/community/patches/aggressive-read-buffering/emacs-31.patch
@@ -1,0 +1,33 @@
+diff --git a/src/sysdep.c b/src/sysdep.c
+index a8320e1db26..918c23e9db6 100644
+--- a/src/sysdep.c
++++ b/src/sysdep.c
+@@ -2778,6 +2778,28 @@ emacs_intr_read (int fd, void *buf, ptrdiff_t nbyte, bool interruptible)
+     }
+   while (result < 0 && errno == EINTR);
+ 
++  /* On macOS the maximum buffer size for a tty/pty is 1024 bytes. If
++     we've asked for more, continue reading data in a loop until we've
++     read NBYTE bytes or there is no more data.  Add a short delay
++     between reads to give the writer an opportunity to put more
++     data. This significantly improves the performance of
++     read_process_output() when receiving large quanities of data.  */
++  if ((result == 1024) && (nbyte > result) && isatty(fd))
++    {
++      ssize_t n;
++
++      do
++	{
++	  usleep (25);
++	  if (interruptible)
++	    maybe_quit ();
++	  n = read (fd, buf + result, nbyte - result);
++	  if (n > 0)
++	    result += n;
++	}
++      while ((n < 0 && errno == EINTR) || (n > 0));
++    }
++
+   return result;
+ }
+ 

--- a/community/patches/aggressive-read-buffering/metadata.json
+++ b/community/patches/aggressive-read-buffering/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "aggressive-read-buffering",
+  "description": "Improve processing large quantities of data from tty/pty reads on macOS",
+  "maintainer": "aport",
+  "compatibility": {
+    "emacs_versions": [
+      "29",
+      "30",
+      "31"
+    ]
+  },
+  "created_at": "2025-12-24"
+}

--- a/community/registry.json
+++ b/community/registry.json
@@ -1,6 +1,9 @@
 {
   "schema_version": "1.0",
   "patches": {
+    "aggressive-read-buffering": {
+      "directory": "patches/aggressive-read-buffering"
+    }
   },
   "icons": {
     "EmacsIcon1": {


### PR DESCRIPTION
On macOS the maximum buffer size of a tty/pty is 1KB. When reading the output data from an async process, the function emacs_intr_read() only issues a single call to read() and then passes the data up the stack for processing. This effectively limits the value of read-process-output-max to 1024 bytes on macOS.

If we've read 1KB on a TTY, it's highly likely we've read the maximum and the writer has more data to send. Continue reading in a loop, with a short delay, to allow the writer to put more data. This lets us bulk read data (up to read-process-output-max bytes) in a single call to emacs_read().

On a MBP with an M4 Pro, running in the emacs git repository:

`(async-shell-command "time git -C ~/emacs --no-pager log --oneline")`

Before:
1.23s user 0.19s system 1% cpu 2:21.32 total

After:
0.76s user 0.07s system 53% cpu 1.550 total

Same command in iTerm2 for comparison:
0.90s user 0.15s system 98% cpu 1.076 total