### PR TITLE
feat: add inject_path option for PATH injection in formula builds

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -217,14 +217,6 @@ class EmacsPlusAT29 < EmacsBase
       # inject PATH to Info.plist
       inject_path
 
-      # Rename dSYM to match the binary name (Emacs-real) so lldb auto-finds it
-      if build.with? "debug"
-        dsym_path = prefix/"Emacs.app/Contents/MacOS/Emacs.dSYM"
-        if dsym_path.exist?
-          mv dsym_path, prefix/"Emacs.app/Contents/MacOS/Emacs-real.dSYM"
-        end
-      end
-
       # inject description for protected resources usage
       inject_protected_resources_usage_desc
 

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -230,14 +230,6 @@ class EmacsPlusAT30 < EmacsBase
       # inject PATH to Info.plist
       inject_path
 
-      # Rename dSYM to match the binary name (Emacs-real) so lldb auto-finds it
-      if build.with? "debug"
-        dsym_path = prefix/"Emacs.app/Contents/MacOS/Emacs.dSYM"
-        if dsym_path.exist?
-          mv dsym_path, prefix/"Emacs.app/Contents/MacOS/Emacs-real.dSYM"
-        end
-      end
-
       # inject description for protected resources usage
       inject_protected_resources_usage_desc
 

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -219,14 +219,6 @@ class EmacsPlusAT31 < EmacsBase
       # inject PATH to Info.plist
       inject_path
 
-      # Rename dSYM to match the binary name (Emacs-real) so lldb auto-finds it
-      if build.with? "debug"
-        dsym_path = prefix/"Emacs.app/Contents/MacOS/Emacs.dSYM"
-        if dsym_path.exist?
-          mv dsym_path, prefix/"Emacs.app/Contents/MacOS/Emacs-real.dSYM"
-        end
-      end
-
       # inject description for protected resources usage
       inject_protected_resources_usage_desc
 

--- a/Library/BuildConfig.rb
+++ b/Library/BuildConfig.rb
@@ -12,8 +12,8 @@ module BuildConfig
   class ConfigurationError < StandardError; end
 
   # Known configuration keys by context
-  FORMULA_KEYS = %w[icon patches revision].freeze
-  CASK_KEYS = %w[icon native_comp_env].freeze
+  FORMULA_KEYS = %w[icon patches revision inject_path].freeze
+  CASK_KEYS = %w[icon inject_path].freeze
   ALL_KEYS = (FORMULA_KEYS + CASK_KEYS).uniq.freeze
 
   class << self
@@ -97,7 +97,7 @@ module BuildConfig
       validate_icon!(config["icon"], path) if config.key?("icon")
       validate_patches!(config["patches"], path) if config.key?("patches")
       validate_revision!(config["revision"], path) if config.key?("revision")
-      validate_native_comp_env!(config["native_comp_env"], path) if config.key?("native_comp_env")
+      validate_inject_path!(config["inject_path"], path) if config.key?("inject_path")
     end
 
     # Suggest correct key name for typos
@@ -148,11 +148,11 @@ module BuildConfig
       end
     end
 
-    def validate_native_comp_env!(value, path)
+    def validate_inject_path!(value, path)
       return if [true, false].include?(value)
 
       raise ConfigurationError,
-        "Invalid 'native_comp_env' in #{path}\n" \
+        "Invalid 'inject_path' in #{path}\n" \
         "Expected: true or false\n" \
         "Got: #{value.inspect} (#{value.class})"
     end
@@ -235,8 +235,6 @@ module BuildConfig
       when :cask
         warnings << "'patches' is ignored (patches are only applied during formula builds)" if config.key?("patches")
         warnings << "'revision' is ignored (revision pinning is only used during formula builds)" if config.key?("revision")
