### PR TITLE
fix: Preserve frame geometry when toggling `undecorated-round`

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -80,7 +80,7 @@ class EmacsPlusAT29 < EmacsBase
   local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
-  local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
+  local_patch "round-undecorated-frame", sha: "7e39e694ce9dca50db72c09be442c1278d1900d69c2402f289742aeae8ea4c3e"
 
   #
   # Install

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -74,7 +74,7 @@ class EmacsPlusAT30 < EmacsBase
 
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "9eb3ce80640025bff96ebaeb5893430116368d6349f4eb0cb4ef8b3d58477db6"
-  local_patch "round-undecorated-frame", sha: "7451f80f559840e54e6a052e55d1100778abc55f98f1d0c038a24e25773f2874"
+  local_patch "round-undecorated-frame", sha: "7e39e694ce9dca50db72c09be442c1278d1900d69c2402f289742aeae8ea4c3e"
   local_patch "fix-macos-tahoe-scrolling", sha: "847a38346c5d917c83ba8c28d63c85006e51e2c0e08c2a2343b3ec9a3f40e380"
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
 

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -74,7 +74,7 @@ class EmacsPlusAT31 < EmacsBase
   opoo "The option --with-imagemagick is deprecated and will be removed in a future version. Modern Emacs has native support for most image formats (SVG via librsvg, WebP, PNG, JPEG, GIF). If you rely on ImageMagick, please open an issue describing your use case." if build.with? "imagemagick"
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
-  local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
+  local_patch "round-undecorated-frame", sha: "c9430a1ead81e313b3d2877ff6f8044fb29441eecc7cc42000515d7c8ec6380f"
 
   #
   # Install

--- a/patches/emacs-29/round-undecorated-frame.patch
+++ b/patches/emacs-29/round-undecorated-frame.patch
@@ -110,7 +110,7 @@ diff --git a/src/nsterm.m b/src/nsterm.m
 index 82fe58e90e..f132a9591d 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -1798,6 +1798,44 @@ Hide the window (X11 semantics)
+@@ -1798,6 +1798,55 @@ Hide the window (X11 semantics)
      }
  }
  
@@ -139,6 +139,17 @@ index 82fe58e90e..f132a9591d 100644
 +
 +      newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
 +
++      /* initWithEmacsFrame: builds the new window at the default size derived
++         from the frame's columns and rows, not at the current window size.
++         The EmacsView is reused, so its fullscreen state (fs_state) carries
++         over to the new window.  Copy the old window's frame here; otherwise a
++         frame that was maximized or resized before `undecorated-round' was
++         toggled comes back at the default size while fs_state still reports it
++         as, say, FULLSCREEN_MAXIMIZED.  The window would then look
++         un-maximized until a later fullscreen or zoom action applied the real
++         geometry.  */
++      [newWindow setFrame:[oldWindow frame] display:NO];
++
 +      if ([oldWindow isKeyWindow])
 +        [newWindow makeKeyAndOrderFront:NSApp];
 +
@@ -155,7 +166,7 @@ index 82fe58e90e..f132a9591d 100644
  void
  ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
  /* --------------------------------------------------------------------------
-@@ -9039,6 +9077,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9039,6 +9088,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  		 | NSWindowStyleMaskMiniaturizable
  		 | NSWindowStyleMaskClosable);
  
@@ -167,7 +178,7 @@ index 82fe58e90e..f132a9591d 100644
    last_drag_event = nil;
  
    width = FRAME_TEXT_COLS_TO_PIXEL_WIDTH (f, f->text_cols);
-@@ -9122,13 +9165,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9122,13 +9176,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  #endif
      }
  

--- a/patches/emacs-30/round-undecorated-frame.patch
+++ b/patches/emacs-30/round-undecorated-frame.patch
@@ -110,7 +110,7 @@ diff --git a/src/nsterm.m b/src/nsterm.m
 index 82fe58e90e..f132a9591d 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -1798,6 +1798,44 @@ Hide the window (X11 semantics)
+@@ -1798,6 +1798,55 @@ Hide the window (X11 semantics)
      }
  }
  
@@ -139,6 +139,17 @@ index 82fe58e90e..f132a9591d 100644
 +
 +      newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
 +
++      /* initWithEmacsFrame: builds the new window at the default size derived
++         from the frame's columns and rows, not at the current window size.
++         The EmacsView is reused, so its fullscreen state (fs_state) carries
++         over to the new window.  Copy the old window's frame here; otherwise a
++         frame that was maximized or resized before `undecorated-round' was
++         toggled comes back at the default size while fs_state still reports it
++         as, say, FULLSCREEN_MAXIMIZED.  The window would then look
++         un-maximized until a later fullscreen or zoom action applied the real
++         geometry.  */
++      [newWindow setFrame:[oldWindow frame] display:NO];
++
 +      if ([oldWindow isKeyWindow])
 +        [newWindow makeKeyAndOrderFront:NSApp];
 +
