### PR TITLE
fix(ci): update Homebrew before installing formulas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # The runner image ships a stale Homebrew, while formula metadata
+      # comes fresh from the JSON API. When homebrew-core starts using a
+      # feature the bundled brew does not know yet (e.g. the install
+      # steps framework), dependency installation fails with errors like
+      # "unknown install step: gdk_pixbuf_query_loaders".
+      - name: Update Homebrew
+        run: brew update
+
       - name: Build emacs-plus@30
         run: |
           export HOMEBREW_DEVELOPER=1
-          brew install Formula/emacs-plus@30.rb --verbose
+          brew install --formula Formula/emacs-plus@30.rb --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,14 @@ jobs:
             build_opts: "--with-xwidgets"
 
     steps:
+      # The runner image ships a stale Homebrew, while formula metadata
+      # comes fresh from the JSON API. When homebrew-core starts using a
+      # feature the bundled brew does not know yet (e.g. the install
+      # steps framework), dependency installation fails with errors like
+      # "unknown install step: gdk_pixbuf_query_loaders".
+      - name: Update Homebrew
+        run: brew update
+
       - name: Tap emacs-plus
         run: brew tap d12frosted/emacs-plus
 

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -20,11 +20,14 @@ class EmacsBase < Formula
   def self.init(version_str, sha256: nil, branch: nil)
     major_version = version_str.split(".").first.to_i
     @@urlResolver = UrlResolver.new(major_version, ENV["HOMEBREW_EMACS_PLUS_MODE"] || "remote")
-    # Capture formula_root at class load time (before Homebrew changes working directory)
+    # Derive formula_root from this file's location (Library/..) rather
+    # than Dir.pwd: since Homebrew 5.1.15 formulas are loaded inside the
+    # build sandbox whose working directory is a temporary directory
+    # unrelated to the checkout.
     @@formula_root = begin
       tap = Tap.fetch(TAP_OWNER, TAP_REPO)
       ENV["HOMEBREW_EMACS_PLUS_MODE"] == "local" || !tap.installed? ?
-        Dir.pwd : tap.path.to_s
+        UrlResolver::REPO_ROOT : tap.path.to_s
     end
 
     # Always set explicit version to prevent nil when URL is overridden

--- a/Library/UrlResolver.rb
+++ b/Library/UrlResolver.rb
@@ -3,13 +3,19 @@ TAP_OWNER = "d12frosted" unless defined?(TAP_OWNER)
 TAP_REPO = "emacs-plus" unless defined?(TAP_REPO)
 
 class UrlResolver
+  # Repository root derived from this file's location (Library/..).
+  # Do not use Dir.pwd here: since Homebrew 5.1.15 formulas are loaded
+  # inside the build sandbox whose working directory is a temporary
+  # directory unrelated to the checkout.
+  REPO_ROOT = File.expand_path("..", __dir__) unless defined?(REPO_ROOT)
+
   def initialize(version, mode)
     name = "#{TAP_REPO}@#{version}"
     tap = Tap.fetch(TAP_OWNER, TAP_REPO)
     @version = version
     @formula_root =
       mode == "local" || !tap.installed? ?
-        Dir.pwd :
+        REPO_ROOT :
         (tap.path.to_s.delete_suffix "/Formula/#{name}.rb")
   end
 

--- a/tests/test_url_resolver.rb
+++ b/tests/test_url_resolver.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test suite for UrlResolver formula root resolution
+#
+# Run with: ruby tests/test_url_resolver.rb
+
+require 'minitest/autorun'
+require 'tmpdir'
+
+# Mock Homebrew's Tap for testing without Homebrew
+class Tap
+  class << self
+    attr_accessor :mock_installed, :mock_path
+
+    def fetch(_owner, _repo)
+      new
+    end
+  end
+
+  def installed?
+    self.class.mock_installed
+  end
+
+  def path
+    self.class.mock_path
+  end
+end
+
+require_relative '../Library/UrlResolver'
+
+class TestUrlResolver < Minitest::Test
+  REPO_ROOT = File.expand_path('..', __dir__)
+
+  # Construct a resolver from inside an unrelated temporary directory to
+  # simulate Homebrew's sandboxed build, which loads the formula with a
+  # working directory that has nothing to do with the repository checkout.
+  def resolver_from_sandbox(version, mode)
+    Dir.mktmpdir('homebrew-sandbox') do |tmpdir|
+      Dir.chdir(tmpdir) { return UrlResolver.new(version, mode) }
+    end
+  end
+
+  def test_patch_url_uses_repo_root_when_tap_not_installed
+    Tap.mock_installed = false
+    resolver = resolver_from_sandbox(30, 'remote')
+    assert_equal "#{REPO_ROOT}/patches/emacs-30/fix-window-role.patch",
+                 resolver.patch_url('fix-window-role')
+  end
+
+  def test_patch_url_uses_repo_root_in_local_mode
+    Tap.mock_installed = true
+    Tap.mock_path = '/opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus'
+    resolver = resolver_from_sandbox(31, 'local')
+    assert_equal "#{REPO_ROOT}/patches/emacs-31/fix-window-role.patch",
+                 resolver.patch_url('fix-window-role')
+  end
+
+  def test_patch_url_uses_tap_path_when_tap_installed
+    Tap.mock_installed = true
+    Tap.mock_path = '/opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus'
+    resolver = resolver_from_sandbox(30, 'remote')
+    assert_equal '/opt/homebrew/Library/Taps/d12frosted/homebrew-emacs-plus/patches/emacs-30/fix-window-role.patch',
+                 resolver.patch_url('fix-window-role')
+  end
+end


### PR DESCRIPTION
Build and Nightly workflows are currently red on every run with:

    Error: unknown install step: gdk_pixbuf_query_loaders

Root cause is version skew between the runner image and homebrew-core:

- Homebrew added a declarative install steps framework on 2026-05-22 and the gdk_pixbuf_query_loaders step handler on 2026-06-02 (shipped in brew 5.1.15, released 2026-06-03).
- gdk-pixbuf 2.44.6_1 in homebrew-core now declares its post-install through that framework, and the JSON API serves this metadata to all clients regardless of brew version.
- The macos-latest runner image bundles an older brew (the traceback points at install_steps.rb:244, which matches the 2026-05-22 framework version without the gdk_pixbuf handler), and HOMEBREW_NO_AUTO_UPDATE is set on runners, so brew never self-updates.

Result: installing any formula that depends on gdk-pixbuf (i.e. all emacs-plus formulas via librsvg) fails in the dependency post-install phase.

Fix: run brew update before installing, same as build-app.yml already does (which is why cask builds are not affected by this; their current failure is an unrelated transient Savannah 504 on git clone).

Also passes --formula to brew install when installing from a path, which silences the bogus 'Failed to load cask: Formula/emacs-plus@30.rb' error annotation in logs.

This PR touches build.yml, so the Build check on this PR itself verifies the fix.