### PR TITLE
refactor: follow-ups for AutoFill plist key (#947)

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -203,7 +203,7 @@ class EmacsPlusAT28 < EmacsBase
       inject_path
 
       # inject description for protected resources usage
-      inject_protected_resources_usage_desc
+      inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
       (bin/"emacs").unlink # Kill the existing symlink

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -211,7 +211,7 @@ class EmacsPlusAT29 < EmacsBase
       inject_path
 
       # inject description for protected resources usage
-      inject_protected_resources_usage_desc
+      inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
       # Check multiple locations so users can copy Emacs.app to /Applications

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -210,7 +210,7 @@ class EmacsPlusAT30 < EmacsBase
       inject_path
 
       # inject description for protected resources usage
-      inject_protected_resources_usage_desc
+      inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
       # Check multiple locations so users can copy Emacs.app to /Applications

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -208,7 +208,7 @@ class EmacsPlusAT31 < EmacsBase
       inject_path
 
       # inject description for protected resources usage
-      inject_protected_resources_usage_desc
+      inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
       # Check multiple locations so users can copy Emacs.app to /Applications

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -192,7 +192,7 @@ class EmacsPlusAT32 < EmacsBase
       inject_path
 
       # inject description for protected resources usage
-      inject_protected_resources_usage_desc
+      inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
       # Check multiple locations so users can copy Emacs.app to /Applications

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -629,8 +629,11 @@ class EmacsBase < Formula
     }
   end
 
-  def inject_protected_resources_usage_desc
-    ohai "Injecting description for protected resources usage"
+  # Inject Emacs Plus customizations into Emacs.app Info.plist: usage
+  # descriptions for protected resources (camera, microphone, speech
+  # recognition) and AutoFill opt-out.
+  def inject_plist_extras
+    ohai "Injecting Info.plist extras"
     app = "#{prefix}/Emacs.app"
     plist = "#{app}/Contents/Info.plist"
 

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -642,7 +642,7 @@ class EmacsBase < Formula
     system "/usr/libexec/PlistBuddy -c 'Set NSSpeechRecognitionUsageDescription Emacs requires permission to handle any speech recognition.' '#{plist}' || true"
 
     # Prevent macOS from heuristically offering one-time-code AutoFill in Emacs text fields
-    system "/usr/libexec/PlistBuddy -c 'Add NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac bool true' '#{plist}'"
+    plist_set plist, "NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac", "bool", true
 
     system "touch '#{app}'"
   end

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,14 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-06-10
+
+** Bug Fixes
+
+*** =AutoFill (Emacs)= helper process disabled on macOS 26 (Tahoe)
+
+On macOS 26 (Tahoe), the system spawns an =AutoFill (Emacs)= helper process alongside Emacs that heuristically scans text fields for one-time codes. Emacs never marks fields as one-time-code, so the helper is pure overhead. All builds now set =NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac= in =Info.plist=, which prevents the helper from launching.
+
 * 2026-05-10
 
 ** New Features


### PR DESCRIPTION
Follow-ups discussed in #947:

- Use the plist_set helper (add-or-set) for NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac instead of a bare PlistBuddy Add. Homebrew's system raises on non-zero exit, so a bare Add would break the build if upstream Emacs ever ships this key in its Info.plist template.
- Rename inject_protected_resources_usage_desc to inject_plist_extras, since the method now injects both protected resources usage descriptions and the AutoFill opt-out.
- Add a NEWS entry documenting the AutoFill (Emacs) process fix.

No functional change to the built app.