### PR TITLE
Auto-update /Applications/Emacs.app in post_install

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -228,17 +228,8 @@ class EmacsPlusAT31 < EmacsBase
       (bin/"emacs").unlink # Kill the existing symlink
       (bin/"emacs").write <<~EOS
         #!/bin/bash
-        EXPECTED_VERSION="#{version}"
         for app in "/Applications/Emacs.app" "$HOME/Applications/Emacs.app" "#{prefix}/Emacs.app"; do
           if [ -x "$app/Contents/MacOS/Emacs" ]; then
-            # Warn if a user-copied app has a different version than the installed formula
-            if [ "$app" != "#{prefix}/Emacs.app" ]; then
-              found_version=$("$app/Contents/MacOS/Emacs" --version 2>/dev/null | head -1 | sed 's/GNU Emacs //')
-              if [ -n "$found_version" ] && [ "$found_version" != "$EXPECTED_VERSION" ]; then
-                echo "Warning: $app is version $found_version (expected $EXPECTED_VERSION)" >&2
-                echo "Update with: cp -r #{prefix}/Emacs.app \\\"\\${app%Emacs.app}\\\"" >&2
-              fi
-            fi
             exec "$app/Contents/MacOS/Emacs" "$@"
           fi
         done
@@ -305,6 +296,24 @@ class EmacsPlusAT31 < EmacsBase
     if client_path.exist?
       system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s
     end
+
+    # Auto-update /Applications copies if they exist (prevents stale binary issues, see #912)
+    {"Emacs.app" => prefix/"Emacs.app", "Emacs Client.app" => prefix/"Emacs Client.app"}.each do |name, src|
+      ["/Applications/#{name}", "#{Dir.home}/Applications/#{name}"].each do |app_dest|
+        if File.exist?(app_dest) && src.exist?
+          ohai "Updating #{app_dest}..."
+          begin
+            FileUtils.rm_rf(app_dest)
+            FileUtils.cp_r(src.to_s, app_dest)
+            system "codesign", "--force", "--deep", "--sign", "-", app_dest
+          rescue => e
+            opoo "Could not update #{app_dest}: #{e.message}"
+            opoo "Update manually: cp -r #{src} \"#{File.dirname(app_dest)}/\""
+          end
+        end
+      end
+    end
+
   end
 
   def caveats


### PR DESCRIPTION
## Summary

After `brew reinstall emacs-plus@XX`, users who previously copied Emacs.app to `/Applications` may still be running a stale binary. This causes confusing errors like the `libjpeg.9.dylib` issue in #912 — the Cellar copy is rebuilt but the `/Applications` copy isn't.

This PR adds auto-update logic to `post_install`: if an existing `/Applications/Emacs.app` (or `~/Applications/Emacs.app`) is detected, it's automatically refreshed from the newly built Cellar copy.

## Changes

- Added auto-update of `/Applications` copies in `post_install` for @29, @30, and @31
- Handles both `Emacs.app` and `Emacs Client.app` (for @30 and @31)
- Re-signs after copy for macOS Sequoia compatibility
- Graceful error handling — warns but doesn't fail if permissions prevent the update

## Why post_install instead of runtime check?

Per [feedback from @d12frosted](https://github.com/d12frosted/homebrew-emacs-plus/pull/914#issuecomment-3895891839):

- **Solves the root cause**: The #912 scenario involves unchanged versions but stale dylib linkage — a version check wouldn't catch it
- **No runtime overhead**: No `--version` spawn on every launch
- **Works for GUI**: No stderr warning that vanishes before users can read it
- **Prevention > detection**: Keeping the copy in sync is better than warning about drift

## Motivation

See #912