-      when :formula
-        warnings << "'native_comp_env' is ignored (only used in cask installations)" if config.key?("native_comp_env")
       end
       warnings
     end

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,51 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-01-11
+
+** Breaking Changes
+
+*** Replaced =native_comp_env= with =inject_path= in build.yml
+
+The =native_comp_env= option in =build.yml= has been replaced with =inject_path=:
+
+#+begin_src yaml
+# Old (no longer works)
+native_comp_env: false
+
+# New
+inject_path: false
+#+end_src
+
+Native compilation environment (=CC=, =LIBRARY_PATH=) is now always injected. The =inject_path= option controls whether user's PATH is also injected.
+
+*** Removed =EMACS_PLUS_NO_PATH_INJECTION= environment variable
+
+The runtime opt-out via =EMACS_PLUS_NO_PATH_INJECTION= environment variable has been removed. To disable PATH injection, use =inject_path: false= in =build.yml= and reinstall.
+
+** New Features
+
+*** =inject_path= option for formula builds
+
+The =inject_path= option in =build.yml= controls user PATH injection for formula builds (default: =true=). When enabled, your shell's full PATH is captured at install time and injected into =Emacs.app=.
+
+Note: This option does not apply to cask builds. Due to a Homebrew limitation, cask postflight doesn't have access to the user's shell environment. Cask users should use =exec-path-from-shell= or switch to the formula for full PATH injection.
+
+*** =ns-emacs-plus-injected-path= variable
+
+A new variable =ns-emacs-plus-injected-path= is defined in =site-start.el=. It is non-nil only for formula builds with =inject_path: true=. This allows you to conditionally skip =exec-path-from-shell=:
+
+#+begin_src elisp
+(unless (bound-and-true-p ns-emacs-plus-injected-path)
+  (exec-path-from-shell-initialize))
+#+end_src
+
+** Internal Changes
+
+*** Unified PATH injection via LSEnvironment
+
+Both formula and cask now use =LSEnvironment= in =Info.plist= for PATH injection (previously formula used a wrapper script). This simplifies the codebase and ensures consistent behavior.
+
 * 2026-01-05
 
 ** Breaking Changes

--- a/README.org
+++ b/README.org
@@ -176,27 +176,17 @@ The configuration file is searched in this order:
 icon: dragon-plus
 patches:
   - fix-window-role
-native_comp_env: true
+inject_path: true
 #+end_src
 
 *** Available Options
 
