### PR TITLE
fix: resolve libemutls_w.a via gcc driver at install time

### DIFF
--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -112,12 +112,32 @@ module CaskEnv
       filtered.empty? ? nil : filtered.join(':')
     end
 
+    # Find the versioned gcc driver (gcc-16 etc.) under the gcc opt prefix.
+    # Returns nil when the gcc formula is not installed.
+    def find_gcc_executable
+      Dir.glob("#{homebrew_prefix}/opt/gcc/bin/gcc-*")
+         .select { |p| File.basename(p).match?(/\Agcc-\d+\z/) && File.executable?(p) }
+         .max_by { |p| File.basename(p).delete_prefix("gcc-").to_i }
+    end
+
     # Find the directory containing libemutls_w.a
+    #
+    # Ask gcc itself via -print-file-name: that is the mechanism the
+    # libgccjit driver uses internally, so it is authoritative. A Cellar-wide
+    # glob can pick a stale directory when multiple gcc versions are
+    # installed (PR #963 fixed the same nondeterminism in CI); it remains
+    # only as a last-resort fallback.
     def find_emutls_dir
+      if (gcc = find_gcc_executable)
+        path = IO.popen([gcc, "-print-file-name=libemutls_w.a"], err: File::NULL, &:read).strip
+        # gcc echoes the bare name back when it cannot find the file;
+        # expand_path drops the bin/../lib indirection gcc reports
+        return File.expand_path(File.dirname(path)) if path.include?("/") && File.file?(path)
+      end
+
       gcc_cellar = "#{homebrew_prefix}/Cellar/gcc"
       return nil unless File.directory?(gcc_cellar)
 
-      # Find libemutls_w.a in the gcc installation
       emutls_files = Dir.glob("#{gcc_cellar}/**/libemutls_w.a")
       return nil if emutls_files.empty?
 
@@ -125,6 +145,7 @@ module CaskEnv
     end
 
     # Build LIBRARY_PATH for native compilation
+    # Mirrors the LIBRARY_PATH built in build-app.yml (PR #963)
     def build_library_path
       prefix = homebrew_prefix
       paths = []
@@ -133,8 +154,9 @@ module CaskEnv
       emutls_dir = find_emutls_dir
       paths << emutls_dir if emutls_dir
 
-      # Add gcc library directories
+      # Add gcc and libgccjit library directories
       paths << "#{prefix}/lib/gcc/current"
+      paths << "#{prefix}/opt/libgccjit/lib/gcc/current"
       paths << "#{prefix}/lib"
 
       paths.compact.join(":")

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -485,8 +485,29 @@ class EmacsBase < Formula
     native_comp_path
   end
 
+  # Find the versioned gcc driver (gcc-16 etc.) under the gcc opt prefix.
+  # Returns nil when the gcc formula is not installed.
+  def find_gcc_executable
+    Dir.glob("#{HOMEBREW_PREFIX}/opt/gcc/bin/gcc-*")
+       .select { |p| File.basename(p).match?(/\Agcc-\d+\z/) && File.executable?(p) }
+       .max_by { |p| File.basename(p).delete_prefix("gcc-").to_i }
+  end
+
   # Find the directory containing libemutls_w.a
+  #
+  # Ask gcc itself via -print-file-name: that is the mechanism the
+  # libgccjit driver uses internally, so it is authoritative. A Cellar-wide
+  # glob can pick a stale directory when multiple gcc versions are
+  # installed (PR #963 fixed the same nondeterminism in CI); it remains
+  # only as a last-resort fallback.
   def find_emutls_dir
+    if (gcc = find_gcc_executable)
+      path = IO.popen([gcc, "-print-file-name=libemutls_w.a"], err: File::NULL, &:read).strip
+      # gcc echoes the bare name back when it cannot find the file;
+      # expand_path drops the bin/../lib indirection gcc reports
+      return File.expand_path(File.dirname(path)) if path.include?("/") && File.file?(path)
+    end
+
     gcc_cellar = "#{HOMEBREW_PREFIX}/Cellar/gcc"
     return nil unless File.directory?(gcc_cellar)
 
@@ -497,6 +518,7 @@ class EmacsBase < Formula
   end
 
   # Build LIBRARY_PATH for native compilation
+  # Mirrors the LIBRARY_PATH built in build-app.yml (PR #963)
   def build_library_path
     paths = []
 
@@ -504,8 +526,9 @@ class EmacsBase < Formula
     emutls_dir = find_emutls_dir
     paths << emutls_dir if emutls_dir
 
