### PR TITLE
fix: drop awk build dependency from emacs-plus@28-32

### DIFF
--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -32,7 +32,6 @@ class EmacsPlusAT28 < EmacsBase
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
   depends_on "grep" => :build
-  depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -31,7 +31,6 @@ class EmacsPlusAT29 < EmacsBase
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
   depends_on "grep" => :build
-  depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -29,7 +29,6 @@ class EmacsPlusAT30 < EmacsBase
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
   depends_on "grep" => :build
-  depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -28,7 +28,6 @@ class EmacsPlusAT31 < EmacsBase
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
   depends_on "grep" => :build
-  depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -28,7 +28,6 @@ class EmacsPlusAT32 < EmacsBase
   depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
   depends_on "grep" => :build
-  depends_on "awk" => :build
   depends_on "coreutils" => :build
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,14 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-06-14
+
+** Bug Fixes
+
+*** Dropped =awk= build dependency
+
+=emacs-plus@28= through =emacs-plus@32= no longer depend on the =awk= formula at build time. It was added defensively alongside =gnu-tar= and =coreutils=, but Emacs builds fine with the system =awk= and has no need for a specific version. Removing it avoids forcing Homebrew's =awk= (onetrueawk) onto users' systems, where its recent versions break tools such as [[https://github.com/elasticdog/transcrypt/issues/213][transcrypt]]. See [[https://github.com/d12frosted/homebrew-emacs-plus/discussions/951][discussion #951]].
+
 * 2026-06-10
 
 ** Bug Fixes


### PR DESCRIPTION
Removes `depends_on "awk" => :build` from `emacs-plus@28` through `@32`.

## Why

`awk` was added in d3ca2de (2022) defensively, alongside `gnu-tar` and `coreutils`, to put GNU tools on the build PATH. The issues that motivated that commit (#465, #466) were actually a `gnu-tar` flag problem — nothing required a specific `awk`. Emacs builds fine with the system `/usr/bin/awk`, and `@26`/`@27` never depended on it. The original mechanism that baked build deps into the app's runtime PATH is also gone, so `awk` is now purely build-time.

Declaring the dependency forces Homebrew's `awk` (onetrueawk) onto users' machines, where recent versions intentionally break tools such as transcrypt (elasticdog/transcrypt#213). Dropping it lets those users uninstall the formula and fall back to the system `awk`.

## Verification

Built `emacs-plus@31` from source (native compilation) with only the system `awk` on PATH — Homebrew's superenv excludes the now-undeclared formula, so this exercises exactly the post-removal path. `configure` (`AC_PROG_AWK`) and the full make completed; resulting Emacs runs with native-comp.

Closes #951