### PR TITLE
fix: use compile-time check for Tahoe scrolling patch

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -98,7 +98,7 @@ class EmacsPlusAT30 < EmacsBase
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
-  local_patch "fix-macos-tahoe-scrolling", sha: "a5abd2f0aa451a05939e9c257c43927243ab3348fd84a244c079e49f89dff895"
+  local_patch "fix-macos-tahoe-scrolling", sha: "847a38346c5d917c83ba8c28d63c85006e51e2c0e08c2a2343b3ec9a3f40e380"
 
   #
   # Install

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -87,7 +87,7 @@ class EmacsPlusAT31 < EmacsBase
   opoo "The option --with-imagemagick is deprecated and will be removed in a future version. Modern Emacs has native support for most image formats (SVG via librsvg, WebP, PNG, JPEG, GIF). If you rely on ImageMagick, please open an issue describing your use case." if build.with? "imagemagick"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
-  local_patch "fix-macos-tahoe-scrolling", sha: "8396ab7795daea1ce698ebdb03f573c07e8067e944dc74c87da8b64a3175603b"
+  local_patch "fix-macos-tahoe-scrolling", sha: "1774fcc0141c663f8d7051cc6a55f4e8233d31ebf5c3c8678e15a8a01d786de7"
 
   #
   # Install

--- a/patches/emacs-30/fix-macos-tahoe-scrolling.patch
+++ b/patches/emacs-30/fix-macos-tahoe-scrolling.patch
@@ -2,7 +2,7 @@ Fix macOS 26 (Tahoe) scrolling lag and input handling issues.
 
 macOS 26 introduced new event processing behavior that causes scrolling
 lag and input handling problems in Emacs. This patch disables two
-features via NSUserDefaults before the application is initialized:
+features via NSUserDefaults when built against the macOS 26 SDK:
 - NSEventConcurrentProcessingEnabled
 - NSApplicationUpdateCycleEnabled
 
@@ -12,19 +12,17 @@ See: https://bitbucket.org/mituharu/emacs-mac/
 diff --git a/src/nsterm.m b/src/nsterm.m
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -5642,6 +5642,17 @@ ns_term_init (Lisp_Object display_name)
+@@ -5642,6 +5642,15 @@ ns_term_init (Lisp_Object display_name)
    ns_pending_service_names = [[NSMutableArray alloc] init];
    ns_pending_service_args = [[NSMutableArray alloc] init];
 
-+#ifdef NS_IMPL_COCOA
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
 +  /* Disable problematic event processing on macOS 26 (Tahoe) to avoid
-+     scrolling lag and input handling issues.  */
-+  NSOperatingSystemVersion osVersion =
-+    [[NSProcessInfo processInfo] operatingSystemVersion];
-+  if (osVersion.majorVersion >= 26)
-+    [NSUserDefaults.standardUserDefaults
-+        registerDefaults:@{@"NSEventConcurrentProcessingEnabled" : @"NO",
-+          @"NSApplicationUpdateCycleEnabled" : @"NO"}];
++     scrolling lag and input handling issues.  These are undocumented
++     options as of macOS 26.0.  */
++  [NSUserDefaults.standardUserDefaults
++      registerDefaults:@{@"NSEventConcurrentProcessingEnabled" : @"NO",
++        @"NSApplicationUpdateCycleEnabled" : @"NO"}];
 +#endif
 +
    /* Start app and create the main menu, window, view.

--- a/patches/emacs-31/fix-macos-tahoe-scrolling.patch
+++ b/patches/emacs-31/fix-macos-tahoe-scrolling.patch
@@ -2,7 +2,7 @@ Fix macOS 26 (Tahoe) scrolling lag and input handling issues.
 
 macOS 26 introduced new event processing behavior that causes scrolling
 lag and input handling problems in Emacs. This patch disables two
-features via NSUserDefaults before the application is initialized:
+features via NSUserDefaults when built against the macOS 26 SDK:
 - NSEventConcurrentProcessingEnabled
 - NSApplicationUpdateCycleEnabled
 
@@ -12,19 +12,17 @@ See: https://bitbucket.org/mituharu/emacs-mac/
 diff --git a/src/nsterm.m b/src/nsterm.m
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -5837,6 +5837,17 @@ ns_term_init (Lisp_Object display_name)
+@@ -5837,6 +5837,15 @@ ns_term_init (Lisp_Object display_name)
    ns_pending_service_names = [[NSMutableArray alloc] init];
    ns_pending_service_args = [[NSMutableArray alloc] init];
 
-+#ifdef NS_IMPL_COCOA
++#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
 +  /* Disable problematic event processing on macOS 26 (Tahoe) to avoid
-+     scrolling lag and input handling issues.  */
-+  NSOperatingSystemVersion osVersion =
-+    [[NSProcessInfo processInfo] operatingSystemVersion];
-+  if (osVersion.majorVersion >= 26)
-+    [NSUserDefaults.standardUserDefaults
-+        registerDefaults:@{@"NSEventConcurrentProcessingEnabled" : @"NO",
-+          @"NSApplicationUpdateCycleEnabled" : @"NO"}];
++     scrolling lag and input handling issues.  These are undocumented
++     options as of macOS 26.0.  */
++  [NSUserDefaults.standardUserDefaults
++      registerDefaults:@{@"NSEventConcurrentProcessingEnabled" : @"NO",
++        @"NSApplicationUpdateCycleEnabled" : @"NO"}];
 +#endif
 +
    /* Start app and create the main menu, window, view.


### PR DESCRIPTION
## Summary

Per upstream feedback from Alan Third, replaces the runtime version check with a compile-time preprocessor check:

```objc
#if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 260000
```

This follows the standard pattern used in Emacs for macOS version-specific code. The value `260000` is confirmed from the macOS SDK header (`__MAC_26_0`).