### PR TITLE
fix: don't let one failed cask env step skip the rest

### DIFF
--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -28,7 +28,8 @@ require_relative 'BuildConfig'
 module CaskEnv
   class << self
     # Inject environment into Emacs.app and Emacs Client.app
-    # Returns true if any modifications were made
+    # Returns true if the bundles may have been modified and the caller
+    # should re-sign them
     def inject(emacs_app, emacs_client_app)
       result = BuildConfig.load_config
       @config = result[:config]
@@ -39,13 +40,28 @@ module CaskEnv
       end
 
       modified = false
-      modified |= inject_emacs_app(emacs_app)
-      modified |= inject_emacs_client_app(emacs_client_app)
-      update_site_start_el(emacs_app)
+      modified |= run_step("Emacs.app environment injection") { inject_emacs_app(emacs_app) }
+      modified |= run_step("Emacs Client.app environment injection") { inject_emacs_client_app(emacs_client_app) }
+      run_step("site-start.el update") { update_site_start_el(emacs_app) }
       modified
     end
 
     private
+
+    # Run a single injection step, reporting a failure without aborting
+    # the remaining steps. The steps are independent, so a broken one
+    # (e.g. the CLI wrapper failing to write) must not leave the rest of
+    # the install unconfigured, such as site-start.el never being patched.
+    # A failed step returns true: it may have modified the bundle before
+    # raising, and the caller re-signs based on this result, so err on
+    # the side of an extra (harmless) re-sign.
+    def run_step(name)
+      yield
+    rescue StandardError => e
+      message = "#{name} failed: #{e.class}: #{e.message}"
+      defined?(opoo) ? opoo(message) : warn("Warning: #{message}")
+      true
+    end
 
     # Check if user PATH injection is enabled (default: true)
     def inject_path?
@@ -184,11 +200,16 @@ module CaskEnv
     def inject_emacs_app(app_path)
       return false unless File.exist?(app_path)
 
+      # Create CLI wrapper script for terminal usage. Runs before the
+      # LSEnvironment check so a previously failed wrapper write is
+      # retried on postinstall reruns.
+      wrapper_created = create_cli_wrapper(app_path)
+
       plist = "#{app_path}/Contents/Info.plist"
 
       # Check if already injected
       existing = `defaults read "#{plist}" LSEnvironment 2>/dev/null`.strip
-      return false unless existing.empty? || existing.include?("does not exist")
+      return wrapper_created unless existing.empty? || existing.include?("does not exist")
 
       # Note: For cask, we can only inject native compilation paths (not user PATH)
       # due to Homebrew limitation - cask postflight doesn't have user's shell environment
@@ -212,20 +233,18 @@ module CaskEnv
       # Touch the app to update LaunchServices cache
       system("touch", app_path)
 
-      # Create CLI wrapper script for terminal usage
-      create_cli_wrapper(app_path)
-
       true
     end
 
     # Create a wrapper script at Emacs.app/Contents/MacOS/bin/emacs
     # This fixes the issue where running via symlink breaks Emacs's bundle path resolution
+    # Returns true if the wrapper was written
     def create_cli_wrapper(app_path)
       bin_dir = "#{app_path}/Contents/MacOS/bin"
       wrapper_path = "#{bin_dir}/emacs"
 
       # Skip if wrapper already exists
-      return if File.exist?(wrapper_path) && File.read(wrapper_path).include?("emacs-plus wrapper")
+      return false if File.exist?(wrapper_path) && File.read(wrapper_path).include?("emacs-plus wrapper")
 
       puts "Creating CLI wrapper script at #{wrapper_path}"
 
@@ -238,6 +257,7 @@ module CaskEnv
       SCRIPT
 
       File.chmod(0755, wrapper_path)
+      true
     end
 
     # Inject PATH into Emacs Client.app by recompiling the AppleScript

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -450,6 +450,110 @@ class TestCaskEnv < Minitest::Test
   end
 
   # ===========================================
