### PR TITLE
chore(emacs-plus@31): update to 31.0.91

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT31 < EmacsBase
-  init "31.0.90", branch: "emacs-31"
+  init "31.0.91", branch: "emacs-31"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"


### PR DESCRIPTION
Second pretest for Emacs 31.1 is out: https://lists.gnu.org/archive/html/emacs-devel/2026-07/msg00270.html

The formula builds from the emacs-31 branch, which is already at 31.0.91, so this just bumps the version string. Same as #946 for the previous pretest.