### PR TITLE
fix: stop injecting CC into LSEnvironment

### DIFF
--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -5,7 +5,7 @@
 # This module configures the Emacs.app bundle for proper operation when
 # installed via cask. It handles:
 #
-# 1. LSEnvironment in Info.plist - Sets CC and LIBRARY_PATH so native
+# 1. LSEnvironment in Info.plist - Sets LIBRARY_PATH so native
 #    compilation works when launching from Finder/Dock
 #
 # 2. CLI wrapper script - Creates bin/emacs wrapper so running via symlink
@@ -21,7 +21,7 @@
 # - ns-emacs-plus-injected-path will always be nil for cask builds
 # - Cask users should use exec-path-from-shell or switch to formula
 #
-# Native compilation works via CC and LIBRARY_PATH without needing PATH.
+# Native compilation works via LIBRARY_PATH without needing PATH.
 
 require_relative 'BuildConfig'
 
@@ -112,14 +112,6 @@ module CaskEnv
       filtered.empty? ? nil : filtered.join(':')
     end
 
-    # Find the gcc version number (e.g., "15")
-    def gcc_version
-      # Look for gcc-NN in Homebrew bin
-      Dir.glob("#{homebrew_prefix}/bin/gcc-*").map do |path|
-        File.basename(path).sub("gcc-", "")
-      end.select { |v| v.match?(/^\d+$/) }.max
-    end
-
     # Find the directory containing libemutls_w.a
     def find_emutls_dir
       gcc_cellar = "#{homebrew_prefix}/Cellar/gcc"
@@ -148,6 +140,24 @@ module CaskEnv
       paths.compact.join(":")
     end
 
+    # Environment variables injected into LSEnvironment for native compilation.
+    #
+    # Only LIBRARY_PATH is needed: it lets the libgccjit linker find
+    # libemutls_w.a when Emacs is launched from the GUI, where the user's
+    # shell environment is absent.
+    #
+    # We intentionally do NOT inject CC. Emacs native compilation never reads
+    # CC (libgccjit resolves its driver via PATH/GCC_EXEC_PREFIX), so setting
+    # it had no effect on compilation while leaking gcc-NN into every child
+    # process spawned by GUI Emacs (terminals, M-x compile, eshell), breaking
+    # builds that expect clang. See issue #939.
+    def native_comp_env
+      env = {}
+      library_path = build_library_path
+      env["LIBRARY_PATH"] = library_path unless library_path.empty?
+      env
+    end
+
     # Inject environment into Emacs.app via LSEnvironment in Info.plist
     def inject_emacs_app(app_path)
       return false unless File.exist?(app_path)
@@ -162,9 +172,6 @@ module CaskEnv
       # due to Homebrew limitation - cask postflight doesn't have user's shell environment
       puts "Injecting native compilation environment into #{app_path}"
 
-      prefix = homebrew_prefix
-      version = gcc_version
-
       # Add LSEnvironment dict
       system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment dict", plist)
 
@@ -174,16 +181,10 @@ module CaskEnv
       # ns-emacs-plus-injected-path would be t - misleading users into thinking
       # their full PATH was injected. Instead, we let ns-emacs-plus-injected-path
       # be nil so users properly use exec-path-from-shell.
-      # Native compilation still works via CC and LIBRARY_PATH below.
+      # Native compilation still works via LIBRARY_PATH below.
 
-      # CC and LIBRARY_PATH: Always set for native compilation
-      if version
-        system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:CC string '#{prefix}/bin/gcc-#{version}'", plist)
-      end
-
-      library_path = build_library_path
-      unless library_path.empty?
-        system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:LIBRARY_PATH string '#{library_path}'", plist)
+      native_comp_env.each do |key, value|
+        system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:#{key} string '#{value}'", plist)
       end
 
       # Touch the app to update LaunchServices cache

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -485,13 +485,6 @@ class EmacsBase < Formula
     native_comp_path
   end
 
-  # Find the gcc version number (e.g., "15")
-  def gcc_version
-    Dir.glob("#{HOMEBREW_PREFIX}/bin/gcc-*").map do |path|
-      File.basename(path).sub("gcc-", "")
-    end.select { |v| v.match?(/^\d+$/) }.max
-  end
-
   # Find the directory containing libemutls_w.a
   def find_emutls_dir
     gcc_cellar = "#{HOMEBREW_PREFIX}/Cellar/gcc"
@@ -592,12 +585,15 @@ class EmacsBase < Formula
       system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:EMACS_PLUS_PATH string '#{path}'", plist)
     end
 
