### PR TITLE
refactor: consolidate version/URL declarations into init

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -1,10 +1,7 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT26 < EmacsBase
-  init 26
-  url "https://ftpmirror.gnu.org/emacs/emacs-26.3.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/emacs/emacs-26.3.tar.xz"
-  sha256 "4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485"
+  init "26.3", sha256: "4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -1,17 +1,10 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT27 < EmacsBase
-  init 27
-  url "https://ftpmirror.gnu.org/emacs/emacs-27.2.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/emacs/emacs-27.2.tar.xz"
-  sha256 "b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9"
+  init "27.2", sha256: "b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9", branch: "emacs-27"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-
-  head do
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-27"
-  end
 
   #
   # Options

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -1,17 +1,10 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT28 < EmacsBase
-  init 28
-  url "https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.xz"
-  sha256 "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488"
+  init "28.2", sha256: "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488", branch: "emacs-28"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-
-  head do
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-28"
-  end
 
   #
   # Options

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -1,17 +1,10 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT29 < EmacsBase
-  init 29
-  url "https://ftpmirror.gnu.org/emacs/emacs-29.4.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
-  sha256 "ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235"
+  init "29.4", sha256: "ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235", branch: "emacs-29"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-
-  head do
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-29"
-  end
 
   #
   # Options

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -1,24 +1,10 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT30 < EmacsBase
-  init 30
-  version "30.2"
-  url "https://ftpmirror.gnu.org/emacs/emacs-30.2.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz"
-  sha256 "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9"
+  init "30.2", sha256: "b3f36f18a6dd2715713370166257de2fae01f9d38cfe878ced9b1e6ded5befd9", branch: "emacs-30"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-
-  head do
-    if (config_revision = EmacsBase.revision_from_config(30))
-      url "https://github.com/emacs-mirror/emacs.git", :revision => config_revision
-    elsif ENV['HOMEBREW_EMACS_PLUS_30_REVISION']
-      url "https://github.com/emacs-mirror/emacs.git", :revision => ENV['HOMEBREW_EMACS_PLUS_30_REVISION']
-    else
-      url "https://github.com/emacs-mirror/emacs.git", :branch => "emacs-30"
-    end
-  end
 
   #
   # Options
@@ -80,16 +66,6 @@ class EmacsPlusAT30 < EmacsBase
     unless (build.with? "cocoa") && (build.without? "x11")
       odie "--with-xwidgets is not available when building --with-x11"
     end
-  end
-
-  #
-  # URL
-  #
-
-  if (config_revision = EmacsBase.revision_from_config(30))
-    url "https://github.com/emacs-mirror/emacs.git", :revision => config_revision
-  elsif ENV['HOMEBREW_EMACS_PLUS_30_REVISION']
-    url "https://github.com/emacs-mirror/emacs.git", :revision => ENV['HOMEBREW_EMACS_PLUS_30_REVISION']
   end
 
   #

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -1,8 +1,7 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT31 < EmacsBase
-  init 31
-  version "31.0.50"
+  init "31.0.50", branch: "master"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -66,18 +65,6 @@ class EmacsPlusAT31 < EmacsBase
     unless (build.with? "cocoa") && (build.without? "x11")
       odie "--with-xwidgets is not available when building --with-x11"
     end
-  end
-
-  #
-  # URL
-  #
-
-  if (config_revision = EmacsBase.revision_from_config(31))
-    url "https://github.com/emacs-mirror/emacs.git", :revision => config_revision
-  elsif ENV['HOMEBREW_EMACS_PLUS_31_REVISION']
-    url "https://github.com/emacs-mirror/emacs.git", :revision => ENV['HOMEBREW_EMACS_PLUS_31_REVISION']
-  else
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "master"
   end
 
   #


### PR DESCRIPTION
## Summary

- Moves `version`, `url`, `mirror`, `sha256`, and `head` block setup into `EmacsBase.init` so each formula declares version info exactly once:
  - Stable: `init "30.2", sha256: "...", branch: "emacs-30"`
  - Dev: `init "31.0.50", branch: "master"`
- Adds `EMACS_GIT_URL` constant and `resolve_revision` helper to centralize git URL and revision logic
- All formulas now uniformly support `build.yml` revision pinning (previously only @30 and @31)
- Fixes #919 by design — explicit `version` is always set regardless of URL overrides

Follows up on #922 which was the quick fix.