### PR TITLE
ci: clone Emacs from GitHub mirror instead of savannah

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -80,7 +80,7 @@ jobs:
           # Emacs 30 uses the latest release tag (update when new version is released)
           BRANCH="emacs-30.2"
           git clone --depth 1 --branch "$BRANCH" \
-            https://git.savannah.gnu.org/git/emacs.git emacs-src
+            https://github.com/emacs-mirror/emacs.git emacs-src
           cd emacs-src
           echo "EMACS_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "Building Emacs $EMACS_VERSION at $(git rev-parse --short HEAD)"
@@ -468,7 +468,7 @@ jobs:
           # Emacs 31 uses emacs-31 branch (pre-release)
           BRANCH="emacs-31"
           git clone --depth 1 --branch "$BRANCH" \
-            https://git.savannah.gnu.org/git/emacs.git emacs-src
+            https://github.com/emacs-mirror/emacs.git emacs-src
           cd emacs-src
           echo "EMACS_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "Building Emacs $EMACS_VERSION at $(git rev-parse --short HEAD)"
@@ -854,7 +854,7 @@ jobs:
           # Emacs 32 uses master branch
           BRANCH="master"
           git clone --depth 1 --branch "$BRANCH" \
-            https://git.savannah.gnu.org/git/emacs.git emacs-src
+            https://github.com/emacs-mirror/emacs.git emacs-src
           cd emacs-src
           echo "EMACS_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "Building Emacs $EMACS_VERSION at $(git rev-parse --short HEAD)"


### PR DESCRIPTION
## Why

The `Build Emacs.app` workflow clones Emacs source from `git.savannah.gnu.org`, which frequently returns **HTTP 504** gateway timeouts. There is no retry around the `git clone`, so a single timeout fails the entire `build-30`/`build-31`/`build-32` job. This is the cause of the recurring red nightlies (e.g. the build-30 failures on June 13–14), not anything in the formulas.

## What

Switches the three `Clone Emacs source` steps to the GitHub mirror `github.com/emacs-mirror/emacs.git` — the same source the formulas already use (`EmacsBase::EMACS_GIT_URL`). It is significantly more reliable and carries everything the workflow needs:

- `emacs-30.2` (tag) — `build-30`
- `emacs-31` (branch) — `build-31`
- `master` (branch) — `build-32`

Verified all three refs resolve on the mirror via `git ls-remote`.

Follow-up to #952.