### PR TITLE
fix(build-app): sync emacs-30 cask patch list with formula

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -93,8 +93,8 @@ jobs:
             "fix-window-role"
             "system-appearance"
             "round-undecorated-frame"
-            "mac-font-use-typo-metrics"
             "fix-macos-tahoe-scrolling"
+            "fix-ns-x-colors"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"


### PR DESCRIPTION
The Emacs 30 job in build-app.yml was out of sync with the formula:

- it was missing `fix-ns-x-colors`, which `Formula/emacs-plus@30.rb` applies unconditionally (the 31 and 32 jobs already have it)
- it listed `mac-font-use-typo-metrics`, but there is no such patch under `patches/emacs-30/`, so the entry was silently skipped

This adds `fix-ns-x-colors` to the 30 job's patch list and drops the dead `mac-font-use-typo-metrics` entry.

Merging this touches the workflow path, so a cask rebuild is expected. Fixes the cask side of #976.