### PR TITLE
ci(build-app): fix libgccjit native-comp build on gcc 16 / macOS arm64

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            libgccjit tree-sitter@0.25 pkg-config webp
+            gcc libgccjit tree-sitter@0.25 pkg-config webp
           # tree-sitter@0.25 is keg-only, set up paths
           echo "PKG_CONFIG_PATH=$(brew --prefix tree-sitter@0.25)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
@@ -126,10 +126,15 @@ jobs:
           # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
           # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
           # "ld: library 'emutls_w' not found / error invoking gcc driver".
-          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | head -1)
+          GCC_MAJOR=${GCC_VER%%.*}
+          GCC_EXE="$(brew --prefix gcc)/bin/gcc-${GCC_MAJOR}"
           EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
           if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
-            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+            echo "::error::could not locate libemutls_w.a via '$GCC_EXE' (got '$EMUTLS_DIR')"
+            echo "debug: brew --prefix gcc=$(brew --prefix gcc); versions: $(brew list --versions gcc)"
+            ls -la "$(brew --prefix gcc)/bin" 2>&1 | head -20 || true
+            exit 1
           fi
           LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH
@@ -507,7 +512,7 @@ jobs:
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            libgccjit tree-sitter pkg-config webp
+            gcc libgccjit tree-sitter pkg-config webp
 
       - name: Clone Emacs source
         run: |
@@ -558,10 +563,15 @@ jobs:
           # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
           # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
           # "ld: library 'emutls_w' not found / error invoking gcc driver".
-          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | head -1)
+          GCC_MAJOR=${GCC_VER%%.*}
+          GCC_EXE="$(brew --prefix gcc)/bin/gcc-${GCC_MAJOR}"
           EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
           if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
-            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+            echo "::error::could not locate libemutls_w.a via '$GCC_EXE' (got '$EMUTLS_DIR')"
+            echo "debug: brew --prefix gcc=$(brew --prefix gcc); versions: $(brew list --versions gcc)"
+            ls -la "$(brew --prefix gcc)/bin" 2>&1 | head -20 || true
+            exit 1
           fi
           LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH
@@ -939,7 +949,7 @@ jobs:
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            libgccjit tree-sitter pkg-config webp
+            gcc libgccjit tree-sitter pkg-config webp
 
       - name: Clone Emacs source
         run: |
@@ -990,10 +1000,15 @@ jobs:
           # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
           # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
           # "ld: library 'emutls_w' not found / error invoking gcc driver".
-          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | head -1)
+          GCC_MAJOR=${GCC_VER%%.*}
+          GCC_EXE="$(brew --prefix gcc)/bin/gcc-${GCC_MAJOR}"
           EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
           if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
