### PR TITLE
Disable MacOS 26 Tahoe "AutoFill (Emacs)" process

### DIFF
--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -640,6 +640,10 @@ class EmacsBase < Formula
     system "/usr/libexec/PlistBuddy -c 'Set NSMicrophoneUsageDescription Emacs requires permission to access the Microphone.' '#{plist}'"
     system "/usr/libexec/PlistBuddy -c 'Add NSSpeechRecognitionUsageDescription string' '#{plist}' || true"
     system "/usr/libexec/PlistBuddy -c 'Set NSSpeechRecognitionUsageDescription Emacs requires permission to handle any speech recognition.' '#{plist}' || true"
+
+    # Prevent macOS from heuristically offering one-time-code AutoFill in Emacs text fields
+    system "/usr/libexec/PlistBuddy -c 'Add NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac bool true' '#{plist}'"
+
     system "touch '#{app}'"
   end
 


### PR DESCRIPTION
On MacOS Tahoe, I observed a running process called "AutoFill (Emacs)" alongside the Emacs app. That seems unnecessary for regular Emacs usage since it's intended for one-time codes.

This adds a plist option to make autofill default to off. Since adding it I haven't seen that process reappear.

See: https://developer.apple.com/documentation/bundleresources/information-property-list/nsautofillrequirestextcontenttypeforonetimecodeonmac

(AI-assisted solution)