-    # CC and LIBRARY_PATH: Always set for native compilation
-    version = gcc_version
-    if version
-      system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:CC string '#{HOMEBREW_PREFIX}/bin/gcc-#{version}'", plist)
-    end
-
+    # LIBRARY_PATH: set for native compilation so the libgccjit linker can
+    # find libemutls_w.a when Emacs is launched from the GUI, where the
+    # user's shell environment is absent.
+    #
+    # We intentionally do NOT inject CC. Emacs native compilation never reads
+    # CC (libgccjit resolves its driver via PATH/GCC_EXEC_PREFIX), so setting
+    # it had no effect on compilation while leaking gcc-NN into every child
+    # process spawned by GUI Emacs (terminals, M-x compile, eshell), breaking
+    # builds that expect clang. See issue #939.
     library_path = build_library_path
     unless library_path.empty?
       system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:LIBRARY_PATH string '#{library_path}'", plist)

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,22 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-06-21
+
+** Bug Fixes
+
+*** =CC= no longer leaks into child processes of GUI Emacs
+
+Emacs Plus previously injected =CC=/opt/homebrew/bin/gcc-NN= into =Info.plist= under =LSEnvironment= for both formula and cask builds. macOS applies =LSEnvironment= to every process spawned by GUI-launched Emacs, so =CC= bled into terminal emulators (=vterm=, =eat=, =eshell=), =M-x compile=, and other subprocesses, breaking builds that expect the default =clang= toolchain.
+
+The injection turned out to be unnecessary. Emacs native compilation never reads =CC= (libgccjit resolves its driver via =PATH= / =GCC_EXEC_PREFIX=), so removing it has no effect on native compilation. =LIBRARY_PATH= is still injected so the linker can find =libemutls_w.a= when launching from the GUI. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/939][#939]].
+
+Reinstall to pick up the fix:
+
+#+begin_src bash
+brew reinstall emacs-plus@30   # or your version
+#+end_src
+
 * 2026-06-14
 
 ** Bug Fixes

--- a/README.org
+++ b/README.org
@@ -341,7 +341,7 @@ In case you have a non-trivial setup relying on specific value of =PATH= inherit
 
 **** Cask builds
 
-For cask builds (=brew install --cask emacs-plus-app=), PATH injection is *not available* due to a Homebrew limitation - cask postflight doesn't have access to the user's shell environment. Native compilation still works because =CC= and =LIBRARY_PATH= are injected.
+For cask builds (=brew install --cask emacs-plus-app=), PATH injection is *not available* due to a Homebrew limitation - cask postflight doesn't have access to the user's shell environment. Native compilation still works because =LIBRARY_PATH= is injected.
 
 Cask users who need their shell PATH in Emacs should use [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]]:
 

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -6,6 +6,7 @@
 # Run with: ruby tests/test_cask_env.rb
 
 require 'minitest/autorun'
+require 'minitest/mock'
 require 'tempfile'
 require 'fileutils'
 
@@ -384,6 +385,36 @@ class TestCaskEnv < Minitest::Test
       # Should not raise error
       CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
       CaskEnv.send(:update_site_start_el, app_path)
+    end
+  end
+
+  # ===========================================
+  # Tests for native_comp_env (LSEnvironment vars)
+  # ===========================================
+
+  def test_native_comp_env_does_not_include_cc
+    # Regression for #939: CC must never be injected into LSEnvironment.
+    # Emacs native compilation does not read CC (libgccjit resolves its
+    # driver via PATH/GCC_EXEC_PREFIX), so injecting CC=gcc-NN had no effect
+    # on compilation while leaking into every child process of GUI Emacs
+    # (terminals, compile, eshell), breaking builds that expect clang.
+    CaskEnv.stub(:build_library_path, "/opt/homebrew/lib/gcc/current") do
+      env = CaskEnv.send(:native_comp_env)
+      refute_includes env.keys, "CC"
+    end
+  end
+
+  def test_native_comp_env_includes_library_path
+    CaskEnv.stub(:build_library_path, "/opt/homebrew/lib/gcc/current") do
+      env = CaskEnv.send(:native_comp_env)
+      assert_equal "/opt/homebrew/lib/gcc/current", env["LIBRARY_PATH"]
+    end
+  end
+
+  def test_native_comp_env_omits_empty_library_path
+    CaskEnv.stub(:build_library_path, "") do
+      env = CaskEnv.send(:native_comp_env)
+      refute_includes env.keys, "LIBRARY_PATH"
     end
   end
 


### PR DESCRIPTION
Closes #939

We were injecting `CC=/opt/homebrew/bin/gcc-NN` into `Info.plist` under `LSEnvironment` for both formula and cask builds. macOS hands `LSEnvironment` to every child process of GUI-launched Emacs, so `CC` leaked into terminal emulators (vterm, eat, eshell), `M-x compile`, and anything else Emacs spawns. That flips their compiler to gcc-15 and breaks builds that expect clang.

The kicker is that CC was never doing anything for us. Emacs native compilation doesn't read `CC` at all (libgccjit resolves its driver via `PATH`/`GCC_EXEC_PREFIX`), so dropping it has zero effect on native comp. `LIBRARY_PATH` stays injected so the linker can still find `libemutls_w.a` when Emacs is launched from the GUI.

Heads up: existing installs keep the old plist until `brew reinstall`.
