### PR TITLE
fix: pass gcc lib dirs to libgccjit via native-comp-driver-options

### DIFF
--- a/Library/BuildConfig.rb
+++ b/Library/BuildConfig.rb
@@ -70,6 +70,52 @@ module BuildConfig
       config
     end
 
+    # Elisp block for site-start.el that lets the libgccjit driver link
+    # .eln files no matter how Emacs was launched (issue #964).
+    #
+    # LIBRARY_PATH injected via LSEnvironment reaches GUI launches only, so
+    # a terminal-launched Emacs with a cold eln-cache fails at the link step
+    # ("ld: library 'emutls_w' not found"). Driver options are passed only
+    # to libgccjit, so unlike setenv they do not leak into child processes
+    # of Emacs (issue #939). The gcc paths are resolved at Emacs startup, so
+    # they survive gcc version bumps without a reinstall.
+    def native_comp_driver_options_el(prefix)
+      <<~ELISP
+        ;; Native compilation: pass gcc library dirs to the libgccjit driver
+        ;; so it can link .eln files (ld needs libemutls_w.a and friends).
+        ;; LIBRARY_PATH from LSEnvironment covers GUI launches only, so a
+        ;; terminal-launched Emacs with a cold eln-cache fails to link
+        ;; without this. Driver options reach only libgccjit, so unlike
+        ;; setenv they do not leak into child processes of Emacs.
+        (when (and (fboundp 'native-comp-available-p)
+                   (native-comp-available-p))
+          (let* ((gcc (car (last (sort (file-expand-wildcards
+                                        "#{prefix}/opt/gcc/bin/gcc-[0-9]*")
+                                       #'string-version-lessp))))
+                 (emutls (when gcc
+                           (with-temp-buffer
+                             (when (eql 0 (ignore-errors
+                                            (call-process
+                                             gcc nil t nil
+                                             "-print-file-name=libemutls_w.a")))
+                               (string-trim (buffer-string))))))
+                 (dirs (list (when (and emutls (string-match-p "/" emutls))
+                               (directory-file-name
+                                (expand-file-name (file-name-directory emutls))))
+                             "#{prefix}/lib/gcc/current"
+                             "#{prefix}/opt/libgccjit/lib/gcc/current"
+                             "#{prefix}/lib")))
+            (unless (boundp 'native-comp-driver-options)
+              (setq native-comp-driver-options nil))
+            (dolist (dir dirs)
+              (when dir
+                (let ((flag (concat "-L" dir)))
+                  (unless (member flag native-comp-driver-options)
+                    (setq native-comp-driver-options
+                          (append native-comp-driver-options (list flag)))))))))
+      ELISP
+    end
+
     # Validate that config has the expected structure
     def validate_config!(config, path)
       unless config.is_a?(Hash)

--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -340,48 +340,61 @@ module CaskEnv
       true
     end
 
-    # Update site-start.el to add PATH injection code
-    # The CI build creates site-start.el with ns-emacs-plus-version, but
-    # the PATH injection code must be added at user install time since
-    # that's when EMACS_PLUS_PATH is set via LSEnvironment
+    # Update site-start.el with code that must be added at user install
+    # time. The CI build creates site-start.el with ns-emacs-plus-version;
+    # here we add PATH injection (EMACS_PLUS_PATH is set via LSEnvironment
+    # at install time) and native-comp driver options (issue #964). Each
+    # block is added independently so upgrades pick up new blocks even
+    # when older ones are already present.
     def update_site_start_el(app_path)
       site_start = "#{app_path}/Contents/Resources/site-lisp/site-start.el"
       return unless File.exist?(site_start)
 
       content = File.read(site_start)
+      original = content.dup
 
-      # Skip if already has ns-emacs-plus-injected-path
-      return if content.include?("ns-emacs-plus-injected-path")
-
-      # Insert PATH injection code before (provide 'emacs-plus)
+      # PATH injection code before (provide 'emacs-plus)
       # ns-emacs-plus-injected-path is dynamically computed from EMACS_PLUS_PATH
-      new_content = content.sub(
-        "(provide 'emacs-plus)",
-        <<~ELISP.chomp
-          ;; PATH injection via EMACS_PLUS_PATH
-          ;; macOS blocks PATH in LSEnvironment for security reasons, so we store
-          ;; the desired PATH in EMACS_PLUS_PATH and apply it here at startup.
-          (defconst ns-emacs-plus-injected-path
-            (not (null (getenv "EMACS_PLUS_PATH")))
-            "Non-nil if PATH was injected by Emacs Plus at install time.
-          When this is t, you can skip exec-path-from-shell-initialize:
+      unless content.include?("ns-emacs-plus-injected-path")
+        content = content.sub(
+          "(provide 'emacs-plus)",
+          <<~ELISP.chomp
+            ;; PATH injection via EMACS_PLUS_PATH
+            ;; macOS blocks PATH in LSEnvironment for security reasons, so we store
+            ;; the desired PATH in EMACS_PLUS_PATH and apply it here at startup.
+            (defconst ns-emacs-plus-injected-path
+              (not (null (getenv "EMACS_PLUS_PATH")))
+              "Non-nil if PATH was injected by Emacs Plus at install time.
+            When this is t, you can skip exec-path-from-shell-initialize:
 
-            (unless (bound-and-true-p ns-emacs-plus-injected-path)
-              (exec-path-from-shell-initialize))")
+              (unless (bound-and-true-p ns-emacs-plus-injected-path)
+                (exec-path-from-shell-initialize))")
 
-          (when-let ((emacs-plus-path (getenv "EMACS_PLUS_PATH")))
-            ;; Set exec-path for Emacs to find executables
-            (setq exec-path (append (split-string emacs-plus-path ":" t)
-                                    (list exec-directory)))
-            ;; Set PATH in process-environment for subprocesses
-            (setenv "PATH" emacs-plus-path))
+            (when-let ((emacs-plus-path (getenv "EMACS_PLUS_PATH")))
+              ;; Set exec-path for Emacs to find executables
+              (setq exec-path (append (split-string emacs-plus-path ":" t)
+                                      (list exec-directory)))
+              ;; Set PATH in process-environment for subprocesses
+              (setenv "PATH" emacs-plus-path))
 
-          (provide 'emacs-plus)
-        ELISP
-      )
+            (provide 'emacs-plus)
+          ELISP
+        )
+      end
 
-      File.write(site_start, new_content)
-      puts "Updated site-start.el with PATH injection code"
+      # Native-comp driver options so libgccjit can link .eln files on
+      # terminal launches too (issue #964)
+      unless content.include?("native-comp-driver-options")
+        content = content.sub(
+          "(provide 'emacs-plus)",
+          "#{BuildConfig.native_comp_driver_options_el(homebrew_prefix).chomp}\n\n(provide 'emacs-plus)"
+        )
+      end
+
+      return if content == original
+
+      File.write(site_start, content)
+      puts "Updated site-start.el"
     end
 
     # Escape a string for embedding in an AppleScript double-quoted string

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -578,6 +578,8 @@ class EmacsBase < Formula
           ;; Set PATH in process-environment for subprocesses
           (setenv "PATH" emacs-plus-path))
 
+        #{BuildConfig.native_comp_driver_options_el(HOMEBREW_PREFIX).chomp}
+
         (provide 'emacs-plus)
 
         ;;; site-start.el ends here

--- a/NEWS.org
+++ b/NEWS.org
@@ -7,6 +7,19 @@ This file documents notable changes to Emacs Plus.
 
 ** Bug Fixes
 
+*** Native compilation now works on terminal launches with a cold =eln-cache=
+
+=LIBRARY_PATH= is injected via =LSEnvironment=, which macOS applies to GUI launches only. So a terminal-launched Emacs (for example =emacs --daemon= from a shell) with a cold =eln-cache= failed to link freshly compiled =.eln= files with "ld: library 'emutls_w' not found". A warm cache masked the problem, since nothing needed compiling. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/964][#964]].
+
+The generated =site-start.el= now appends =-L= flags to =native-comp-driver-options= for the gcc, libgccjit and gcc support library directories. Driver options are passed only to the libgccjit driver, so unlike =setenv= they do not leak into child processes of Emacs (the problem that got =CC= injection removed, see [[https://github.com/d12frosted/homebrew-emacs-plus/issues/939][#939]]). The gcc paths are resolved at Emacs startup, so they survive gcc version bumps without a reinstall. Works for formula and cask, GUI and terminal launches alike.
+
+Reinstall to pick up the fix:
+
+#+begin_src bash
+brew reinstall emacs-plus@30            # formula
+brew reinstall --cask emacs-plus-app    # cask
+#+end_src
+
 *** More reliable =LIBRARY_PATH= injection for native compilation
 
 Both formula and cask builds inject =LIBRARY_PATH= into =Info.plist= so the libgccjit linker can find =libemutls_w.a= when GUI-launched Emacs native-compiles packages. The directory was previously located by globbing the gcc Cellar and taking the first match, which could pick a stale gcc version when several are installed. It is now resolved by asking the gcc driver itself (=gcc-NN -print-file-name=libemutls_w.a=), the same mechanism libgccjit uses internally, with the glob kept only as a fallback. The libgccjit library directory is also added to =LIBRARY_PATH=, matching the CI build environment. This ports [[https://github.com/d12frosted/homebrew-emacs-plus/pull/963][#963]] to install-time injection.

--- a/README.org
+++ b/README.org
@@ -345,7 +345,7 @@ In case you have a non-trivial setup relying on specific value of =PATH= inherit
 
 **** Cask builds
 
-For cask builds (=brew install --cask emacs-plus-app=), PATH injection is *not available* due to a Homebrew limitation - cask postflight doesn't have access to the user's shell environment. Native compilation still works because =LIBRARY_PATH= is injected.
+For cask builds (=brew install --cask emacs-plus-app=), PATH injection is *not available* due to a Homebrew limitation - cask postflight doesn't have access to the user's shell environment. Native compilation still works because the gcc library directories are passed to the libgccjit driver via =native-comp-driver-options= (set in the bundled =site-start.el=), with =LIBRARY_PATH= also injected for GUI launches.
 
 Cask users who need their shell PATH in Emacs should use [[https://github.com/purcell/exec-path-from-shell][purcell/exec-path-from-shell]]:
 

--- a/tests/test_build_config.rb
+++ b/tests/test_build_config.rb
@@ -468,6 +468,35 @@ class TestBuildConfig < Minitest::Test
     assert_empty output
   end
 
+  # ===========================================
+  # Tests for native_comp_driver_options_el (issue #964)
+  # ===========================================
+
+  def test_driver_options_el_interpolates_prefix
+    el = BuildConfig.native_comp_driver_options_el("/opt/homebrew")
+    assert_includes el, "/opt/homebrew/opt/gcc/bin/gcc-[0-9]*"
+    assert_includes el, "/opt/homebrew/lib/gcc/current"
+    assert_includes el, "/opt/homebrew/opt/libgccjit/lib/gcc/current"
+
+    el_intel = BuildConfig.native_comp_driver_options_el("/usr/local")
+    assert_includes el_intel, "/usr/local/opt/gcc/bin/gcc-[0-9]*"
+    refute_includes el_intel, "/opt/homebrew"
+  end
+
+  def test_driver_options_el_guards_on_native_comp
+    el = BuildConfig.native_comp_driver_options_el("/opt/homebrew")
+    assert_includes el, "native-comp-available-p"
+    assert_includes el, "native-comp-driver-options"
+    assert_includes el, "-print-file-name=libemutls_w.a"
+  end
+
+  def test_driver_options_el_has_balanced_parens
+    el = BuildConfig.native_comp_driver_options_el("/opt/homebrew")
+    # Strip comment lines, then count parens
+    code = el.lines.reject { |l| l.strip.start_with?(";;") }.join
+    assert_equal code.count("("), code.count(")")
+  end
+
   private
 
   # Helper to load config from a specific path using the environment variable

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -355,7 +355,7 @@ class TestCaskEnv < Minitest::Test
     end
   end
 
-  def test_update_site_start_el_skips_if_already_has_variable
+  def test_update_site_start_el_does_not_duplicate_path_injection
     Dir.mktmpdir do |dir|
       app_path = "#{dir}/Emacs.app"
       site_lisp = "#{app_path}/Contents/Resources/site-lisp"
@@ -373,8 +373,68 @@ class TestCaskEnv < Minitest::Test
       CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
       CaskEnv.send(:update_site_start_el, app_path)
 
-      # Content should be unchanged
-      assert_equal original_content, File.read("#{site_lisp}/site-start.el")
+      content = File.read("#{site_lisp}/site-start.el")
+
+      # PATH injection block must not be added again, but the driver
+      # options block (issue #964) must be added independently
+      assert_equal 1, content.scan("ns-emacs-plus-injected-path").length
+      assert_includes content, "native-comp-driver-options"
+    end
+  end
+
+  def test_update_site_start_el_adds_native_comp_driver_options
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      File.write("#{site_lisp}/site-start.el", <<~ELISP)
+        ;;; site-start.el --- Emacs Plus site initialization -*- lexical-binding: t -*-
+
+        (defconst ns-emacs-plus-version 30
+          "Major version of Emacs Plus.")
+
+        (provide 'emacs-plus)
+
+        ;;; site-start.el ends here
+      ELISP
+
+      Hardware::CPU.mock_arm = true
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      CaskEnv.send(:update_site_start_el, app_path)
+
+      content = File.read("#{site_lisp}/site-start.el")
+
+      # Driver options block resolves gcc at startup and adds -L flags
+      assert_includes content, "native-comp-driver-options"
+      assert_includes content, "-print-file-name=libemutls_w.a"
+      assert_includes content, "native-comp-available-p"
+      assert_includes content, "/opt/homebrew/opt/gcc/bin/gcc-[0-9]*"
+      assert_includes content, "/opt/homebrew/lib/gcc/current"
+      # Block must come before provide so it runs when the file loads
+      assert_operator content.index("native-comp-driver-options"), :<,
+                      content.index("(provide 'emacs-plus)")
+    end
+  end
+
+  def test_update_site_start_el_is_idempotent
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      File.write("#{site_lisp}/site-start.el", <<~ELISP)
+        ;;; site-start.el
+        (defconst ns-emacs-plus-version 30)
+        (provide 'emacs-plus)
+      ELISP
+
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      CaskEnv.send(:update_site_start_el, app_path)
+      first = File.read("#{site_lisp}/site-start.el")
+
+      CaskEnv.send(:update_site_start_el, app_path)
+      assert_equal first, File.read("#{site_lisp}/site-start.el")
     end
   end
 


### PR DESCRIPTION
## What

Fixes #964: native compilation failing on terminal launches with a cold eln-cache.

The generated site-start.el (both formula and cask) now appends -L flags to `native-comp-driver-options` for the emutls dir, gcc lib dir, libgccjit lib dir and the prefix lib dir. The elisp snippet lives in `BuildConfig` and is shared by both install paths. The gcc paths are resolved at Emacs startup (via `gcc-NN -print-file-name=libemutls_w.a`, same lookup as #963/#965), so they survive gcc version bumps without a reinstall.

The LSEnvironment LIBRARY_PATH injection stays as is for now, it does no harm and covers older installs. Once this is proven in the wild we can probably drop it.

## Why

LSEnvironment is applied by the macOS app launcher, so the injected LIBRARY_PATH reaches GUI launches only. A shell-started `emacs --daemon` with a cold eln-cache has to link fresh .eln files and fails with `ld: library 'emutls_w' not found`. A warm cache masks it completely, which is why it took this long to surface. Great analysis in #964 by the way, the repro there isolated it perfectly.

Driver options are the third path out of the bind described in #964: unlike LSEnvironment they work for any launch method, and unlike `setenv` they are passed only to the libgccjit driver invocation, so nothing leaks into child processes of Emacs (the #939 problem).

## Validation

Ran the generated site-start.el in a real Emacs (`emacs --batch` with `LIBRARY_PATH` scrubbed from env): flags get appended once (idempotent across double load), and `native-compile` of a test function runs the full pipeline including the driver link step successfully.