### PR TITLE
ci(build-app): pass gcc runtime paths so libgccjit test passes

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -110,12 +110,19 @@ jobs:
         run: |
           cd emacs-src
           ./autogen.sh
+          # Point configure at the Homebrew gcc runtime so the libgccjit
+          # test program links and runs. Without this, configure fails with
+          # "libgccjit failed to compile and run a test program" on arm64
+          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
+          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
           # Note: ImageMagick excluded to avoid libomp conflicts (issue #890)
           ./configure \
-            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT" \
+            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT -I$(brew --prefix gcc)/include -I$(brew --prefix libgccjit)/include" \
+            LDFLAGS="-L$GCC_LIB -Wl,-rpath,$GCC_LIB" \
             --enable-locallisppath=$HOMEBREW_PREFIX/share/emacs/site-lisp \
             --with-ns \
             --with-native-compilation=aot \
@@ -496,12 +503,19 @@ jobs:
         run: |
           cd emacs-src
           ./autogen.sh
+          # Point configure at the Homebrew gcc runtime so the libgccjit
+          # test program links and runs. Without this, configure fails with
+          # "libgccjit failed to compile and run a test program" on arm64
+          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
+          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
           # Note: ImageMagick excluded to avoid libomp conflicts (issue #890)
           ./configure \
-            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT" \
+            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT -I$(brew --prefix gcc)/include -I$(brew --prefix libgccjit)/include" \
+            LDFLAGS="-L$GCC_LIB -Wl,-rpath,$GCC_LIB" \
             --enable-locallisppath=$HOMEBREW_PREFIX/share/emacs/site-lisp \
             --with-ns \
             --with-native-compilation=aot \
@@ -882,12 +896,19 @@ jobs:
         run: |
           cd emacs-src
           ./autogen.sh
+          # Point configure at the Homebrew gcc runtime so the libgccjit
+          # test program links and runs. Without this, configure fails with
+          # "libgccjit failed to compile and run a test program" on arm64
+          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
+          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
           # Note: ImageMagick excluded to avoid libomp conflicts (issue #890)
           ./configure \
-            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT" \
+            CFLAGS="-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT -I$(brew --prefix gcc)/include -I$(brew --prefix libgccjit)/include" \
+            LDFLAGS="-L$GCC_LIB -Wl,-rpath,$GCC_LIB" \
             --enable-locallisppath=$HOMEBREW_PREFIX/share/emacs/site-lisp \
             --with-ns \
             --with-native-compilation=aot \


### PR DESCRIPTION
## What

In all three build jobs (`build-30`, `build-31`, `build-32`) of `Build Emacs.app`, pass the Homebrew gcc runtime to `./configure`:

- `LDFLAGS="-L$HOMEBREW_PREFIX/lib/gcc/current -Wl,-rpath,..."`
- gcc + libgccjit include dirs added to `CFLAGS`

This mirrors what `Formula/emacs-plus@*.rb` already does for native-compilation parity.

## Why

`configure` was failing with:

```
configure: error: The installed libgccjit failed to compile and run a test program using the libgccjit library
```

The workflow relied on the runner's default search paths to find libgccjit instead of pointing at the gcc runtime like the formula does. After a gcc bottle bump (~2026-06-19, last green build 06-18) the arm64 runners stopped resolving the gcc runtime, so every arm64 job (tahoe/sequoia/sonoma) fails while the Intel job still passes. Supplying the gcc lib path and rpath restores the build.

This is the `Build Emacs.app` half of the nightly failures; the tap-build (`Nightly`) tap-trust failure is fixed separately.

## Suggested validation

Trigger a manual `workflow_dispatch` run (e.g. version 31) to confirm the arm64 build before merging.