### PR TITLE
feat: support per-version values in build.yml

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -67,7 +67,7 @@ cask "emacs-plus-app" do
 
     # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
     load "#{tap.path}/Library/IconApplier.rb"
-    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app") || needs_resign
+    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app", version: version.major) || needs_resign
 
     if needs_resign
       # Re-sign after modifications

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -67,7 +67,7 @@ cask "emacs-plus-app@master" do
 
     # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
     load "#{tap.path}/Library/IconApplier.rb"
-    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app") || needs_resign
+    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app", version: version.major) || needs_resign
 
     if needs_resign
       # Re-sign after modifications

--- a/Library/BuildConfig.rb
+++ b/Library/BuildConfig.rb
@@ -16,6 +16,15 @@ module BuildConfig
   CASK_KEYS = %w[icon inject_path].freeze
   ALL_KEYS = (FORMULA_KEYS + CASK_KEYS).uniq.freeze
 
+  # Keys of an external resource spec ({url, sha256}). A hash whose keys are
+  # a subset of these is a spec; any other hash is a version map keyed by
+  # major Emacs version (or "default"). A version key is never literally
+  # "url" or "sha256", so the two shapes cannot collide.
+  SPEC_KEYS = %w[url sha256].freeze
+
+  # Valid version map key: "default" or a major Emacs version like "30"/30
+  VERSION_KEY = /\A\d+\z/
+
   class << self
     def tap_path
       @tap_path ||= File.expand_path('..', __dir__)
@@ -68,6 +77,31 @@ module BuildConfig
 
       validate_config!(config, path)
       config
+    end
+
+    # True if value is an external resource spec: {url, sha256}
+    def external_spec?(value)
+      value.is_a?(Hash) && !value.empty? && (value.keys.map(&:to_s) - SPEC_KEYS).empty?
+    end
+
+    # True if value is a version map: a hash keyed by major version/"default"
+    def version_map?(value)
+      value.is_a?(Hash) && !external_spec?(value)
+    end
+
+    # Resolve a possibly version-mapped value for a major Emacs version.
+    # Plain values (string, spec hash, nil) pass through unchanged.
+    # For a version map: exact version match wins, then "default", else nil.
+    # Handles both string and integer keys/versions ("30" vs 30).
+    def resolve_versioned(value, version)
+      return value unless version_map?(value)
+
+      version = version&.to_s
+      exact = value.keys.find { |k| k.to_s == version }
+      return value[exact] if exact
+
+      default = value.keys.find { |k| k.to_s == "default" }
+      default ? value[default] : nil
     end
 
     # Elisp block for site-start.el that lets the libgccjit driver link
@@ -175,6 +209,25 @@ module BuildConfig
     end
 
     def validate_icon!(icon, path)
+      # An empty hash is neither a usable spec nor a version map; let the
+      # spec validator produce the "url and sha256 required" error for it
+      if version_map?(icon) && !icon.empty?
+        validate_version_map_keys!(icon, "icon", path)
+        icon.each do |ver, spec|
+          if version_map?(spec)
+            raise ConfigurationError,
+              "Invalid 'icon.#{ver}' in #{path}\n" \
+              "Version maps cannot be nested.\n" \
+              "Got: #{spec.inspect}"
+          end
+          validate_icon_spec!(spec, path, key: "icon.#{ver}")
+        end
+      else
+        validate_icon_spec!(icon, path)
+      end
+    end
+
+    def validate_icon_spec!(icon, path, key: "icon")
       case icon
       when String, nil
         # Valid: icon name from registry or no icon
@@ -182,16 +235,27 @@ module BuildConfig
       when Hash
         unless icon["url"] && icon["sha256"]
           raise ConfigurationError,
-            "Invalid 'icon' configuration in #{path}\n" \
+            "Invalid '#{key}' configuration in #{path}\n" \
             "When specifying an external icon, both 'url' and 'sha256' are required.\n" \
             "Got: #{icon.inspect}"
         end
       else
         raise ConfigurationError,
-          "Invalid 'icon' in #{path}\n" \
+          "Invalid '#{key}' in #{path}\n" \
           "Expected: string (icon name) or object with 'url' and 'sha256'\n" \
           "Got: #{icon.inspect} (#{icon.class})"
       end
