### PR TITLE
Only remove quarantine xattr instead of clearing all

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -54,10 +54,10 @@ cask "emacs-plus-app" do
   # Remove quarantine attribute, inject PATH, and apply custom icon
   postflight do
     system_command "/usr/bin/xattr",
-                   args: ["-cr", "#{appdir}/Emacs.app"],
+                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs.app"],
                    sudo: false
     system_command "/usr/bin/xattr",
-                   args: ["-cr", "#{appdir}/Emacs Client.app"],
+                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs Client.app"],
                    sudo: false
 
     # Environment setup for native compilation and CLI usage

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -54,10 +54,10 @@ cask "emacs-plus-app@master" do
   # Remove quarantine attribute, inject PATH, and apply custom icon
   postflight do
     system_command "/usr/bin/xattr",
-                   args: ["-cr", "#{appdir}/Emacs.app"],
+                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs.app"],
                    sudo: false
     system_command "/usr/bin/xattr",
-                   args: ["-cr", "#{appdir}/Emacs Client.app"],
+                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs Client.app"],
                    sudo: false
 
     # Environment setup for native compilation and CLI usage


### PR DESCRIPTION
## Summary

- Replace `xattr -cr` with `xattr -r -d com.apple.quarantine` in both cask files
- This preserves other extended attributes that may be set by security software or other tools, while still removing the macOS quarantine flag that prevents Emacs from launching

Closes #920