### PR TITLE
fix(emacs-plus@32): fix broken patch SHA for round-undecorated-frame

### DIFF
--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -72,7 +72,7 @@ class EmacsPlusAT32 < EmacsBase
 
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
-  local_patch "round-undecorated-frame", sha: "26947b6724fc29fadd44889808c5cf0b4ce6278cf04f46086a21df50c8c4151d"
+  local_patch "round-undecorated-frame", sha: "c9430a1ead81e313b3d2877ff6f8044fb29441eecc7cc42000515d7c8ec6380f"
 
   #
   # Install


### PR DESCRIPTION
The `round-undecorated-frame` patch SHA was outdated after the patch was updated in #943, causing `brew install emacs-plus@32` to fail during the patch phase.

Update the SHA to match the current patch content.