+    end
+
+    # Validate that all keys of a version map are major versions or "default"
+    def validate_version_map_keys!(map, key, path)
+      bad = map.keys.reject { |k| k.to_s == "default" || k.to_s.match?(VERSION_KEY) }
+      return if bad.empty?
+
+      raise ConfigurationError,
+        "Invalid '#{key}' version map in #{path}\n" \
+        "Version keys must be major Emacs versions (e.g. \"30\") or 'default'.\n" \
+        "Got key(s): #{bad.map(&:inspect).join(', ')}"
     end
 
     def validate_inject_path!(value, path)
@@ -204,16 +268,48 @@ module BuildConfig
     end
 
     def validate_patches!(patches, path)
-      return if patches.is_a?(Array)
+      unless patches.is_a?(Array)
+        raise ConfigurationError,
+          "Invalid 'patches' in #{path}\n" \
+          "Expected: array of patch names\n" \
+          "Got: #{patches.inspect} (#{patches.class})\n\n" \
+          "Example:\n" \
+          "  patches:\n" \
+          "    - frame-transparency\n" \
+          "    - aggressive-read-buffering"
+      end
+
+      patches.each do |entry|
+        case entry
+        when String
+          # Valid: patch name from registry
+        when Hash
+          entry.each do |name, value|
+            if version_map?(value) && !value.empty?
+              validate_version_map_keys!(value, "patches.#{name}", path)
+              value.each do |ver, spec|
+                validate_patch_spec!(spec, path, key: "patches.#{name}.#{ver}")
+              end
+            else
+              validate_patch_spec!(value, path, key: "patches.#{name}")
+            end
+          end
+        else
+          raise ConfigurationError,
+            "Invalid 'patches' entry in #{path}\n" \
+            "Expected: patch name (string) or named patch with 'url' and 'sha256'\n" \
+            "Got: #{entry.inspect} (#{entry.class})"
+        end
+      end
+    end
+
+    def validate_patch_spec!(spec, path, key:)
+      return if spec.is_a?(Hash) && spec["url"] && spec["sha256"]
 
       raise ConfigurationError,
-        "Invalid 'patches' in #{path}\n" \
-        "Expected: array of patch names\n" \
-        "Got: #{patches.inspect} (#{patches.class})\n\n" \
-        "Example:\n" \
-        "  patches:\n" \
-        "    - frame-transparency\n" \
-        "    - aggressive-read-buffering"
+        "Invalid '#{key}' in #{path}\n" \
+        "External and local patches require both 'url' and 'sha256'.\n" \
+        "Got: #{spec.inspect}"
     end
 
     def validate_revision!(revision, path)
@@ -226,6 +322,7 @@ module BuildConfig
             "Got: #{revision.inspect}"
         end
       when Hash
+        validate_version_map_keys!(revision, "revision", path)
         revision.each do |ver, rev|
           unless rev.is_a?(String) && rev.match?(/\A[a-f0-9]+\z/i)
             raise ConfigurationError,
@@ -258,17 +355,22 @@ module BuildConfig
 
       output.call "Build configuration:"
       config.each do |key, value|
-        formatted_value = case value
-        when Hash then value.map { |k, v| "#{k}: #{v}" }.join(", ")
-        when Array then value.join(", ")
-        else value.to_s
-        end
-        output.call "  #{key}: #{formatted_value}"
+        output.call "  #{key}: #{format_config_value(value)}"
       end
 
       # Context-specific warnings
       warnings = context_warnings(config, context)
       warnings.each { |w| output.call "  ⚠ #{w}" }
+    end
+
+    # Format a config value for display, flattening nested hashes
+    # (external specs and version maps) into a compact one-line form
+    def format_config_value(value)
+      case value
+      when Hash then value.map { |k, v| "#{k}: #{format_config_value(v)}" }.join(", ")
+      when Array then value.map { |v| format_config_value(v) }.join(", ")
+      else value.to_s
+      end
     end
 
     # Get warnings for keys that don't apply to the current context
@@ -294,12 +396,14 @@ module BuildConfig
     end
 
     # Resolve an icon from build.yml configuration