-            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+            echo "::error::could not locate libemutls_w.a via '$GCC_EXE' (got '$EMUTLS_DIR')"
+            echo "debug: brew --prefix gcc=$(brew --prefix gcc); versions: $(brew list --versions gcc)"
+            ls -la "$(brew --prefix gcc)/bin" 2>&1 | head -20 || true
+            exit 1
           fi
           LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -124,6 +124,13 @@ jobs:
           LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
           [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
           export LIBRARY_PATH
+          # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
+          # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
+          # (sequoia/tahoe) its JIT driver otherwise fails to find the system
+          # libraries it links against, so the libgccjit test compiles but
+          # fails to run. Homebrew's superenv sets SDKROOT for the formula
+          # build; replicate that here.
+          export SDKROOT="$(xcrun --show-sdk-path)"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
@@ -144,6 +151,12 @@ jobs:
             --without-compress-install
           make -j$(sysctl -n hw.ncpu)
           make install
+
+      - name: Dump config.log on failure
+        if: failure()
+        run: |
+          echo "=== tail of emacs-src/config.log ==="
+          tail -n 150 emacs-src/config.log || true
 
       - name: Verify build
         run: |
@@ -525,6 +538,13 @@ jobs:
           LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
           [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
           export LIBRARY_PATH
+          # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
+          # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
+          # (sequoia/tahoe) its JIT driver otherwise fails to find the system
+          # libraries it links against, so the libgccjit test compiles but
+          # fails to run. Homebrew's superenv sets SDKROOT for the formula
+          # build; replicate that here.
+          export SDKROOT="$(xcrun --show-sdk-path)"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
@@ -545,6 +565,12 @@ jobs:
             --without-compress-install
           make -j$(sysctl -n hw.ncpu)
           make install
+
+      - name: Dump config.log on failure
+        if: failure()
+        run: |
+          echo "=== tail of emacs-src/config.log ==="
+          tail -n 150 emacs-src/config.log || true
 
       - name: Verify build
         run: |
@@ -926,6 +952,13 @@ jobs:
           LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
           [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
           export LIBRARY_PATH
+          # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
+          # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
+          # (sequoia/tahoe) its JIT driver otherwise fails to find the system
+          # libraries it links against, so the libgccjit test compiles but
+          # fails to run. Homebrew's superenv sets SDKROOT for the formula
+          # build; replicate that here.
+          export SDKROOT="$(xcrun --show-sdk-path)"
           # CFLAGS must match the formula for parity:
           # - FD_SETSIZE=10000: Increases file descriptor limit (default ~1024) for LSP/eglot
           # - DARWIN_UNLIMITED_SELECT: Removes macOS select() limit
@@ -946,6 +979,12 @@ jobs:
             --without-compress-install
           make -j$(sysctl -n hw.ncpu)
           make install
+
+      - name: Dump config.log on failure
+        if: failure()
+        run: |
+          echo "=== tail of emacs-src/config.log ==="
+          tail -n 150 emacs-src/config.log || true
 
       - name: Verify build
         run: |

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -155,8 +155,16 @@ jobs:
       - name: Dump config.log on failure
         if: failure()
         run: |
-          echo "=== tail of emacs-src/config.log ==="
-          tail -n 150 emacs-src/config.log || true
+          echo "=== libgccjit-related lines from config.log ==="
+          grep -n -iE "gccjit|gcc_jit|conftest|^ld:|error:|undefined|cannot|no such|sysroot|sdk|fatal" emacs-src/config.log | tail -150 || true
+
+      - name: Upload config.log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: configlog-${{ matrix.platform.os_name }}
+          path: emacs-src/config.log
+          if-no-files-found: ignore
 
       - name: Verify build
         run: |
@@ -569,8 +577,16 @@ jobs:
       - name: Dump config.log on failure
         if: failure()
         run: |
-          echo "=== tail of emacs-src/config.log ==="
-          tail -n 150 emacs-src/config.log || true
+          echo "=== libgccjit-related lines from config.log ==="
+          grep -n -iE "gccjit|gcc_jit|conftest|^ld:|error:|undefined|cannot|no such|sysroot|sdk|fatal" emacs-src/config.log | tail -150 || true
+
+      - name: Upload config.log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: configlog-${{ matrix.platform.os_name }}
+          path: emacs-src/config.log
+          if-no-files-found: ignore
 
       - name: Verify build
         run: |
@@ -983,8 +999,16 @@ jobs:
       - name: Dump config.log on failure
         if: failure()
         run: |
-          echo "=== tail of emacs-src/config.log ==="
-          tail -n 150 emacs-src/config.log || true
+          echo "=== libgccjit-related lines from config.log ==="
+          grep -n -iE "gccjit|gcc_jit|conftest|^ld:|error:|undefined|cannot|no such|sysroot|sdk|fatal" emacs-src/config.log | tail -150 || true
+
+      - name: Upload config.log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: configlog-${{ matrix.platform.os_name }}
+          path: emacs-src/config.log
+          if-no-files-found: ignore
 
       - name: Verify build
         run: |

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -120,10 +120,20 @@ jobs:
           #   ("libgccjit failed to compile and run a test program").
           #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
-          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
-          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
-          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          # Locate libemutls_w.a via gcc itself: -print-file-name is what the
+          # driver uses internally, so it is authoritative and deterministic
+          # (a Cellar-wide `find | head -1` proved flaky across runners).
+          # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
+          # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
+          # "ld: library 'emutls_w' not found / error invoking gcc driver".
+          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
+          if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
+            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+          fi
+          LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH
+          echo "Using LIBRARY_PATH=$LIBRARY_PATH"
           # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
           # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
           # (sequoia/tahoe) its JIT driver otherwise fails to find the system
@@ -542,10 +552,20 @@ jobs:
           #   ("libgccjit failed to compile and run a test program").
           #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
-          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
-          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
-          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          # Locate libemutls_w.a via gcc itself: -print-file-name is what the
+          # driver uses internally, so it is authoritative and deterministic
+          # (a Cellar-wide `find | head -1` proved flaky across runners).
+          # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
+          # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
+          # "ld: library 'emutls_w' not found / error invoking gcc driver".
+          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
+          if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
+            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+          fi
+          LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH
+          echo "Using LIBRARY_PATH=$LIBRARY_PATH"
           # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
           # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
           # (sequoia/tahoe) its JIT driver otherwise fails to find the system
@@ -964,10 +984,20 @@ jobs:
           #   ("libgccjit failed to compile and run a test program").
           #   Mirrors Library/EmacsBase.rb#build_library_path.
           GCC_LIB="$HOMEBREW_PREFIX/lib/gcc/current"
-          EMUTLS_DIR=$(dirname "$(find "$HOMEBREW_PREFIX/Cellar/gcc" -name libemutls_w.a 2>/dev/null | head -1)")
-          LIBRARY_PATH="$GCC_LIB:$HOMEBREW_PREFIX/lib"
-          [ -n "$EMUTLS_DIR" ] && LIBRARY_PATH="$EMUTLS_DIR:$LIBRARY_PATH"
+          # Locate libemutls_w.a via gcc itself: -print-file-name is what the
+          # driver uses internally, so it is authoritative and deterministic
+          # (a Cellar-wide `find | head -1` proved flaky across runners).
+          # gcc 16's libgccjit driver links the JIT program with -lemutls_w,
+          # so this dir MUST be on LIBRARY_PATH or the run-time test fails with
+          # "ld: library 'emutls_w' not found / error invoking gcc driver".
+          GCC_EXE=$(ls "$(brew --prefix gcc)"/bin/gcc-[0-9]* 2>/dev/null | grep -E 'gcc-[0-9]+$' | head -1)
+          EMUTLS_DIR=$(dirname "$("$GCC_EXE" -print-file-name=libemutls_w.a)")
+          if [ ! -f "$EMUTLS_DIR/libemutls_w.a" ]; then
+            echo "::error::could not locate libemutls_w.a (got '$EMUTLS_DIR')"; exit 1
+          fi
+          LIBRARY_PATH="$EMUTLS_DIR:$GCC_LIB:$(brew --prefix libgccjit)/lib/gcc/current:$HOMEBREW_PREFIX/lib"
           export LIBRARY_PATH
+          echo "Using LIBRARY_PATH=$LIBRARY_PATH"
           # Pin SDKROOT to the installed SDK. The Homebrew gcc bottle behind
           # libgccjit bakes in a sysroot at build time; on newer macOS SDKs
           # (sequoia/tahoe) its JIT driver otherwise fails to find the system


### PR DESCRIPTION
## What

Make `./configure --with-native-compilation` find the gcc runtime that gcc 16's libgccjit driver links against, across all three build jobs:

- Install `gcc` explicitly and derive the versioned binary from `brew list --versions gcc` (no fragile globbing).
- Locate `libemutls_w.a` via `gcc -print-file-name` (the driver's own mechanism — deterministic, unlike a Cellar-wide `find | head -1`) and put that dir, the gcc lib dir, and the libgccjit lib dir on `LIBRARY_PATH`.
- Pin `SDKROOT` to the installed SDK, mirroring Homebrew superenv.
- On failure, surface `config.log` (grep + artifact) to make libgccjit linker errors debuggable in CI.

## Why

After the gcc 16.1.0 bottle landed (~2026-06-19), every arm64 `Build Emacs.app` job failed at the libgccjit configure test:

```
configure: error: The installed libgccjit failed to compile and run a test program
```

config.log showed the real cause — gcc 16's libgccjit driver links the JIT test with `-lemutls_w` and the linker couldn't find it:

```
ld: library 'emutls_w' not found
libgccjit.so: error: error invoking gcc driver
```

This is the recurring native-comp-on-macOS issue (#554, #733, #562). The earlier `LIBRARY_PATH` attempt (#962) used a flaky `find` that resolved inconsistently across runners (sequoia flipped pass/fail between identical runs); deriving the path from gcc itself makes it reliable.

## Validation

Manual `workflow_dispatch` (version 31) — all four platforms green, including tahoe/macOS 26 which never built before:

| Platform | Result |
|---|---|
| macos-26 arm64 (tahoe) | ✅ |
| macos-15 arm64 (sequoia) | ✅ |
| macos-14 arm64 (sonoma) | ✅ |
| macos-15-intel x86_64 | ✅ |

Follow-up to #961 and #962.