### PR TITLE
ci(build-app): export LIBRARY_PATH so libgccjit JIT test runs

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -111,11 +111,19 @@ jobs:
           cd emacs-src
           ./autogen.sh
           # Point configure at the Homebrew gcc runtime so the libgccjit
-          # test program links and runs. Without this, configure fails with
-          # "libgccjit failed to compile and run a test program" on arm64
-          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
-          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          # test program compiles, links, AND runs:
+          # - LDFLAGS lets configure link the test binary and embeds an rpath
+          #   to libgccjit (mirrors Formula/emacs-plus@*.rb).
+          # - LIBRARY_PATH lets libgccjit's own driver find the gcc runtime
+          #   (libgcc, libemutls_w.a) when it links the JIT test program at
+          #   run time. Without it the test compiles but fails to run on arm64
+          #   ("libgccjit failed to compile and run a test program").
+          #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
+          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
+          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
+          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          export LIBRARY_PATH
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
@@ -504,11 +512,19 @@ jobs:
           cd emacs-src
           ./autogen.sh
           # Point configure at the Homebrew gcc runtime so the libgccjit
-          # test program links and runs. Without this, configure fails with
-          # "libgccjit failed to compile and run a test program" on arm64
-          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
-          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          # test program compiles, links, AND runs:
+          # - LDFLAGS lets configure link the test binary and embeds an rpath
+          #   to libgccjit (mirrors Formula/emacs-plus@*.rb).
+          # - LIBRARY_PATH lets libgccjit's own driver find the gcc runtime
+          #   (libgcc, libemutls_w.a) when it links the JIT test program at
+          #   run time. Without it the test compiles but fails to run on arm64
+          #   ("libgccjit failed to compile and run a test program").
+          #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
+          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
+          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
+          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          export LIBRARY_PATH
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
@@ -897,11 +913,19 @@ jobs:
           cd emacs-src
           ./autogen.sh
           # Point configure at the Homebrew gcc runtime so the libgccjit
-          # test program links and runs. Without this, configure fails with
-          # "libgccjit failed to compile and run a test program" on arm64
-          # after a gcc bottle bump. Mirrors the LDFLAGS the formula sets
-          # (Formula/emacs-plus@*.rb) for native-compilation parity.
+          # test program compiles, links, AND runs:
+          # - LDFLAGS lets configure link the test binary and embeds an rpath
+          #   to libgccjit (mirrors Formula/emacs-plus@*.rb).
+          # - LIBRARY_PATH lets libgccjit's own driver find the gcc runtime
+          #   (libgcc, libemutls_w.a) when it links the JIT test program at
+          #   run time. Without it the test compiles but fails to run on arm64
+          #   ("libgccjit failed to compile and run a test program").
+          #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
+          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
+          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
+          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          export LIBRARY_PATH
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit


### PR DESCRIPTION
## What

Export `LIBRARY_PATH` (gcc emutls dir + `lib/gcc/current` + `$HOMEBREW_PREFIX/lib`) before `./configure` in all three `Build Emacs.app` jobs, mirroring `Library/EmacsBase.rb#build_library_path`.

## Why

The earlier fix (#961) added gcc paths to `LDFLAGS`, which lets configure link its libgccjit *test binary*. But that test then **runs** libgccjit, which spawns its own linker to build a JIT program — and that inner link needs `LIBRARY_PATH` to find the gcc runtime (`libgcc`, `libemutls_w.a`).

So on the dispatched validation run the test now compiled and linked (`-lgccjit ... yes`, `libgccjit.h ... yes`) but still failed at the run step on arm64:

```
configure: error: The installed libgccjit failed to compile and run a test program
```

Intel happened to resolve the runtime libs by default, which is why only arm64 (tahoe/sequoia/sonoma) failed. Setting `LIBRARY_PATH` the way the cask/formula does at native-compilation time fixes the arm64 jobs.

Follow-up to #961.