-    # Returns nil if no icon configured
+    # Supports a plain spec (name or {url, sha256}) or a version map
+    # ({default: spec, "30": spec, ...}); version is the major Emacs version.
+    # Returns nil if no icon configured (or none for this version)
     # Returns hash with :name, :path, :tahoe_path, :type, :metadata, or :url/:sha256 for external
-    def resolve_icon(config)
-      return nil unless config["icon"]
+    def resolve_icon(config, version: nil)
+      icon_ref = resolve_versioned(config["icon"], version)
+      return nil unless icon_ref
 
-      icon_ref = config["icon"]
       case icon_ref
       when String
         resolve_registry_icon(icon_ref)

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -81,17 +81,10 @@ class EmacsBase < Formula
     begin
       result = BuildConfig.load_config
       config = result[:config]
-      return nil unless config["revision"]
 
-      revision = config["revision"]
-      # Support both: revision: "abc" (single) or revision: { "30": "abc" } (versioned)
-      if revision.is_a?(Hash)
-        # Try both string and integer keys
-        revision[version.to_s] || revision[version]
-      else
-        # Single revision applies to all versions (not recommended but supported)
-        revision
-      end
+      # Supports: revision: "abc" (single, applies to all versions) or
+      # revision: { "default": "abc", "30": "def" } (version map)
+      BuildConfig.resolve_versioned(config["revision"], version)
     rescue BuildConfig::ConfigurationError
       # Silently ignore - error will be shown with full context during formula run
       nil
@@ -142,16 +135,26 @@ class EmacsBase < Formula
     @@formula_root
   end
 
+  # Major Emacs version ("30", "31", ...) used to resolve version-mapped
+  # build.yml values (icon, patches, revision)
+  def major_version
+    version.to_s.split(".").first
+  end
+
   def resolve_patches
     return [] unless custom_config["patches"]
 
-    custom_config["patches"].map do |patch_ref|
+    custom_config["patches"].filter_map do |patch_ref|
       case patch_ref
       when String
         resolve_registry_patch(patch_ref)
       when Hash
         name = patch_ref.keys.first
-        spec = patch_ref[name]
+        spec = BuildConfig.resolve_versioned(patch_ref[name], major_version)
+        if spec.nil?
+          puts "  Skipping #{name} (not configured for Emacs #{major_version})"
+          next
+        end
         odie "External patch '#{name}' requires 'url' and 'sha256'" unless spec["url"] && spec["sha256"]
         url = spec["url"]
         if local_path?(url)
@@ -209,9 +212,9 @@ class EmacsBase < Formula
   end
 
   def resolve_icon
-    return nil unless custom_config["icon"]
+    icon_ref = BuildConfig.resolve_versioned(custom_config["icon"], major_version)
+    return nil unless icon_ref
 
-    icon_ref = custom_config["icon"]
     case icon_ref
     when String
       resolve_registry_icon(icon_ref)
@@ -245,9 +248,9 @@ class EmacsBase < Formula
     # Check if icon is configured for non-Cocoa builds
     return if (build.with? "cocoa") && (build.without? "x11")
 
-    # Check for icon in build.yml config
-    config = custom_config
-    if config["icon"]
+    # Check for icon in build.yml config (resolved for this version, so a
+    # version map that has no icon for this build does not trigger the error)
+    if BuildConfig.resolve_versioned(custom_config["icon"], major_version)
       odie "Icon configuration in build.yml is not compatible with --with-x11 or --without-cocoa. " \
            "These build configurations do not produce Emacs.app."
     end
@@ -257,11 +260,7 @@ class EmacsBase < Formula
     # Check for revision from build.yml config
     config = custom_config
     if config["revision"]
-      revision = if config["revision"].is_a?(Hash)
-        config["revision"][version.to_s] || config["revision"][version]
-      else
-        config["revision"]
-      end
+      revision = BuildConfig.resolve_versioned(config["revision"], version)
 
       if revision
         ohai "Building from pinned revision (via build.yml)"
@@ -299,9 +298,16 @@ class EmacsBase < Formula
     # Here we do additional formula-specific validation (e.g., icon exists in registry)
     errors = []
 