-| Option            | Default | Description                                                                  |
-|-------------------+---------+------------------------------------------------------------------------------|
-| =icon=            | /none/  | Custom icon to apply. See [[./community/icons/README.md][→ Icons Gallery]] for available icons.               |
-| =patches=         | /none/  | (Formula only) List of community patches to apply. See [[#community-features][→ Community Features]]. |
-| =revision=        | /none/  | (Formula only) Pin Emacs source to a specific git revision.                  |
-| =native_comp_env= | =true=  | (Cask only) Inject environment variables for native compilation.             |
-
-*** Native Compilation Environment (Cask)
-
-When installing via cask, Emacs+ automatically injects environment variables (=PATH=, =CC=, =LIBRARY_PATH=) into =Emacs.app= so that native compilation works when launching from Finder/Dock. This ensures =libgccjit= can find =gcc= and its libraries without requiring shell configuration.
-
-To disable this (e.g., if you manage your environment differently):
-
-#+begin_src yaml
-native_comp_env: false
-#+end_src
+| Option        | Default | Description                                                                  |
+|---------------+---------+------------------------------------------------------------------------------|
+| =icon=        | /none/  | Custom icon to apply. See [[./community/icons/README.md][→ Icons Gallery]] for available icons.               |
+| =patches=     | /none/  | (Formula only) List of community patches to apply. See [[#community-features][→ Community Features]]. |
+| =revision=    | /none/  | (Formula only) Pin Emacs source to a specific git revision.                  |
+| =inject_path= | =true=  | (Formula only) Inject user's PATH into Emacs.app. See [[#injected-path][→ Injected PATH]].     |
 
 For more customization options, see [[#community-features][→ Community Features]] for patches and [[#icons][→ Icons]] for icon customization.
 
@@ -303,24 +293,51 @@ In macOS applications are started in the login environment, meaning that all use
 
 There is a wonderful solution to overcome this problem, [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]]. As with any package that is not preinstalled with Emacs, you need to discover it first, and then install it. And while being a well known package and popular package (top 100 on MELPA), not everyone install it. In addition, with =native-comp= feature you might need it's functionality before any package is bootstrapped.
 
-All that being said, during installation Emacs+ injects value of =PATH= into =Emacs.app/Contents/Info.plist= file, making this value available whenever you start =Emacs.app= from Finder, Docker, Spotlight, =open= command in Terminal or via =launchd=. This solves a wide range of problems for GUI users without the need to use [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]], but if needed you can still fall back to this wonderful package, especially if you need other variables.
+**** Formula builds
+
+For formula builds (=brew install emacs-plus@30=), Emacs+ captures your shell's PATH at install time and injects it into =Emacs.app=. This makes your PATH available whenever you start =Emacs.app= from Finder, Dock, Spotlight, =open= command, or =launchd=. This solves a wide range of problems for GUI users without the need to use [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]].
+
+To disable PATH injection for formula builds, set =inject_path: false= in your =build.yml= and reinstall:
+
+#+begin_src yaml
+inject_path: false
+#+end_src
 
 In case you have a non-trivial setup relying on specific value of =PATH= inherited from current terminal session, it is advised to start Emacs using =/opt/homebrew/bin/emacs= instead of =open -n -a /path/to/Emacs.app=, because =open= messes around with =PATH= value even without Emacs+ injection. You can find more information in [[https://github.com/d12frosted/homebrew-emacs-plus/issues/469][#469]].
 
-To disable PATH injection at runtime, set the =EMACS_PLUS_NO_PATH_INJECTION= environment variable to any non-empty value before launching Emacs.
+**** Cask builds
 
-And if for some reason PATH injection doesn't work for you, report it either in [[https://github.com/d12frosted/homebrew-emacs-plus/issues/469][#469]] or open a new issue.
+For cask builds (=brew install --cask emacs-plus-app=), PATH injection is *not available* due to a Homebrew limitation - cask postflight doesn't have access to the user's shell environment. Native compilation still works because =CC= and =LIBRARY_PATH= are injected.
+
+Cask users who need their shell PATH in Emacs should use [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]]:
+
+#+begin_src elisp
+(exec-path-from-shell-initialize)
+#+end_src
+
+If you need full PATH injection, use the formula instead of the cask.
 
 *** Detecting Emacs Plus
 
-Starting with =emacs-plus@30= and =emacs-plus@31=, the variable =ns-emacs-plus-version= is defined, allowing you to detect Emacs Plus in your init.el:
+Starting with =emacs-plus@30= and =emacs-plus@31=, the following variables are defined in =site-start.el=:
+
+| Variable                      | Description                                                           |
+|-------------------------------+-----------------------------------------------------------------------|
+| =ns-emacs-plus-version=       | Major version of Emacs Plus (e.g., 30 or 31)                          |
+| =ns-emacs-plus-injected-path= | Non-nil if user PATH was injected (formula with =inject_path: true=)  |
+
+This allows you to detect Emacs Plus and conditionally configure your init.el:
 
 #+begin_src elisp
 (when (bound-and-true-p ns-emacs-plus-version)
   ;; Emacs Plus specific configuration
   )
 
-;; Or check specific version
+;; Skip exec-path-from-shell if PATH was already injected
+(unless (bound-and-true-p ns-emacs-plus-injected-path)
+  (exec-path-from-shell-initialize))
+
+;; Check specific version
 (when (and (bound-and-true-p ns-emacs-plus-version)
            (>= ns-emacs-plus-version 31))
   ;; Emacs Plus 31+ specific

--- a/tests/test_build_config.rb
+++ b/tests/test_build_config.rb
@@ -45,29 +45,29 @@ class TestBuildConfig < Minitest::Test
     end
   end
 
-  def test_valid_native_comp_env_true
-    with_temp_config("native_comp_env: true") do |path|
+  def test_valid_inject_path_true
+    with_temp_config("inject_path: true") do |path|
       result = load_config_from_path(path)
-      assert_equal true, result[:config]["native_comp_env"]
+      assert_equal true, result[:config]["inject_path"]
     end
   end
 
-  def test_valid_native_comp_env_false
-    with_temp_config("native_comp_env: false") do |path|
+  def test_valid_inject_path_false
+    with_temp_config("inject_path: false") do |path|
       result = load_config_from_path(path)
-      assert_equal false, result[:config]["native_comp_env"]
+      assert_equal false, result[:config]["inject_path"]
     end
   end
 
   def test_valid_full_config
     yaml = <<~YAML
       icon: spacemacs
-      native_comp_env: true
+      inject_path: true
     YAML
     with_temp_config(yaml) do |path|
       result = load_config_from_path(path)
       assert_equal "spacemacs", result[:config]["icon"]
-      assert_equal true, result[:config]["native_comp_env"]
+      assert_equal true, result[:config]["inject_path"]
     end
   end
 
@@ -124,23 +124,23 @@ class TestBuildConfig < Minitest::Test
   # Tests for invalid field values
   # ===========================================
 
-  def test_invalid_native_comp_env_string
+  def test_invalid_inject_path_string
     # Note: YAML 1.1 treats "yes"/"no" as booleans, so we use a quoted string
-    with_temp_config('native_comp_env: "yes"') do |path|
+    with_temp_config('inject_path: "yes"') do |path|
       error = assert_raises(BuildConfig::ConfigurationError) do
         load_config_from_path(path)
       end
-      assert_includes error.message, "Invalid 'native_comp_env'"
+      assert_includes error.message, "Invalid 'inject_path'"
       assert_includes error.message, "Expected: true or false"
     end
   end
 
-  def test_invalid_native_comp_env_number
-    with_temp_config("native_comp_env: 1") do |path|
+  def test_invalid_inject_path_number
+    with_temp_config("inject_path: 1") do |path|
       error = assert_raises(BuildConfig::ConfigurationError) do
         load_config_from_path(path)
       end
-      assert_includes error.message, "Invalid 'native_comp_env'"
+      assert_includes error.message, "Invalid 'inject_path'"
     end
   end
 
@@ -416,12 +416,11 @@ class TestBuildConfig < Minitest::Test
     assert_includes warnings.first, "ignored"
   end
 
-  def test_formula_context_warns_about_native_comp_env
-    config = { "native_comp_env" => true }
+  def test_formula_context_no_warning_for_inject_path
+    # inject_path applies to both formula and cask, so no warning
+    config = { "inject_path" => true }
     warnings = BuildConfig.context_warnings(config, :formula)
-    assert_equal 1, warnings.length
-    assert_includes warnings.first, "native_comp_env"
-    assert_includes warnings.first, "ignored"
+    assert_empty warnings
   end
 
   def test_cask_context_no_warning_for_icon

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -1,0 +1,356 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test suite for CaskEnv PATH injection logic
+#
+# Run with: ruby tests/test_cask_env.rb
+
+require 'minitest/autorun'
+require 'tempfile'
+require 'fileutils'
+
+# Mock Hardware::CPU for testing without Homebrew
+module Hardware
+  module CPU
+    class << self
+      attr_accessor :mock_arm
+
+      def arm?
+        @mock_arm.nil? ? false : @mock_arm
+      end
+    end
+  end
+end
+
+require_relative '../Library/CaskEnv'
+
+class TestCaskEnv < Minitest::Test
+  def setup
+    # Default to ARM architecture for consistent tests
+    Hardware::CPU.mock_arm = true
+    # Clear any cached config
+    CaskEnv.instance_variable_set(:@config, nil)
+  end
+
+  def teardown
+    # Clean up environment
+    ENV.delete("HOMEBREW_EMACS_PLUS_BUILD_CONFIG")
+  end
+
+  # ===========================================
+  # Tests for inject_path? behavior
+  # ===========================================
+
+  def test_inject_path_defaults_to_true_when_no_config
+    CaskEnv.instance_variable_set(:@config, nil)
+    assert_equal true, CaskEnv.send(:inject_path?)
+  end
+
+  def test_inject_path_defaults_to_true_when_empty_config
+    CaskEnv.instance_variable_set(:@config, {})
+    assert_equal true, CaskEnv.send(:inject_path?)
+  end
+
+  def test_inject_path_true_when_explicitly_set
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    assert_equal true, CaskEnv.send(:inject_path?)
+  end
+
+  def test_inject_path_false_when_explicitly_set
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => false })
+    assert_equal false, CaskEnv.send(:inject_path?)
+  end
+
+  # ===========================================
+  # Tests for native_comp_path
+  # ===========================================
+
+  def test_native_comp_path_arm64
+    Hardware::CPU.mock_arm = true
+    path = CaskEnv.send(:native_comp_path)
+
+    assert_includes path, "/opt/homebrew/bin"
+    assert_includes path, "/opt/homebrew/sbin"
+    assert_includes path, "/usr/bin"
+    assert_includes path, "/bin"
+    assert_includes path, "/usr/sbin"
+    assert_includes path, "/sbin"
+  end
+
+  def test_native_comp_path_intel
+    Hardware::CPU.mock_arm = false
+    path = CaskEnv.send(:native_comp_path)
+
+    assert_includes path, "/usr/local/bin"
+    assert_includes path, "/usr/local/sbin"
+    assert_includes path, "/usr/bin"
+    refute_includes path, "/opt/homebrew"
+  end
+
+  def test_native_comp_path_order
+    Hardware::CPU.mock_arm = true
+    path = CaskEnv.send(:native_comp_path)
+    parts = path.split(':')
+
+    # Homebrew paths should come first
+    assert_equal "/opt/homebrew/bin", parts[0]
+    assert_equal "/opt/homebrew/sbin", parts[1]
+    # System paths after
+    assert_equal "/usr/bin", parts[2]
+    assert_equal "/bin", parts[3]
+  end
+
+  # ===========================================
+  # Tests for build_path composition
+  # ===========================================
+
+  def test_build_path_without_inject_path
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => false })
+    Hardware::CPU.mock_arm = true
+
+    path = CaskEnv.send(:build_path)
+
+    # Should only contain native comp paths
+    assert_equal CaskEnv.send(:native_comp_path), path
+  end
+
+  def test_build_path_with_inject_path_appends_user_path
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    Hardware::CPU.mock_arm = true
+
+    # Set a custom PATH with some unique entries
+    original_path = ENV['PATH']
+    ENV['PATH'] = "/custom/bin:/another/path:/usr/bin"
+
+    begin
+      path = CaskEnv.send(:build_path)
+      parts = path.split(':')
+
+      # Native comp paths should come first
+      assert_equal "/opt/homebrew/bin", parts[0]
+      assert_equal "/opt/homebrew/sbin", parts[1]
+
+      # User paths should be appended (excluding duplicates)
+      assert_includes path, "/custom/bin"
+      assert_includes path, "/another/path"
+
+      # /usr/bin is already in native_comp_path, so should not be duplicated
+      assert_equal 1, parts.count("/usr/bin")
+    ensure
+      ENV['PATH'] = original_path
+    end
+  end
+
+  def test_build_path_native_comp_always_first
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    Hardware::CPU.mock_arm = true
+
+    # User PATH that might contain homebrew paths in different order
+    original_path = ENV['PATH']
+    ENV['PATH'] = "/custom/first:/opt/homebrew/bin:/custom/last"
+
+    begin
+      path = CaskEnv.send(:build_path)
+      parts = path.split(':')
+
+      # Native comp paths must be first regardless of user PATH order
+      assert_equal "/opt/homebrew/bin", parts[0]
+      assert_equal "/opt/homebrew/sbin", parts[1]
+      assert_equal "/usr/bin", parts[2]
+
+      # User's custom paths should be appended after
+      custom_first_index = parts.index("/custom/first")
+      custom_last_index = parts.index("/custom/last")
+
+      assert custom_first_index > 5, "User paths should come after native comp paths"
+      assert custom_last_index > 5, "User paths should come after native comp paths"
+    ensure
+      ENV['PATH'] = original_path
+    end
+  end
+
+  def test_build_path_removes_duplicates
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    Hardware::CPU.mock_arm = true
+
+    original_path = ENV['PATH']
+    # PATH with entries that overlap with native_comp_path
+    ENV['PATH'] = "/opt/homebrew/bin:/usr/bin:/custom/bin:/sbin"
+
+    begin
+      path = CaskEnv.send(:build_path)
+      parts = path.split(':')
+
+      # Each path should appear only once
+      assert_equal 1, parts.count("/opt/homebrew/bin")
+      assert_equal 1, parts.count("/usr/bin")
+      assert_equal 1, parts.count("/sbin")
+      assert_equal 1, parts.count("/custom/bin")
+    ensure
+      ENV['PATH'] = original_path
+    end
+  end
+
+  def test_build_path_handles_empty_user_path
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    Hardware::CPU.mock_arm = true
+
+    original_path = ENV['PATH']
+    ENV['PATH'] = ""
+
+    begin
+      path = CaskEnv.send(:build_path)
+      # Should just be native_comp_path
+      assert_equal CaskEnv.send(:native_comp_path), path
+    ensure
+      ENV['PATH'] = original_path
+    end
+  end
+
+  def test_build_path_filters_homebrew_shims
+    CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+    Hardware::CPU.mock_arm = true
+
+    original_path = ENV['PATH']
+    # Simulate Homebrew's modified PATH with shims
+    ENV['PATH'] = "/opt/homebrew/Library/Homebrew/shims/shared:/usr/bin:/bin:/custom/bin"
+
+    begin
+      path = CaskEnv.send(:build_path)
+
+      # Homebrew shims should be filtered out
+      refute_includes path, "Homebrew/shims"
+
+      # Custom paths should still be included
+      assert_includes path, "/custom/bin"
+    ensure
+      ENV['PATH'] = original_path
+    end
+  end
+
+  # ===========================================
+  # Tests for update_site_start_el
+  # ===========================================
+
+  def test_update_site_start_el_adds_path_injection_code
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      # Create initial site-start.el (as CI would create it)
+      File.write("#{site_lisp}/site-start.el", <<~ELISP)
+        ;;; site-start.el --- Emacs Plus site initialization -*- lexical-binding: t -*-
+
+        (defconst ns-emacs-plus-version 30
+          "Major version of Emacs Plus.")
+
+        (provide 'emacs-plus)
+
+        ;;; site-start.el ends here
+      ELISP
+
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      CaskEnv.send(:update_site_start_el, app_path)
+
+      content = File.read("#{site_lisp}/site-start.el")
+
+      # Should have ns-emacs-plus-injected-path computed from EMACS_PLUS_PATH
+      assert_includes content, "ns-emacs-plus-injected-path"
+      assert_includes content, '(getenv "EMACS_PLUS_PATH")'
+
+      # Should have the PATH injection code
+      assert_includes content, "exec-path"
+      assert_includes content, '(setenv "PATH" emacs-plus-path)'
+
+      # Should still have the original content
+      assert_includes content, "ns-emacs-plus-version"
+      assert_includes content, "(provide 'emacs-plus)"
+    end
+  end
+
+  def test_update_site_start_el_adds_code_regardless_of_inject_path_setting
+    # The site-start.el PATH injection code is always added.
+    # Whether EMACS_PLUS_PATH is actually set (and thus ns-emacs-plus-injected-path
+    # is t at runtime) depends on the inject_path config at install time.
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      File.write("#{site_lisp}/site-start.el", <<~ELISP)
+        ;;; site-start.el
+        (defconst ns-emacs-plus-version 30)
+        (provide 'emacs-plus)
+      ELISP
+
+      # Even with inject_path: false, the site-start.el gets the PATH injection code
+      # (ns-emacs-plus-injected-path will be nil at runtime since EMACS_PLUS_PATH won't be set)
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => false })
+      CaskEnv.send(:update_site_start_el, app_path)
+
+      content = File.read("#{site_lisp}/site-start.el")
+
+      # The code is added, but at runtime ns-emacs-plus-injected-path will be nil
+      # because EMACS_PLUS_PATH won't be present in the environment
+      assert_includes content, "ns-emacs-plus-injected-path"
+      assert_includes content, '(getenv "EMACS_PLUS_PATH")'
+    end
+  end
+
+  def test_update_site_start_el_skips_if_already_has_variable
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      original_content = <<~ELISP
+        ;;; site-start.el
+        (defconst ns-emacs-plus-version 30)
+        (defconst ns-emacs-plus-injected-path t)
+        (provide 'emacs-plus)
+      ELISP
+
+      File.write("#{site_lisp}/site-start.el", original_content)
+
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      CaskEnv.send(:update_site_start_el, app_path)
+
+      # Content should be unchanged
+      assert_equal original_content, File.read("#{site_lisp}/site-start.el")
+    end
+  end
+
+  def test_update_site_start_el_handles_missing_file
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      # Don't create site-start.el
+
+      # Should not raise error
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      CaskEnv.send(:update_site_start_el, app_path)
+    end
+  end
+
+  # ===========================================
+  # Tests for escape_for_applescript_shell
+  # ===========================================
+
+  def test_escape_for_applescript_shell_handles_single_quotes
+    result = CaskEnv.send(:escape_for_applescript_shell, "path'with'quotes")
+    # Single quotes escaped for shell (' -> '\''), then backslashes doubled for AppleScript
+    # Result: '\'' becomes '\\''
+    assert_includes result, "'\\\\''"
+  end
+
+  def test_escape_for_applescript_shell_handles_backslashes
+    result = CaskEnv.send(:escape_for_applescript_shell, "path\\with\\backslash")
+    # Backslashes should be doubled for AppleScript
+    assert_includes result, "\\\\"
+  end
+
+  def test_escape_for_applescript_shell_handles_normal_path
+    result = CaskEnv.send(:escape_for_applescript_shell, "/usr/bin:/opt/homebrew/bin")
+    assert_equal "/usr/bin:/opt/homebrew/bin", result
+  end
+end


### PR DESCRIPTION
## Summary

Add configurable user PATH injection for formula builds. This addresses the common issue where GUI Emacs doesn't have access to user's shell PATH.

**Key discovery:** macOS blocks `PATH` in LSEnvironment for security reasons, while allowing other env vars like `CC` and `LIBRARY_PATH`.

**Solution:** Store the desired PATH in a custom env var (`EMACS_PLUS_PATH`) via LSEnvironment, then have site-start.el read it at Emacs startup to set `exec-path` and `process-environment`.

### Formula builds
- Full user PATH captured via `ORIGINAL_PATHS` (set by Homebrew)
- `ns-emacs-plus-injected-path` is `t` when PATH was injected
- Configurable via `inject_path` option in build.yml (default: `true`)

### Cask builds
- PATH injection is **not available** (Homebrew limitation)
- Cask postflight runs in controlled environment without user's PATH
- `ns-emacs-plus-injected-path` is always `nil` for cask
- Native compilation works via `CC` and `LIBRARY_PATH`
- Users should use `exec-path-from-shell` or switch to formula

### Breaking changes
- Removed `EMACS_PLUS_NO_PATH_INJECTION` environment variable
- Replaced `native_comp_env` option with `inject_path` in build.yml

Closes #895