-    # Add gcc library directories
+    # Add gcc and libgccjit library directories
     paths << "#{HOMEBREW_PREFIX}/lib/gcc/current"
+    paths << "#{HOMEBREW_PREFIX}/opt/libgccjit/lib/gcc/current"
     paths << "#{HOMEBREW_PREFIX}/lib"
 
     paths.compact.join(":")

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,20 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-07-08
+
+** Bug Fixes
+
+*** More reliable =LIBRARY_PATH= injection for native compilation
+
+Both formula and cask builds inject =LIBRARY_PATH= into =Info.plist= so the libgccjit linker can find =libemutls_w.a= when GUI-launched Emacs native-compiles packages. The directory was previously located by globbing the gcc Cellar and taking the first match, which could pick a stale gcc version when several are installed. It is now resolved by asking the gcc driver itself (=gcc-NN -print-file-name=libemutls_w.a=), the same mechanism libgccjit uses internally, with the glob kept only as a fallback. The libgccjit library directory is also added to =LIBRARY_PATH=, matching the CI build environment. This ports [[https://github.com/d12frosted/homebrew-emacs-plus/pull/963][#963]] to install-time injection.
+
+Reinstall to pick up the fix:
+
+#+begin_src bash
+brew reinstall emacs-plus@30   # or your version
+#+end_src
+
 * 2026-06-21
 
 ** Bug Fixes

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -36,6 +36,7 @@ class TestCaskEnv < Minitest::Test
   def teardown
     # Clean up environment
     ENV.delete("HOMEBREW_EMACS_PLUS_BUILD_CONFIG")
+    ENV.delete("HOMEBREW_PREFIX")
   end
 
   # ===========================================
@@ -415,6 +416,131 @@ class TestCaskEnv < Minitest::Test
     CaskEnv.stub(:build_library_path, "") do
       env = CaskEnv.send(:native_comp_env)
       refute_includes env.keys, "LIBRARY_PATH"
+    end
+  end
+
+  # ===========================================
+  # Tests for gcc-based emutls lookup (PR #963 ported to install-time injection)
+  # ===========================================
+
+  # Run a block with HOMEBREW_PREFIX pointing at a fresh tempdir
+  def with_fake_prefix
+    Dir.mktmpdir do |dir|
+      ENV["HOMEBREW_PREFIX"] = dir
+      yield dir
+    ensure
+      ENV.delete("HOMEBREW_PREFIX")
+    end
+  end
+
+  # Create a fake versioned gcc driver that answers -print-file-name with
+  # the given output (gcc echoes the bare file name back when it cannot
+  # find the requested library)
+  def make_fake_gcc(prefix, version, output)
+    bin = File.join(prefix, "opt/gcc/bin")
+    FileUtils.mkdir_p(bin)
+    gcc = File.join(bin, "gcc-#{version}")
+    File.write(gcc, "#!/bin/sh\necho '#{output}'\n")
+    File.chmod(0o755, gcc)
+    gcc
+  end
+
+  def make_cellar_emutls(prefix, gcc_version)
+    lib_dir = File.join(prefix, "Cellar/gcc/#{gcc_version}/lib/gcc/current/gcc/aarch64-apple-darwin24/#{gcc_version.split('.').first}")
+    FileUtils.mkdir_p(lib_dir)
+    File.write(File.join(lib_dir, "libemutls_w.a"), "")
+    lib_dir
+  end
+
+  def test_find_gcc_executable_returns_nil_without_gcc
+    with_fake_prefix do
+      assert_nil CaskEnv.send(:find_gcc_executable)
+    end
+  end
+
+  def test_find_gcc_executable_picks_highest_version
+    with_fake_prefix do |prefix|
+      make_fake_gcc(prefix, 15, "")
+      gcc16 = make_fake_gcc(prefix, 16, "")
+      assert_equal gcc16, CaskEnv.send(:find_gcc_executable)
+    end
+  end
+
+  def test_find_gcc_executable_ignores_non_driver_binaries
+    with_fake_prefix do |prefix|
+      gcc = make_fake_gcc(prefix, 16, "")
+      # gcc-ar-16 style wrappers must not be picked up as the driver
+      ar = File.join(File.dirname(gcc), "gcc-ar-16")
+      File.write(ar, "#!/bin/sh\n")
+      File.chmod(0o755, ar)
+      assert_equal gcc, CaskEnv.send(:find_gcc_executable)
+    end
+  end
+
+  def test_find_emutls_dir_uses_gcc_print_file_name
+    with_fake_prefix do |prefix|
+      lib_dir = make_cellar_emutls(prefix, "16.1.0")
+      make_fake_gcc(prefix, 16, File.join(lib_dir, "libemutls_w.a"))
+      assert_equal lib_dir, CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_find_emutls_dir_normalizes_gcc_answer
+    with_fake_prefix do |prefix|
+      lib_dir = make_cellar_emutls(prefix, "16.1.0")
+      # gcc reports the path relative to its bin dir, e.g. .../bin/../lib/...
+      cellar = File.join(prefix, "Cellar/gcc/16.1.0")
+      unresolved = File.join(cellar, "bin/..", lib_dir.delete_prefix("#{cellar}/"), "libemutls_w.a")
+      FileUtils.mkdir_p(File.join(cellar, "bin"))
+      make_fake_gcc(prefix, 16, unresolved)
+      assert_equal lib_dir, CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_find_emutls_dir_prefers_gcc_answer_over_glob
+    with_fake_prefix do |prefix|
+      # Two gcc versions in the Cellar: the glob could pick either, but the
+      # driver's own answer must win
+      make_cellar_emutls(prefix, "15.2.0")
+      current = make_cellar_emutls(prefix, "16.1.0")
+      make_fake_gcc(prefix, 16, File.join(current, "libemutls_w.a"))
+      assert_equal current, CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_find_emutls_dir_falls_back_to_glob_when_gcc_cannot_find_it
+    with_fake_prefix do |prefix|
+      # gcc echoes the bare name back when it cannot find the library
+      make_fake_gcc(prefix, 16, "libemutls_w.a")
+      lib_dir = make_cellar_emutls(prefix, "16.1.0")
+      assert_equal lib_dir, CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_find_emutls_dir_falls_back_to_glob_without_gcc
+    with_fake_prefix do |prefix|
+      lib_dir = make_cellar_emutls(prefix, "16.1.0")
+      assert_equal lib_dir, CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_find_emutls_dir_returns_nil_when_not_found
+    with_fake_prefix do
+      assert_nil CaskEnv.send(:find_emutls_dir)
+    end
+  end
+
+  def test_build_library_path_order_and_contents
+    with_fake_prefix do |prefix|
+      lib_dir = make_cellar_emutls(prefix, "16.1.0")
+      make_fake_gcc(prefix, 16, File.join(lib_dir, "libemutls_w.a"))
+      parts = CaskEnv.send(:build_library_path).split(":")
+      # Mirrors the LIBRARY_PATH built in build-app.yml (PR #963):
+      # emutls dir first, then gcc, libgccjit and prefix lib dirs
+      assert_equal [lib_dir,
+                    "#{prefix}/lib/gcc/current",
+                    "#{prefix}/opt/libgccjit/lib/gcc/current",
+                    "#{prefix}/lib"], parts
     end
   end
 


### PR DESCRIPTION
## What

Ports the deterministic emutls lookup from #963 to the install-time `LIBRARY_PATH` injection in `Library/EmacsBase.rb` (formula) and `Library/CaskEnv.rb` (cask postflight):

- `find_emutls_dir` now asks the versioned gcc driver directly via `gcc-NN -print-file-name=libemutls_w.a` instead of globbing the Cellar and taking the first match. The glob stays as a last-resort fallback when gcc isn't installed or can't answer.
- The driver is resolved from `opt/gcc/bin` (highest `gcc-NN`, ignoring wrappers like `gcc-ar-16`), and the `bin/../lib` indirection gcc reports gets normalized so a clean path lands in the plist.
- The libgccjit lib dir is added to `LIBRARY_PATH` for parity with what `build-app.yml` uses since #963.

Deliberately not ported: the `SDKROOT` pin. Baking that into `LSEnvironment` would leak into every child process of GUI Emacs, same class of problem that got `CC` injection removed in #939.

## Why

#963 fixed this lookup in CI (all three build-app jobs), but the two Ruby copies that bake `LIBRARY_PATH` into `Info.plist` for runtime native compilation kept the old `Dir.glob(...).first` approach. Glob order is unspecified, so with more than one gcc version in the Cellar it can pick the stale one: the same nondeterminism that made CI flaky, just waiting for a user machine with two gccs. Asking the driver itself is authoritative, since `-print-file-name` is what libgccjit's driver uses internally.

Also adds test coverage for the lookup (there was none) and a NEWS.org entry.