-    # Validate icon exists in registry (if it's a string reference)
-    if config["icon"].is_a?(String)
-      name = config["icon"]
+    # Validate icon exists in registry (string references, including
+    # string values inside a version map)
+    icon_names = if BuildConfig.version_map?(config["icon"])
+      config["icon"].values.grep(String)
+    elsif config["icon"].is_a?(String)
+      [config["icon"]]
+    else
+      []
+    end
+    icon_names.each do |name|
       unless registry.dig("icons", name)
         errors << "Unknown icon '#{name}'. Check community/registry.json for available icons."
       end
@@ -443,7 +449,7 @@ class EmacsBase < Formula
   # Call this from post_install to re-apply icon from build.yml
   def apply_icon_post_install
     require_relative 'IconApplier'
-    IconApplier.apply(prefix/"Emacs.app", prefix/"Emacs Client.app")
+    IconApplier.apply(prefix/"Emacs.app", prefix/"Emacs Client.app", version: major_version)
   end
 
   # ============================================================

--- a/Library/IconApplier.rb
+++ b/Library/IconApplier.rb
@@ -11,8 +11,10 @@ module IconApplier
     # Apply icon from build.yml to the given app paths
     # @param app_path [String, Pathname] Path to Emacs.app
     # @param client_app_path [String, Pathname, nil] Path to Emacs Client.app (optional)
+    # @param version [String, nil] Major Emacs version ("30") for version-mapped icons;
+    #   nil resolves version maps to their 'default' entry only
     # @return [Boolean] true if icon was applied, false if no icon configured
-    def apply(app_path, client_app_path = nil)
+    def apply(app_path, client_app_path = nil, version: nil)
       app_path = app_path.to_s
       client_app_path = client_app_path&.to_s
 
@@ -26,7 +28,7 @@ module IconApplier
 
       # Config details are already printed by CaskEnv.inject
 
-      icon = BuildConfig.resolve_icon(config)
+      icon = BuildConfig.resolve_icon(config, version: version)
       unless icon
         ohai "No custom icon configured in build.yml"
         return false

--- a/NEWS.org
+++ b/NEWS.org
@@ -27,7 +27,7 @@ revision:
   "31": def456
 #+end_src
 
