### PR TITLE
fix(emacs-plus@30): add explicit version to prevent nil when using custom revision

### DIFF
--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -2,6 +2,7 @@ require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
   init 30
+  version "30.2"
   url "https://ftpmirror.gnu.org/emacs/emacs-30.2.tar.xz"
   mirror "https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz"
   sha256 "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"


### PR DESCRIPTION
## Summary

- When a custom `revision` is set in `build.yml`, lines 88-92 of the formula replace the stable tarball URL with a git URL (`https://github.com/emacs-mirror/emacs.git`). Homebrew extracts the version from the URL, but the git URL contains no version info, so `version` becomes `nil` and Homebrew errors out.
- Adding an explicit `version "30.2"` declaration (matching the pattern already used in `emacs-plus@31`) ensures the version is always defined regardless of URL overrides.

Closes #919