### PR TITLE
fix: re-sign when only site-start.el changed

### DIFF
--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -42,7 +42,7 @@ module CaskEnv
       modified = false
       modified |= run_step("Emacs.app environment injection") { inject_emacs_app(emacs_app) }
       modified |= run_step("Emacs Client.app environment injection") { inject_emacs_client_app(emacs_client_app) }
-      run_step("site-start.el update") { update_site_start_el(emacs_app) }
+      modified |= run_step("site-start.el update") { update_site_start_el(emacs_app) }
       modified
     end
 
@@ -366,9 +366,11 @@ module CaskEnv
     # at install time) and native-comp driver options (issue #964). Each
     # block is added independently so upgrades pick up new blocks even
     # when older ones are already present.
+    # Returns true if the file was modified (it lives inside the bundle,
+    # so the caller must re-sign)
     def update_site_start_el(app_path)
       site_start = "#{app_path}/Contents/Resources/site-lisp/site-start.el"
-      return unless File.exist?(site_start)
+      return false unless File.exist?(site_start)
 
       content = File.read(site_start)
       original = content.dup
@@ -411,10 +413,11 @@ module CaskEnv
         )
       end
 
-      return if content == original
+      return false if content == original
 
       File.write(site_start, content)
       puts "Updated site-start.el"
+      true
     end
 
     # Escape a string for embedding in an AppleScript double-quoted string

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -445,7 +445,26 @@ class TestCaskEnv < Minitest::Test
 
       # Should not raise error
       CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
-      CaskEnv.send(:update_site_start_el, app_path)
+      assert_equal false, CaskEnv.send(:update_site_start_el, app_path)
+    end
+  end
+
+  def test_update_site_start_el_returns_whether_it_modified
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      site_lisp = "#{app_path}/Contents/Resources/site-lisp"
+      FileUtils.mkdir_p(site_lisp)
+
+      File.write("#{site_lisp}/site-start.el", <<~ELISP)
+        ;;; site-start.el
+        (defconst ns-emacs-plus-version 30)
+        (provide 'emacs-plus)
+      ELISP
+
+      CaskEnv.instance_variable_set(:@config, { "inject_path" => true })
+      assert_equal true, CaskEnv.send(:update_site_start_el, app_path)
+      # Second run changes nothing
+      assert_equal false, CaskEnv.send(:update_site_start_el, app_path)
     end
   end
 
@@ -514,6 +533,22 @@ class TestCaskEnv < Minitest::Test
             needs_resign = CaskEnv.inject(app_path, "#{dir}/Emacs Client.app")
           end
           assert_equal true, needs_resign
+        end
+      end
+    end
+  end
+
+  def test_inject_requests_resign_when_only_site_start_changed
+    # site-start.el lives inside the bundle, so updating it invalidates
+    # the code seal just like the plist steps do; inject must report it
+    Dir.mktmpdir do |dir|
+      app_path = make_site_start(dir)
+
+      with_empty_build_config do
+        CaskEnv.stub(:inject_emacs_app, false) do
+          CaskEnv.stub(:inject_emacs_client_app, false) do
+            assert_equal true, CaskEnv.inject(app_path, "#{dir}/Emacs Client.app")
+          end
         end
       end
     end


### PR DESCRIPTION
Replaces #970, which GitHub auto-closed when its base branch got deleted after #969 merged. Same change, now against master.

update_site_start_el edits a file inside the Emacs.app bundle, so it invalidates the code seal just like the plist steps. But inject discarded its result. Concretely: on a postinstall rerun where LSEnvironment and the client marker are already set, adding a new site-start block (the whole point of the 'each block is added independently' upgrade path) returned needs_resign = false, the cask skipped codesign, and the bundle ended up with a broken seal.

Now update_site_start_el returns whether it actually wrote the file, and inject counts that in its result. No behavior change on fresh installs; reruns that touch only site-start.el now get re-signed.