### PR TITLE
feat: support local file paths for external patches

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,26 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-01-29
+
+** New Features
+
+*** Local file paths for patches
+
+External patches in =build.yml= now support local file paths in addition to URLs. This makes configurations portable across machines.
+
+#+begin_src yaml
+patches:
+  - my-patch:
+      url: ~/.config/emacs-plus/my-patch.patch
+      sha256: abc123...
+  - another-patch:
+      url: ./relative-to-config.patch
+      sha256: def456...
+#+end_src
+
+Supported path formats: absolute (=/path/to/patch=), home-relative (=~/path=), and relative (=./path=, =../path=). Relative paths resolve against the directory containing =build.yml=.
+
 * 2026-01-26
 
 ** Bug Fixes

--- a/README.org
+++ b/README.org
@@ -489,6 +489,12 @@ icon: modern-purple-flat
 # Apply community patches
 # patches:
 #   - patch-name-from-registry
+#   - my-patch:
+#       url: https://example.com/external.patch
+#       sha256: abc123...
+#   - local-patch:
+#       url: ~/.config/emacs-plus/my-local.patch
+#       sha256: abc123...
 #+end_src
 
 Then rebuild Emacs:

--- a/community/README.md
+++ b/community/README.md
@@ -26,7 +26,7 @@ This directory contains community-maintained patches and icons for Emacs+.
 - No SLA - can break
 
 ### Wild-West
-- Any external URL
+- Any external URL or local file path
 - Requires SHA256 hash
 - Maximum flexibility
 
@@ -40,6 +40,12 @@ patches:
   - my-patch:
       url: https://example.com/external.patch
       sha256: abc123...
+  - local-patch:
+      url: ~/.config/emacs-plus/my-local.patch
+      sha256: abc123...
+  - relative-patch:
+      url: ./my-relative.patch   # relative to build.yml directory
+      sha256: abc123...
 
 icon: icon-name-from-registry
 # OR
@@ -47,6 +53,8 @@ icon:
   url: https://example.com/external.icns
   sha256: def456...
 ```
+
+Local file paths (`/absolute/path`, `~/home/path`, `./relative/path`) are supported for patches. Relative paths are resolved relative to the directory containing `build.yml`.
 
 See `registry.json` for available features.
 


### PR DESCRIPTION
## Summary

- Support local file paths (`/absolute`, `~/home`, `./relative`) in patch `url` fields in `build.yml`
- Relative paths resolve against the `build.yml` directory, making configs portable across machines
- SHA256 verification is enforced for local patches just like external ones
- Uses `Etc.getpwuid.dir` for `~` expansion to handle Homebrew's sandboxed `HOME`

Closes #909