### PR TITLE
refactor(cask): extract shared postflight logic into Library

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -52,39 +52,15 @@ cask "emacs-plus-app" do
   app "Emacs Client.app"
 
   # Remove quarantine attribute, inject PATH, and apply custom icon
+  # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
   postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs.app"],
-                   sudo: false
-    system_command "/usr/bin/xattr",
-                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs Client.app"],
-                   sudo: false
-
-    # Environment setup for native compilation and CLI usage
     tap = Tap.fetch("d12frosted", "emacs-plus")
-    load "#{tap.path}/Library/CaskEnv.rb"
-    needs_resign = CaskEnv.inject("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app")
-
-    # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
-    load "#{tap.path}/Library/IconApplier.rb"
-    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app", version: version.major) || needs_resign
-
-    if needs_resign
-      # Re-sign after modifications
-      system_command "/usr/bin/codesign",
-                     args: ["--force", "--deep", "--sign", "-", "#{appdir}/Emacs.app"],
-                     sudo: false
-      system_command "/usr/bin/codesign",
-                     args: ["--force", "--deep", "--sign", "-", "#{appdir}/Emacs Client.app"],
-                     sudo: false
-    end
-
-    # Create emacs symlink manually (can't use binary stanza since wrapper is created above)
-    emacs_wrapper = "#{appdir}/Emacs.app/Contents/MacOS/bin/emacs"
-    emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
-    if File.exist?(emacs_wrapper) && !File.exist?(emacs_symlink)
-      FileUtils.ln_sf(emacs_wrapper, emacs_symlink)
-    end
+    load "#{tap.path}/Library/CaskPostflight.rb"
+    CaskPostflight.run(self,
+                       emacs_app: "#{appdir}/Emacs.app",
+                       emacs_client_app: "#{appdir}/Emacs Client.app",
+                       version: version.major,
+                       homebrew_prefix: HOMEBREW_PREFIX.to_s)
   end
 
   # Clean up emacs symlink on uninstall (since we create it manually in postflight)

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -52,39 +52,15 @@ cask "emacs-plus-app@master" do
   app "Emacs Client.app"
 
   # Remove quarantine attribute, inject PATH, and apply custom icon
+  # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
   postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs.app"],
-                   sudo: false
-    system_command "/usr/bin/xattr",
-                   args: ["-r", "-d", "com.apple.quarantine", "#{appdir}/Emacs Client.app"],
-                   sudo: false
-
-    # Environment setup for native compilation and CLI usage
     tap = Tap.fetch("d12frosted", "emacs-plus")
-    load "#{tap.path}/Library/CaskEnv.rb"
-    needs_resign = CaskEnv.inject("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app")
-
-    # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
-    load "#{tap.path}/Library/IconApplier.rb"
-    needs_resign = IconApplier.apply("#{appdir}/Emacs.app", "#{appdir}/Emacs Client.app", version: version.major) || needs_resign
-
-    if needs_resign
-      # Re-sign after modifications
-      system_command "/usr/bin/codesign",
-                     args: ["--force", "--deep", "--sign", "-", "#{appdir}/Emacs.app"],
-                     sudo: false
-      system_command "/usr/bin/codesign",
-                     args: ["--force", "--deep", "--sign", "-", "#{appdir}/Emacs Client.app"],
-                     sudo: false
-    end
-
-    # Create emacs symlink manually (can't use binary stanza since wrapper is created above)
-    emacs_wrapper = "#{appdir}/Emacs.app/Contents/MacOS/bin/emacs"
-    emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
-    if File.exist?(emacs_wrapper) && !File.exist?(emacs_symlink)
-      FileUtils.ln_sf(emacs_wrapper, emacs_symlink)
-    end
+    load "#{tap.path}/Library/CaskPostflight.rb"
+    CaskPostflight.run(self,
+                       emacs_app: "#{appdir}/Emacs.app",
+                       emacs_client_app: "#{appdir}/Emacs Client.app",
+                       version: version.major,
+                       homebrew_prefix: HOMEBREW_PREFIX.to_s)
   end
 
   # Clean up emacs symlink on uninstall (since we create it manually in postflight)

