### PR TITLE
ci(nightly): trust emacs-plus tap before install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Tap emacs-plus
         run: brew tap d12frosted/emacs-plus
 
+      # Homebrew now refuses to load formulae from third-party taps unless
+      # they are explicitly trusted ("Refusing to load formula ... from
+      # untrusted tap"). Trust our own tap so install can proceed in CI.
+      - name: Trust emacs-plus tap
+        run: brew trust d12frosted/emacs-plus
+
       - name: Build ${{ matrix.formula }} ${{ matrix.build_opts }}
         run: |
           export HOMEBREW_DEVELOPER=1


### PR DESCRIPTION
## What

Add a `brew trust d12frosted/emacs-plus` step to the `Nightly` workflow, right after tapping and before `brew install`.

## Why

Homebrew rolled out a tap-trust security gate. Every nightly matrix job now fails within ~1 minute at `brew install` with:

```
Refusing to load formula d12frosted/emacs-plus/emacs-plus@31 from untrusted tap d12frosted/emacs-plus.
Run `brew trust --formula ...` or `brew trust d12frosted/emacs-plus` to trust it.
```

The recent docs commits (dc50d8a, dbc974e) covered this for end users, but the CI workflow was never updated. Trusting our own tap in CI lets the tap-build install the formulae again.

This is the tap-build half of the nightly failures; the `Build Emacs.app` libgccjit failure is fixed separately.