@@ -155,7 +166,7 @@ index 82fe58e90e..f132a9591d 100644
  void
  ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
  /* --------------------------------------------------------------------------
-@@ -9039,6 +9077,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9039,6 +9088,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  		 | NSWindowStyleMaskMiniaturizable
  		 | NSWindowStyleMaskClosable);
  
@@ -167,7 +178,7 @@ index 82fe58e90e..f132a9591d 100644
    last_drag_event = nil;
  
    width = FRAME_TEXT_COLS_TO_PIXEL_WIDTH (f, f->text_cols);
-@@ -9122,13 +9165,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9122,13 +9176,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  #endif
      }
  

--- a/patches/emacs-31/round-undecorated-frame.patch
+++ b/patches/emacs-31/round-undecorated-frame.patch
@@ -102,7 +102,7 @@ diff --git a/src/nsterm.m b/src/nsterm.m
 index 89664ad3f4d..0aa17a7fa10 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -1810,6 +1810,44 @@ Hide the window (X11 semantics)
+@@ -1810,6 +1810,55 @@ Hide the window (X11 semantics)
      }
  }
  
@@ -131,6 +131,17 @@ index 89664ad3f4d..0aa17a7fa10 100644
 +
 +      newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
 +
++      /* initWithEmacsFrame: builds the new window at the default size derived
++         from the frame's columns and rows, not at the current window size.
++         The EmacsView is reused, so its fullscreen state (fs_state) carries
++         over to the new window.  Copy the old window's frame here; otherwise a
++         frame that was maximized or resized before `undecorated-round' was
++         toggled comes back at the default size while fs_state still reports it
++         as, say, FULLSCREEN_MAXIMIZED.  The window would then look
++         un-maximized until a later fullscreen or zoom action applied the real
++         geometry.  */
++      [newWindow setFrame:[oldWindow frame] display:NO];
++
 +      if ([oldWindow isKeyWindow])
 +        [newWindow makeKeyAndOrderFront:NSApp];
 +
@@ -147,7 +158,7 @@ index 89664ad3f4d..0aa17a7fa10 100644
  void
  ns_set_parent_frame (struct frame *f, Lisp_Object new_value, Lisp_Object old_value)
  /* --------------------------------------------------------------------------
-@@ -9360,6 +9398,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9360,6 +9409,11 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  		 | NSWindowStyleMaskMiniaturizable
  		 | NSWindowStyleMaskClosable);
  
@@ -159,7 +170,7 @@ index 89664ad3f4d..0aa17a7fa10 100644
    last_drag_event = nil;
  
    width = FRAME_TEXT_COLS_TO_PIXEL_WIDTH (f, f->text_cols);
-@@ -9443,13 +9486,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
+@@ -9443,13 +9497,22 @@ - (instancetype) initWithEmacsFrame: (struct frame *) f
  #endif
      }
  


### PR DESCRIPTION
## Summary

Toggling the `undecorated-round` frame parameter at runtime resizes the
frame back to the default `text-cols × text-lines` size, even when the
frame was maximized (or had been resized). The window shrinks, while
Emacs still believes the frame is maximized.

This affects the `round-undecorated-frame` patch for emacs-29, emacs-30,
and emacs-31. The fix is one line per patch variant.

## Reproduction

`emacs -Q` on an emacs-plus build (macOS):

```elisp
(setq ns-use-native-fullscreen nil)
(set-frame-parameter nil 'fullscreen 'maximized)   ;; frame fills the screen
(set-frame-parameter nil 'undecorated-round t)     ;; <-- remove window decorations
```

**Before:** the second call leaves a small, default-sized window in a
random position, even though `(frame-parameter nil 'fullscreen)` still
returns `maximized`.

**After:** the window keeps its maximized size and position.

The same mismatch shows up later as confusing behavior: because the
window is the default size but Emacs records it as maximized, the *next*
`toggle-frame-fullscreen` cycle is what first applies the real maximized
geometry, so the window appears to "snap" to full size at an unexpected
moment.

## Root cause

`ns_set_undecorated_round` changes the style mask by tearing down the
window and building a new one:

```objc
newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];
```

`initWithEmacsFrame:` sizes the new window from the frame's
`text-cols × text-lines`, i.e. the default geometry. The `EmacsView` is
reused, so its `fs_state` still says `FULLSCREEN_MAXIMIZED` — but nothing
reapplies that geometry to the freshly built window. The result is a
window whose size no longer matches the fullscreen state Emacs is
tracking.

This is a pre-existing upstream pattern, not something the round-corners patch
introduced; this patch just inherited it. The stock `ns_set_undecorated` suffer
from the same problem, but it is out of the scope of this PR and this patch.

## Fix

Copy the old window's frame onto the new one right after it is created,
so the rebuilt window keeps its size and position:

```objc
newWindow = [[EmacsWindow alloc] initWithEmacsFrame:f];

/* initWithEmacsFrame: builds the new window at the default size derived
   from the frame's columns and rows, not at the current window size.
   The EmacsView is reused, so its fullscreen state (fs_state) carries
   over to the new window.  Copy the old window's frame here; otherwise a
   frame that was maximized or resized before `undecorated-round' was
   toggled comes back at the default size while fs_state still reports it
   as, say, FULLSCREEN_MAXIMIZED.  The window would then look
   un-maximized until a later fullscreen or zoom action applied the real
   geometry.  */
[newWindow setFrame:[oldWindow frame] display:NO];
```

## Scope

- `patches/emacs-29/round-undecorated-frame.patch`
- `patches/emacs-30/round-undecorated-frame.patch`
- `patches/emacs-31/round-undecorated-frame.patch`

Each adds the one `setFrame:` call (plus the explanatory comment) inside
`ns_set_undecorated_round`. No other behavior changes.


## Verification

- All three patches apply cleanly with GNU `patch` (the tool the formulae
  use via `local_patch`, i.e. `patch -g0 -f -p1`) to the exact release
  each formula builds — emacs 29.4, 30.2 and 31.0.60 — with no failed
  hunks.
- `git apply --check` additionally succeeds for the emacs-29 and emacs-31
  patches. The emacs-30 patch fails `git apply` only at an unrelated,
  pre-existing `src/nsfns.m` hunk that this change does not touch (the
  original patch fails there identically); GNU `patch` applies it cleanly,
  which is what the build uses.
- Built Emacs from the patched source and confirmed the behavior: a
  maximized `undecorated-round` frame now keeps its geometry when the
  parameter is set at runtime, and its fullscreen state stays consistent
  with what is shown on screen.