--- a/Library/CaskPostflight.rb
+++ b/Library/CaskPostflight.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# CaskPostflight - Shared postflight logic for emacs-plus-app casks
+#
+# All emacs-plus-app* casks run the same post-install steps; only the
+# release channel they download differs. This module keeps that logic in
+# one place so the casks cannot drift apart. It handles:
+#
+# 1. Removing the quarantine attribute from both app bundles
+# 2. Environment injection (CaskEnv) and custom icon (IconApplier)
+# 3. Re-signing the bundles if they were modified
+# 4. Symlinking bin/emacs into HOMEBREW_PREFIX
+#
+# The matching cleanup (removing the emacs symlink) stays inline in each
+# cask's uninstall_postflight so uninstall does not depend on this file.
+#
+# ctx is the cask's postflight block (self), which provides system_command.
+
+require 'fileutils'
+require_relative 'CaskEnv'
+require_relative 'IconApplier'
+
+module CaskPostflight
+  class << self
+    def run(ctx, emacs_app:, emacs_client_app:, version:, homebrew_prefix:)
+      remove_quarantine(ctx, emacs_app)
+      remove_quarantine(ctx, emacs_client_app)
+
+      # Environment setup for native compilation and CLI usage
+      needs_resign = CaskEnv.inject(emacs_app, emacs_client_app)
+
+      # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
+      needs_resign = IconApplier.apply(emacs_app, emacs_client_app, version: version) || needs_resign
+
+      if needs_resign
+        resign(ctx, emacs_app)
+        resign(ctx, emacs_client_app)
+      end
+
+      link_emacs(emacs_app, homebrew_prefix)
+    end
+
+    private
+
+    def remove_quarantine(ctx, app)
+      ctx.system_command "/usr/bin/xattr",
+                         args: ["-r", "-d", "com.apple.quarantine", app],
+                         sudo: false
+    end
+
+    def resign(ctx, app)
+      ctx.system_command "/usr/bin/codesign",
+                         args: ["--force", "--deep", "--sign", "-", app],
+                         sudo: false
+    end
+
+    # Create the emacs symlink manually: the wrapper script is generated
+    # by CaskEnv during postflight, and binary stanzas run before that.
+    def link_emacs(emacs_app, homebrew_prefix)
+      emacs_wrapper = "#{emacs_app}/Contents/MacOS/bin/emacs"
+      emacs_symlink = "#{homebrew_prefix}/bin/emacs"
+      if File.exist?(emacs_wrapper) && !File.exist?(emacs_symlink)
+        FileUtils.ln_sf(emacs_wrapper, emacs_symlink)
+      end
+    end
+  end
+end