-All existing =build.yml= files keep working unchanged: a plain value applies to every version, exactly as before. Malformed patch entries (missing =url= or =sha256=) are now rejected when the config is loaded instead of failing later during the build.
+All existing =build.yml= files keep working unchanged: a plain value applies to every version, exactly as before. Malformed patch entries (missing =url= or =sha256=) and unknown =revision= keys are now rejected when the config is loaded instead of failing later during the build. Note that this also applies to cask installs: a malformed =patches= or =revision= entry now fails the cask postflight too, where it was previously ignored (those keys are formula-only). If you hit a new error after updating, fix the reported entry in your =build.yml=.
 
 * 2026-07-08
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,32 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-07-12
+
+** New Features
+
+*** Per-version values in =build.yml=
+
+=icon=, external/local =patches=, and =revision= now accept a version map keyed by major Emacs version (quoted, e.g. ="30"=) with an optional =default= fallback. An exact version match wins, =default= is used otherwise, and with no match the value is simply not applied; for patches this means the patch is skipped for that version. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/950][#950]] and [[https://github.com/d12frosted/homebrew-emacs-plus/issues/973][#973]].
+
+#+begin_src yaml
+icon:
+  default: dragon-plus
+  "31": modern-purple-flat
+
+patches:
+  - only-for-31:
+      "31":
+        url: ./my-31-only.patch
+        sha256: abc123...
+
+revision:
+  default: abc123
+  "31": def456
+#+end_src
+
+All existing =build.yml= files keep working unchanged: a plain value applies to every version, exactly as before. Malformed patch entries (missing =url= or =sha256=) are now rejected when the config is loaded instead of failing later during the build.
+
 * 2026-07-08
 
 ** Bug Fixes

--- a/README.org
+++ b/README.org
@@ -198,6 +198,16 @@ inject_path: true
 | =revision=    | /none/  | (Formula only) Pin Emacs source to a specific git revision.                  |
 | =inject_path= | =true=  | (Formula only) Inject user's PATH into Emacs.app. See [[#injected-path][→ Injected PATH]].     |
 
+=icon=, external/local patches, and =revision= also accept a per-version map keyed by major Emacs version (quoted, e.g. ="30"=) with an optional =default= fallback:
+
+#+begin_src yaml
+icon:
+  default: dragon-plus
+  "31": modern-purple-flat
+#+end_src
+
+An exact version match wins, =default= is used otherwise, and with no match the value is not applied. See [[#community-features][→ Community Features]] for patch examples.
+
 For more customization options, see [[#community-features][→ Community Features]] for patches and [[#icons][→ Icons]] for icon customization.
 
 ** Emacs 32
@@ -533,6 +543,13 @@ icon: modern-purple-flat
 #   - local-patch:
 #       url: ~/.config/emacs-plus/my-local.patch
 #       sha256: abc123...
+
+# Apply a patch only for a specific Emacs version
+# patches:
+#   - only-for-31:
+#       "31":
+#         url: ./my-31-only.patch
+#         sha256: abc123...
 #+end_src
 
 Then rebuild Emacs:

--- a/community/README.md
+++ b/community/README.md
@@ -56,6 +56,37 @@ icon:
 
 Local file paths (`/absolute/path`, `~/home/path`, `./relative/path`) are supported for patches. Relative paths are resolved relative to the directory containing `build.yml`.
 
+### Per-version configuration
+
+`icon`, external/local patches, and `revision` accept a version map instead of a single value. Keys are major Emacs versions (quoted, e.g. `"30"`) or `default`. An exact version match wins, `default` is the fallback, and with no match the value is simply not applied (for patches this means the patch is skipped for that version):
+
+```yaml
+icon:
+  default: icon-name-from-registry
+  "31":
+    url: https://example.com/external.icns
+    sha256: def456...
+
+patches:
+  - only-for-31:
+      "31":
+        url: ./my-31-only.patch    # skipped for other versions
+        sha256: abc123...
+  - per-version-patch:
+      default:
+        url: ./my.patch
+        sha256: abc123...
+      "31":
+        url: ./my-31.patch
+        sha256: def456...
+
+revision:
+  default: abc123
+  "31": def456
+```
+
+Community patches from the registry (plain names) already declare their supported Emacs versions in their metadata, so they do not need a version map.
+
 See `registry.json` for available features.
 
 ## Contributing

--- a/scripts/postinstall-cask.rb
+++ b/scripts/postinstall-cask.rb
@@ -32,6 +32,16 @@ def find_emacs_client_app(emacs_app)
   File.exist?(client) ? client : nil
 end
 
+# Major Emacs version for version-mapped config, from the formula path
+# (emacs-plus@NN) or the app bundle's Info.plist
+def detect_major_version(emacs_app)
+  return Regexp.last_match(1) if emacs_app =~ /emacs-plus@(\d+)/
+
+  plist = File.join(emacs_app, 'Contents', 'Info.plist')
+  ver = `/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' '#{plist}' 2>/dev/null`.strip
+  ver[/\A\d+/]
+end
+
 emacs_app = find_emacs_app(ARGV[0])
 
 unless emacs_app
@@ -46,9 +56,11 @@ unless emacs_app
 end
 
 emacs_client_app = find_emacs_client_app(emacs_app)
+major_version = detect_major_version(emacs_app)
 
 puts "==> Found Emacs.app: #{emacs_app}"
 puts "==> Found Emacs Client.app: #{emacs_client_app || '(not found)'}"
+puts "==> Emacs major version: #{major_version || '(unknown)'}"
 puts
 
 # Run CaskEnv.inject (environment setup)
@@ -65,7 +77,7 @@ puts
 # Run IconApplier.apply (custom icon)
 puts "==> Running IconApplier.apply..."
 begin
-  applied = IconApplier.apply(emacs_app, emacs_client_app)
+  applied = IconApplier.apply(emacs_app, emacs_client_app, version: major_version)
   puts applied ? "    Icon applied" : "    No custom icon configured"
 rescue BuildConfig::ConfigurationError => e
   puts "Error: #{e.message}"

--- a/scripts/postinstall-formula.rb
+++ b/scripts/postinstall-formula.rb
@@ -38,6 +38,16 @@ def find_emacs_client_app(emacs_app)
   File.exist?(client) ? client : nil
 end
 
+# Major Emacs version for version-mapped config, from the formula path
+# (emacs-plus@NN) or the app bundle's Info.plist
+def detect_major_version(emacs_app)
+  return Regexp.last_match(1) if emacs_app =~ /emacs-plus@(\d+)/
+
+  plist = File.join(emacs_app, 'Contents', 'Info.plist')
+  ver = `/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' '#{plist}' 2>/dev/null`.strip
+  ver[/\A\d+/]
+end
+
 emacs_app = find_emacs_app(ARGV[0])
 
 unless emacs_app
@@ -51,9 +61,11 @@ unless emacs_app
 end
 
 emacs_client_app = find_emacs_client_app(emacs_app)
+major_version = detect_major_version(emacs_app)
 
 puts "==> Found Emacs.app: #{emacs_app}"
 puts "==> Found Emacs Client.app: #{emacs_client_app || '(not found)'}"
+puts "==> Emacs major version: #{major_version || '(unknown)'}"
 puts
 
 # Load and validate config
@@ -75,10 +87,17 @@ end
 puts
 
 # Validate against registry (formula-specific validation)
-if config["icon"].is_a?(String)
+icon_names = if BuildConfig.version_map?(config["icon"])
+  config["icon"].values.grep(String)
+elsif config["icon"].is_a?(String)
+  [config["icon"]]
+else
+  []
+end
+icon_names.each do |name|
   registry = BuildConfig.registry
-  unless registry.dig("icons", config["icon"])
-    puts "Error: Unknown icon '#{config["icon"]}'"
+  unless registry.dig("icons", name)
+    puts "Error: Unknown icon '#{name}'"
     puts "Check community/registry.json for available icons."
     exit 1
   end
@@ -102,7 +121,7 @@ puts
 # Apply icon
 puts "==> Running IconApplier.apply..."
 begin
-  applied = IconApplier.apply(emacs_app, emacs_client_app)
+  applied = IconApplier.apply(emacs_app, emacs_client_app, version: major_version)
   puts applied ? "    Icon applied" : "    No custom icon configured"
 rescue => e
   puts "Error: #{e.message}"

--- a/tests/test_build_config.rb
+++ b/tests/test_build_config.rb
@@ -397,6 +397,362 @@ class TestBuildConfig < Minitest::Test
   end
 
   # ===========================================
+  # Tests for version maps (unified convention)
+  # ===========================================
+
+  def test_valid_icon_version_map_with_string_values
+    yaml = <<~YAML
+      icon:
+        default: modern-purple-flat
+        "30": with-modern-vscode-icon
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "modern-purple-flat", result[:config]["icon"]["default"]
+      assert_equal "with-modern-vscode-icon", result[:config]["icon"]["30"]
+    end
+  end
+
+  def test_valid_icon_version_map_with_external_values
+    yaml = <<~YAML
+      icon:
+        default: modern-purple-flat
+        "31":
+          url: https://example.com/icon.icns
+          sha256: abc123
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "https://example.com/icon.icns", result[:config]["icon"]["31"]["url"]
+    end
+  end
+
+  def test_valid_icon_version_map_without_default
+    yaml = <<~YAML
+      icon:
+        "31": modern-purple-flat
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "modern-purple-flat", result[:config]["icon"]["31"]
+    end
+  end
+
+  def test_valid_icon_version_map_with_integer_keys
+    yaml = <<~YAML
+      icon:
+        30: modern-purple-flat
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "modern-purple-flat", result[:config]["icon"][30]
+    end
+  end
+
+  def test_invalid_icon_version_map_bad_key
+    yaml = <<~YAML
+      icon:
+        stable: modern-purple-flat
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "Invalid 'icon'"
+      assert_includes error.message, "stable"
+      assert_includes error.message, "default"
+    end
+  end
+
+  def test_invalid_icon_version_map_nested_map
+    yaml = <<~YAML
+      icon:
+        "30":
+          default: modern-purple-flat
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "Invalid 'icon"
+    end
+  end
+
+  def test_invalid_icon_version_map_spec_missing_sha256
+    yaml = <<~YAML
+      icon:
+        "30":
+          url: https://example.com/icon.icns
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "sha256"
+    end
+  end
+
+  def test_invalid_icon_version_map_non_string_value
+    yaml = <<~YAML
+      icon:
+        "30": 5
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "Invalid 'icon"
+    end
+  end
+
+  def test_valid_patch_version_map
+    yaml = <<~YAML
+      patches:
+        - my-patch:
+            "31":
+              url: ./my-patch.patch
+              sha256: abc123
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      spec = result[:config]["patches"].first["my-patch"]
+      assert_equal "./my-patch.patch", spec["31"]["url"]
+    end
+  end
+
+  def test_valid_patch_version_map_with_default
+    yaml = <<~YAML
+      patches:
+        - my-patch:
+            default:
+              url: ./my-patch.patch
+              sha256: abc123
+            "31":
+              url: ./my-patch-31.patch
+              sha256: def456
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      spec = result[:config]["patches"].first["my-patch"]
+      assert_equal "./my-patch-31.patch", spec["31"]["url"]
+      assert_equal "./my-patch.patch", spec["default"]["url"]
+    end
+  end
+
+  def test_valid_patch_external_spec_still_works
+    yaml = <<~YAML
+      patches:
+        - registry-patch
+        - my-patch:
+            url: https://example.com/my.patch
+            sha256: abc123
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "registry-patch", result[:config]["patches"].first
+    end
+  end
+
+  def test_invalid_patch_version_map_bad_key
+    yaml = <<~YAML
+      patches:
+        - my-patch:
+            stable:
+              url: ./my.patch
+              sha256: abc123
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "my-patch"
+      assert_includes error.message, "stable"
+    end
+  end
+
+  def test_invalid_patch_version_map_value_not_spec
+    yaml = <<~YAML
+      patches:
+        - my-patch:
+            "31": just-a-string
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "my-patch"
+    end
+  end
+
+  def test_invalid_patch_spec_missing_sha256
+    yaml = <<~YAML
+      patches:
+        - my-patch:
+            url: https://example.com/my.patch
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "my-patch"
+      assert_includes error.message, "sha256"
+    end
+  end
+
+  def test_invalid_patch_entry_number
+    yaml = <<~YAML
+      patches:
+        - 42
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "Invalid 'patches"
+    end
+  end
+
+  def test_valid_revision_map_with_default
+    yaml = <<~YAML
+      revision:
+        default: abc123
+        "31": def456
+    YAML
+    with_temp_config(yaml) do |path|
+      result = load_config_from_path(path)
+      assert_equal "abc123", result[:config]["revision"]["default"]
+      assert_equal "def456", result[:config]["revision"]["31"]
+    end
+  end
+
+  def test_invalid_revision_map_bad_key
+    yaml = <<~YAML
+      revision:
+        stable: abc123
+    YAML
+    with_temp_config(yaml) do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "Invalid 'revision'"
+      assert_includes error.message, "stable"
+    end
+  end
+
+  # ===========================================
+  # Tests for resolve_versioned
+  # ===========================================
+
+  def test_resolve_versioned_passes_through_string
+    assert_equal "abc", BuildConfig.resolve_versioned("abc", "30")
+  end
+
+  def test_resolve_versioned_passes_through_nil
+    assert_nil BuildConfig.resolve_versioned(nil, "30")
+  end
+
+  def test_resolve_versioned_passes_through_external_spec
+    spec = { "url" => "https://example.com/x", "sha256" => "abc" }
+    assert_equal spec, BuildConfig.resolve_versioned(spec, "30")
+  end
+
+  def test_resolve_versioned_exact_match_wins_over_default
+    map = { "default" => "a", "30" => "b" }
+    assert_equal "b", BuildConfig.resolve_versioned(map, "30")
+  end
+
+  def test_resolve_versioned_falls_back_to_default
+    map = { "default" => "a", "30" => "b" }
+    assert_equal "a", BuildConfig.resolve_versioned(map, "31")
+  end
+
+  def test_resolve_versioned_returns_nil_without_match_or_default
+    map = { "30" => "b" }
+    assert_nil BuildConfig.resolve_versioned(map, "31")
+  end
+
+  def test_resolve_versioned_matches_integer_keys
+    map = { 30 => "b" }
+    assert_equal "b", BuildConfig.resolve_versioned(map, "30")
+  end
+
+  def test_resolve_versioned_accepts_integer_version
+    map = { "30" => "b" }
+    assert_equal "b", BuildConfig.resolve_versioned(map, 30)
+  end
+
+  def test_resolve_versioned_nil_version_uses_default
+    map = { "default" => "a", "30" => "b" }
+    assert_equal "a", BuildConfig.resolve_versioned(map, nil)
+  end
+
+  def test_resolve_versioned_empty_hash_resolves_to_nil
+    assert_nil BuildConfig.resolve_versioned({}, "30")
+  end
+
+  def test_invalid_icon_empty_hash_still_rejected
+    with_temp_config("icon: {}") do |path|
+      error = assert_raises(BuildConfig::ConfigurationError) do
+        load_config_from_path(path)
+      end
+      assert_includes error.message, "sha256"
+    end
+  end
+
+  # ===========================================
+  # Tests for versioned resolve_icon
+  # ===========================================
+
+  def test_resolve_icon_versioned_external_spec
+    config = {
+      "icon" => {
+        "31" => { "url" => "https://example.com/icon.icns", "sha256" => "abc123" },
+      },
+    }
+    icon = BuildConfig.resolve_icon(config, version: "31")
+    assert_equal "external", icon[:type]
+    assert_equal "https://example.com/icon.icns", icon[:url]
+  end
+
+  def test_resolve_icon_versioned_no_match_returns_nil
+    config = {
+      "icon" => {
+        "31" => { "url" => "https://example.com/icon.icns", "sha256" => "abc123" },
+      },
+    }
+    assert_nil BuildConfig.resolve_icon(config, version: "30")
+  end
+
+  def test_resolve_icon_versioned_default_fallback
+    config = {
+      "icon" => {
+        "default" => { "url" => "https://example.com/d.icns", "sha256" => "d" },
+        "31" => { "url" => "https://example.com/31.icns", "sha256" => "e" },
+      },
+    }
+    icon = BuildConfig.resolve_icon(config, version: "30")
+    assert_equal "https://example.com/d.icns", icon[:url]
+  end
+
+  def test_resolve_icon_without_version_uses_default
+    config = {
+      "icon" => {
+        "default" => { "url" => "https://example.com/d.icns", "sha256" => "d" },
+      },
+    }
+    icon = BuildConfig.resolve_icon(config)
+    assert_equal "https://example.com/d.icns", icon[:url]
+  end
+
+  def test_resolve_icon_plain_external_still_works
+    config = {
+      "icon" => { "url" => "https://example.com/icon.icns", "sha256" => "abc123" },
+    }
+    icon = BuildConfig.resolve_icon(config, version: "30")
+    assert_equal "external", icon[:type]
+  end
+
+  # ===========================================
   # Tests for context warnings
   # ===========================================
 


### PR DESCRIPTION
Unified per-version convention for build.yml, as discussed in #950 and #973.

`icon`, external/local `patches`, and `revision` now accept a version map keyed by major Emacs version, with an optional `default` fallback:

```yaml
icon:
  default: dragon-plus
  "31": modern-purple-flat

patches:
  - only-for-31:
      "31":
        url: ./my-31-only.patch
        sha256: abc123...

revision:
  default: abc123
  "31": def456
```

Exact version match wins, `default` is the fallback, and with no match the value is just not applied (patches get skipped for that version, with a note in the build output).

Disambiguation is the rule from #950: a hash with `url`/`sha256` keys is an external spec, anything else is a version map. A version key is never literally `url` or `sha256`, so old and new shapes cannot collide, and every existing build.yml keeps working unchanged. The cask side gets the version threaded through `IconApplier.apply`, so per-version icons work for casks too.

One behavior change: patch entries missing `url` or `sha256` now fail at config load with a pointed message instead of blowing up mid-build (the early-validation direction from #950). Same for unknown revision keys. This also surfaces in cask installs, where broken patches/revision entries were previously ignored.

Closes #950
Closes #973