+  # Tests for inject step isolation
+  # ===========================================
+
+  # Point config loading at a nonexistent file so inject uses an empty
+  # config instead of whatever the developer has in ~/.config/emacs-plus
+  def with_empty_build_config
+    ENV["HOMEBREW_EMACS_PLUS_BUILD_CONFIG"] = "/nonexistent/build.yml"
+    yield
+  ensure
+    ENV.delete("HOMEBREW_EMACS_PLUS_BUILD_CONFIG")
+  end
+
+  def make_site_start(dir)
+    app_path = "#{dir}/Emacs.app"
+    site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+    FileUtils.mkdir_p(site_lisp)
+    File.write("#{site_lisp}/site-start.el", <<~ELISP)
+      ;;; site-start.el
+      (defconst ns-emacs-plus-version 30)
+      (provide 'emacs-plus)
+    ELISP
+    app_path
+  end
+
+  def test_inject_continues_when_a_step_fails
+    Dir.mktmpdir do |dir|
+      app_path = make_site_start(dir)
+
+      # Simulate create_cli_wrapper blowing up inside inject_emacs_app
+      # (e.g. Contents/MacOS/bin missing)
+      boom = ->(_path) { raise Errno::ENOENT, "#{app_path}/Contents/MacOS/bin/emacs" }
+
+      with_empty_build_config do
+        CaskEnv.stub(:inject_emacs_app, boom) do
+          # The failure is reported (on stderr) but must not raise out of inject
+          assert_output(nil, /Emacs\.app.*failed.*ENOENT/mi) do
+            CaskEnv.inject(app_path, "#{dir}/Emacs Client.app")
+          end
+        end
+      end
+
+      # Later steps must still run: site-start.el gets patched
+      content = File.read("#{app_path}/Contents/Resources/site-lisp/site-start.el")
+      assert_includes content, "ns-emacs-plus-injected-path"
+      assert_includes content, "native-comp-driver-options"
+    end
+  end
+
+  def test_inject_requests_resign_when_a_step_fails
+    # A failed step may have modified the bundle before raising (e.g. the
+    # plist written but the CLI wrapper not), and the cask re-signs based
+    # on inject's return value, so a failure must report true
+    Dir.mktmpdir do |dir|
+      app_path = make_site_start(dir)
+
+      boom = ->(_path) { raise Errno::ENOENT, "no such file" }
+
+      with_empty_build_config do
+        CaskEnv.stub(:inject_emacs_app, boom) do
+          needs_resign = nil
+          assert_output(nil, /failed/i) do
+            needs_resign = CaskEnv.inject(app_path, "#{dir}/Emacs Client.app")
+          end
+          assert_equal true, needs_resign
+        end
+      end
+    end
+  end
+
+  def test_inject_survives_real_cli_wrapper_failure
+    # End-to-end version of the motivating failure: an Emacs.app without
+    # Contents/MacOS/bin makes create_cli_wrapper hit a genuine
+    # Errno::ENOENT inside the real inject_emacs_app
+    Dir.mktmpdir do |dir|
+      app_path = make_site_start(dir)
+
+      with_empty_build_config do
+        with_fake_prefix do
+          assert_output(nil, /ENOENT/i) do
+            assert_equal true, CaskEnv.inject(app_path, "#{dir}/Emacs Client.app")
+          end
+        end
+      end
+
+      content = File.read("#{app_path}/Contents/Resources/site-lisp/site-start.el")
+      assert_includes content, "ns-emacs-plus-injected-path"
+      assert_includes content, "native-comp-driver-options"
+    end
+  end
+
+  def test_create_cli_wrapper_reports_whether_it_wrote
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      FileUtils.mkdir_p("#{app_path}/Contents/MacOS/bin")
+
+      assert_output(/Creating CLI wrapper/) do
+        assert_equal true, CaskEnv.send(:create_cli_wrapper, app_path)
+      end
+      # Second run is a no-op
+      assert_equal false, CaskEnv.send(:create_cli_wrapper, app_path)
+    end
+  end
+
+  # ===========================================
   # Tests for native_comp_env (LSEnvironment vars)
   # ===========================================
 


### PR DESCRIPTION
CaskEnv.inject runs three independent steps (Emacs.app env injection, Emacs Client.app recompile, site-start.el update), but they ran sequentially with no isolation. If an early step raised - say the CLI wrapper write hitting ENOENT because Contents/MacOS/bin is missing - everything after it was silently skipped, so you'd end up with an install where site-start.el was never patched.

Now each step goes through a small run_step helper: a failure gets reported (via opoo in brew context, stderr otherwise) and the remaining steps still run.

Two subtleties that came out of review:

- a failed step now counts as "needs re-sign". The cask gates codesign on inject's return value, and a step can modify Info.plist before raising, so returning false there could leave a mutated bundle with a broken seal. An extra ad-hoc re-sign is harmless, so we err that way.
- the CLI wrapper is created before the LSEnvironment already-injected check. Previously a failed wrapper write was unrecoverable: the plist guard short-circuited the step on reruns, so only a full reinstall would retry it. Now postinstall reruns repair it (create_cli_wrapper has its own idempotence check).