--- a/tests/test_cask_postflight.rb
+++ b/tests/test_cask_postflight.rb
@@ -1,0 +1,174 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test suite for CaskPostflight shared cask postflight logic
+#
+# Run with: ruby tests/test_cask_postflight.rb
+
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'tmpdir'
+require 'fileutils'
+
+# Mock Hardware::CPU for testing without Homebrew (CaskEnv depends on it)
+module Hardware
+  module CPU
+    class << self
+      attr_accessor :mock_arm
+
+      def arm?
+        @mock_arm.nil? ? false : @mock_arm
+      end
+    end
+  end
+end
+
+require_relative '../Library/CaskPostflight'
+
+# Records system_command invocations the way a cask postflight block would
+class FakeContext
+  Command = Struct.new(:cmd, :args, :sudo, keyword_init: true)
+
+  attr_reader :commands
+
+  def initialize
+    @commands = []
+  end
+
+  def system_command(cmd, args:, sudo: false)
+    @commands << Command.new(cmd: cmd, args: args, sudo: sudo)
+  end
+end
+
+class TestCaskPostflight < Minitest::Test
+  def setup
+    Hardware::CPU.mock_arm = true
+    @tmpdir = Dir.mktmpdir
+    @emacs_app = File.join(@tmpdir, 'Emacs.app')
+    @client_app = File.join(@tmpdir, 'Emacs Client.app')
+    @prefix = File.join(@tmpdir, 'prefix')
+    FileUtils.mkdir_p(File.join(@emacs_app, 'Contents/MacOS/bin'))
+    FileUtils.mkdir_p(@client_app)
+    FileUtils.mkdir_p(File.join(@prefix, 'bin'))
+    @ctx = FakeContext.new
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def run_postflight(inject: false, icon: false)
+    inject_args = nil
+    icon_args = nil
+    CaskEnv.stub(:inject, lambda { |*args|
+      inject_args = args
+      inject
+    }) do
+      IconApplier.stub(:apply, lambda { |*args, **kwargs|
+        icon_args = [args, kwargs]
+        icon
+      }) do
+        CaskPostflight.run(@ctx,
+                           emacs_app: @emacs_app,
+                           emacs_client_app: @client_app,
+                           version: '31',
+                           homebrew_prefix: @prefix)
+      end
+    end
+    { inject_args: inject_args, icon_args: icon_args }
+  end
+
+  def commands_for(cmd)
+    @ctx.commands.select { |c| c.cmd == cmd }
+  end
+
+  # ===========================================
+  # Quarantine removal
+  # ===========================================
+
+  def test_removes_quarantine_from_both_apps
+    run_postflight
+    xattr = commands_for('/usr/bin/xattr')
+    assert_equal 2, xattr.size
+    assert_equal ['-r', '-d', 'com.apple.quarantine', @emacs_app], xattr[0].args
+    assert_equal ['-r', '-d', 'com.apple.quarantine', @client_app], xattr[1].args
+    xattr.each { |c| refute c.sudo }
+  end
+
+  # ===========================================
+  # Env injection and icon application
+  # ===========================================
+
+  def test_passes_app_paths_to_cask_env
+    result = run_postflight
+    assert_equal [@emacs_app, @client_app], result[:inject_args]
+  end
+
+  def test_passes_app_paths_and_version_to_icon_applier
+    result = run_postflight
+    args, kwargs = result[:icon_args]
+    assert_equal [@emacs_app, @client_app], args
+    assert_equal({ version: '31' }, kwargs)
+  end
+
+  def test_applies_icon_even_when_env_injection_modified_bundles
+    result = run_postflight(inject: true, icon: false)
+    refute_nil result[:icon_args]
+  end
+
+  # ===========================================
+  # Re-signing
+  # ===========================================
+
+  def test_no_resign_when_bundles_untouched
+    run_postflight(inject: false, icon: false)
+    assert_empty commands_for('/usr/bin/codesign')
+  end
+
+  def test_resigns_both_apps_after_env_injection
+    run_postflight(inject: true, icon: false)
+    codesign = commands_for('/usr/bin/codesign')
+    assert_equal 2, codesign.size
+    assert_equal ['--force', '--deep', '--sign', '-', @emacs_app], codesign[0].args
+    assert_equal ['--force', '--deep', '--sign', '-', @client_app], codesign[1].args
+  end
+
+  def test_resigns_both_apps_after_icon_application
+    run_postflight(inject: false, icon: true)
+    assert_equal 2, commands_for('/usr/bin/codesign').size
+  end
+
+  # ===========================================
+  # emacs symlink
+  # ===========================================
+
+  def wrapper_path
+    File.join(@emacs_app, 'Contents/MacOS/bin/emacs')
+  end
+
+  def symlink_path
+    File.join(@prefix, 'bin/emacs')
+  end
+
+  def test_creates_emacs_symlink_when_wrapper_exists
+    FileUtils.touch(wrapper_path)
+    run_postflight
+    assert File.symlink?(symlink_path)
+    assert_equal wrapper_path, File.readlink(symlink_path)
+  end
+
+  def test_keeps_existing_emacs_symlink
+    FileUtils.touch(wrapper_path)
+    other_target = File.join(@tmpdir, 'other-emacs')
+    FileUtils.touch(other_target)
+    File.symlink(other_target, symlink_path)
+    run_postflight
+    assert_equal other_target, File.readlink(symlink_path)
+  end
+
+  def test_no_symlink_when_wrapper_missing
+    run_postflight
+    refute File.exist?(symlink_path)
+    refute File.symlink?(symlink_path)
+  end
+end


### PR DESCRIPTION
The app casks duplicate the same 35-line postflight block (quarantine removal, env injection, icon, re-signing, emacs symlink), and it already drifted once (the ctags symlink). This moves the logic into Library/CaskPostflight.rb next to CaskEnv and IconApplier, with unit tests. Uninstall cleanup stays inline so uninstall does not depend on tap files.

Prep for adding emacs-plus-app@next (#978).