### PR TITLE
fix(emacs-plus@30,31): refresh x-colors during NS window system init

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -87,6 +87,7 @@ jobs:
             "round-undecorated-frame"
             "mac-font-use-typo-metrics"
             "fix-macos-tahoe-scrolling"
+            "fix-ns-x-colors"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"
@@ -469,6 +470,7 @@ jobs:
             "system-appearance"
             "round-undecorated-frame"
             "mac-font-use-typo-metrics"
+            "fix-ns-x-colors"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -99,6 +99,7 @@ class EmacsPlusAT30 < EmacsBase
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
   local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
   local_patch "fix-macos-tahoe-scrolling", sha: "847a38346c5d917c83ba8c28d63c85006e51e2c0e08c2a2343b3ec9a3f40e380"
+  local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
 
   #
   # Install

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -87,6 +87,7 @@ class EmacsPlusAT31 < EmacsBase
   opoo "The option --with-imagemagick is deprecated and will be removed in a future version. Modern Emacs has native support for most image formats (SVG via librsvg, WebP, PNG, JPEG, GIF). If you rely on ImageMagick, please open an issue describing your use case." if build.with? "imagemagick"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
+  local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
 
   #
   # Install

--- a/patches/emacs-30/fix-ns-x-colors.patch
+++ b/patches/emacs-30/fix-ns-x-colors.patch
@@ -1,0 +1,27 @@
+Refresh x-colors during NS window system initialization
+
+On NS Emacs, x-colors is set by calling ns-list-colors at dump time
+(in common-win.el).  When the dump is created in a headless environment,
+ns-list-colors returns only ~62 colors, while at runtime with a display
+it returns the full list (~800+).
+
+Refresh x-colors from ns-list-colors during window-system-initialization
+for NS, when the display is available.
+
+* lisp/term/ns-win.el (window-system-initialization): Refresh x-colors.
+
+diff --git a/lisp/term/ns-win.el b/lisp/term/ns-win.el
+--- a/lisp/term/ns-win.el
++++ b/lisp/term/ns-win.el
+@@ -872,6 +872,11 @@ See the documentation of `create-fontset-from-fontset-spec' for the format.")
+
+   (x-apply-session-resources)
+
++  ;; Refresh x-colors now that the display is available.  The value
++  ;; from the dump may have been captured in a headless environment
++  ;; where ns-list-colors returns a limited set.
++  (setq x-colors (ns-list-colors))
++
+   ;; Don't let Emacs suspend under NS.
+   (add-hook 'suspend-hook 'ns-suspend-error)
+

--- a/patches/emacs-31/fix-ns-x-colors.patch
+++ b/patches/emacs-31/fix-ns-x-colors.patch
@@ -1,0 +1,27 @@
+Refresh x-colors during NS window system initialization
+
+On NS Emacs, x-colors is set by calling ns-list-colors at dump time
+(in common-win.el).  When the dump is created in a headless environment,
+ns-list-colors returns only ~62 colors, while at runtime with a display
+it returns the full list (~800+).
+
+Refresh x-colors from ns-list-colors during window-system-initialization
+for NS, when the display is available.
+
+* lisp/term/ns-win.el (window-system-initialization): Refresh x-colors.
+
+diff --git a/lisp/term/ns-win.el b/lisp/term/ns-win.el
+--- a/lisp/term/ns-win.el
++++ b/lisp/term/ns-win.el
+@@ -872,6 +872,11 @@ See the documentation of `create-fontset-from-fontset-spec' for the format.")
+
+   (x-apply-session-resources)
+
++  ;; Refresh x-colors now that the display is available.  The value
++  ;; from the dump may have been captured in a headless environment
++  ;; where ns-list-colors returns a limited set.
++  (setq x-colors (ns-list-colors))
++
+   ;; Don't let Emacs suspend under NS.
+   (add-hook 'suspend-hook 'ns-suspend-error)
+


### PR DESCRIPTION
## Summary

- Fix `x-colors` being limited to ~62 colors instead of ~800+ on NS Emacs
- Affects packages that rely on `x-colors`: `helm-colors`, `rainbow-mode`, `color-name-rgb-alist`, etc.

## Root cause

On NS Emacs, `x-colors` is set by calling `ns-list-colors` at dump time (in `common-win.el`). When the dump is created in a headless environment (like CI for cask builds), `ns-list-colors` returns only ~62 colors. At runtime with a display, it returns the full list (~800+).

## Fix

Refresh `x-colors` from `ns-list-colors` during `window-system-initialization` for NS, when the display is available.

Closes #911