### PR TITLE
Fix tree-sitter compatibility for Emacs 29 and 30

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -95,6 +95,7 @@ class EmacsPlusAT29 < EmacsBase
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
   local_patch "mac-font-use-typo-metrics", sha: "318395d3869d3479da4593360bcb11a5df08b494b995287074d0d744ec562c17"
+  local_patch "treesit-compatibility", sha: "6bfcd2463e9571e17ed697625769b4db26607281dc82da4cf618910898001096" if build.with? "tree-sitter"
 
   #
   # Install

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -107,6 +107,7 @@ class EmacsPlusAT30 < EmacsBase
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
   local_patch "mac-font-use-typo-metrics", sha: "318395d3869d3479da4593360bcb11a5df08b494b995287074d0d744ec562c17"
+  local_patch "treesit-compatibility", sha: "7cb460084261af2b6ce04ddaefeffa658c35caa931bbf99ab6053ce7b23f2359" if build.with? "tree-sitter"
 
   #
   # Install

--- a/patches/emacs-29/treesit-compatibility.patch
+++ b/patches/emacs-29/treesit-compatibility.patch
@@ -1,0 +1,49 @@
+diff --git a/src/treesit.c.orig b/src/treesit.c
+index 45efa42..8194528 100644
+--- a/src/treesit.c.orig
++++ b/src/treesit.c
+@@ -89,7 +89,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ #undef ts_tree_get_changed_ranges
+ #undef ts_tree_root_node
+ 
+-DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
++DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
+ DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
+ DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
+ 	    (TSNode, const char *, uint32_t));
+@@ -166,7 +166,7 @@ init_treesit_functions (void)
+   if (!library)
+     return false;
+ 
+-  LOAD_DLL_FN (library, ts_language_version);
++  LOAD_DLL_FN (library, ts_language_abi_version);
+   LOAD_DLL_FN (library, ts_node_child);
+   LOAD_DLL_FN (library, ts_node_child_by_field_name);
+   LOAD_DLL_FN (library, ts_node_child_count);
+@@ -224,7 +224,7 @@ init_treesit_functions (void)
+   return true;
+ }
+ 
+-#define ts_language_version fn_ts_language_version
++#define ts_language_abi_version fn_ts_language_abi_version
+ #define ts_node_child fn_ts_node_child
+ #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
+ #define ts_node_child_count fn_ts_node_child_count
+@@ -664,7 +664,7 @@ treesit_load_language (Lisp_Object language_symbol,
+     {
+       *signal_symbol = Qtreesit_load_language_error;
+       *signal_data = list2 (Qversion_mismatch,
+-			    make_fixnum (ts_language_version (lang)));
++			    make_fixnum (ts_language_abi_version (lang)));
+       return NULL;
+     }
+   return lang;
+@@ -735,7 +735,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
+ 			       &signal_data);
+   if (ts_language == NULL)
+     return Qnil;
+-  uint32_t version = ts_language_version (ts_language);
++  uint32_t version = ts_language_abi_version (ts_language);
+   return make_fixnum((ptrdiff_t) version);
+ }
+ }

--- a/patches/emacs-30/treesit-compatibility.patch
+++ b/patches/emacs-30/treesit-compatibility.patch
@@ -1,0 +1,49 @@
+diff --git a/src/treesit.c.orig b/src/treesit.c
+index 45efa42..8194528 100644
+--- a/src/treesit.c.orig
++++ b/src/treesit.c
+@@ -89,7 +89,7 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
+ #undef ts_tree_get_changed_ranges
+ #undef ts_tree_root_node
+ 
+-DEF_DLL_FN (uint32_t, ts_language_version, (const TSLanguage *));
++DEF_DLL_FN (uint32_t, ts_language_abi_version, (const TSLanguage *));
+ DEF_DLL_FN (TSNode, ts_node_child, (TSNode, uint32_t));
+ DEF_DLL_FN (TSNode, ts_node_child_by_field_name,
+ 	    (TSNode, const char *, uint32_t));
+@@ -166,7 +166,7 @@ init_treesit_functions (void)
+   if (!library)
+     return false;
+ 
+-  LOAD_DLL_FN (library, ts_language_version);
++  LOAD_DLL_FN (library, ts_language_abi_version);
+   LOAD_DLL_FN (library, ts_node_child);
+   LOAD_DLL_FN (library, ts_node_child_by_field_name);
+   LOAD_DLL_FN (library, ts_node_child_count);
+@@ -224,7 +224,7 @@ init_treesit_functions (void)
+   return true;
+ }
+ 
+-#define ts_language_version fn_ts_language_version
++#define ts_language_abi_version fn_ts_language_abi_version
+ #define ts_node_child fn_ts_node_child
+ #define ts_node_child_by_field_name fn_ts_node_child_by_field_name
+ #define ts_node_child_count fn_ts_node_child_count
+@@ -746,7 +746,7 @@ treesit_load_language (Lisp_Object language_symbol,
+     {
+       *signal_symbol = Qtreesit_load_language_error;
+       *signal_data = list2 (Qversion_mismatch,
+-			    make_fixnum (ts_language_version (lang)));
++			    make_fixnum (ts_language_abi_version (lang)));
+       return NULL;
+     }
+   return lang;
+@@ -817,7 +817,7 @@ Return nil if a grammar library for LANGUAGE is not available.  */)
+ 			       &signal_data);
+   if (ts_language == NULL)
+     return Qnil;
+-  uint32_t version = ts_language_version (ts_language);
++  uint32_t version = ts_language_abi_version (ts_language);
+   return make_fixnum((ptrdiff_t) version);
+ }
+ }


### PR DESCRIPTION
Replace ts_language_version with ts_language_abi_version to support newer tree-sitter versions that removed the deprecated function.

- Add treesit-compatibility.patch for Emacs 29 and 30
- Apply patches conditionally when tree-sitter option is enabled
- Use local_patch method for proper integration

Based on commit c27c6f37126fd6045983ce91aa4118b42849d6f2 from daviderestivo/homebrew-emacs-head