### PR TITLE
Doc: Add Brew trust instruction

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,6 +24,7 @@ Emacs+ is [[https://www.gnu.org/software/emacs/emacs.html][→ GNU Emacs]] formu
 
 #+begin_src bash
   $ brew tap d12frosted/emacs-plus
+  $ brew trust d12frosted/emacs-plus
 
   # Pre-built binaries (fast, ~1 min)
   $ brew install --cask emacs-plus-app          # latest stable

--- a/README.org
+++ b/README.org
@@ -24,7 +24,10 @@ Emacs+ is [[https://www.gnu.org/software/emacs/emacs.html][→ GNU Emacs]] formu
 
 #+begin_src bash
   $ brew tap d12frosted/emacs-plus
-  $ brew trust d12frosted/emacs-plus
+
+  # Homebrew 6.0+ won't load non-official taps until you trust them. If an
+  # install reports an "untrusted tap", run `brew trust d12frosted/emacs-plus`
+  # (or trust a single formula/cask) and retry. See https://docs.brew.sh/Tap-Trust.
 
   # Pre-built binaries (fast, ~1 min)
   $ brew install --cask emacs-plus-app          # latest stable


### PR DESCRIPTION
Since version 6.0, Homebrew requires explicit trusting of newly added taps, formulae or casks.
This change adds the command the user needs to type in the terminal to trust the whole tap, however I am pondering whether its better to instruct users to trust only the specific formulae?