### PR TITLE
feat(cask): add emacs-plus-app@next tracking the release branch

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1444,8 +1444,8 @@ jobs:
           fi
 
   release-31:
-    # Emacs 31 (pre-release): publish artifacts. Does not update a cask file —
-    # there's no dedicated @31 cask, since 31 hasn't been released yet.
+    # Emacs 31 (pre-release): publish artifacts and update the
+    # emacs-plus-app@next cask, which tracks the release branch.
     needs: build-31
     runs-on: ubuntu-latest
     permissions:
@@ -1484,14 +1484,71 @@ jobs:
             - Commit: ${{ github.sha }}
 
             **Installation:**
-            Download the appropriate `.zip` and copy `Emacs.app` and
-            `Emacs Client.app` into `/Applications`.
+            ```
+            brew tap d12frosted/emacs-plus
+            brew install --cask emacs-plus-app@next
+            ```
 
             For source builds, use the formula:
             ```
-            brew tap d12frosted/emacs-plus
             brew install emacs-plus@31
             ```
+
+      - name: Update cask file
+        run: |
+          BUILD_NUM=${{ github.run_number }}
+
+          # Get Emacs full version from artifact
+          EMACS_VER=$(cat artifacts/*/emacs-version.txt | head -1)
+          echo "Emacs version: $EMACS_VER"
+
+          CASK_FILE="Casks/emacs-plus-app@next.rb"
+          echo "Updating $CASK_FILE"
+
+          # Extract SHA256 for each build and update cask
+          for sha_file in artifacts/*/*.sha256; do
+            filename=$(basename "$sha_file" .sha256)
+            sha=$(awk '{print $1}' "$sha_file")
+            echo "Found: $filename -> $sha"
+
+            # Determine arch and OS from filename (emacs-plus-31.0.91-arm64-26.zip)
+            if [[ "$filename" =~ (arm64|x86_64)-([0-9]+)\.zip$ ]]; then
+              arch="${BASH_REMATCH[1]}"
+              os_ver="${BASH_REMATCH[2]}"
+              url_pattern="${arch}-${os_ver}.zip"
+
+              echo "Updating SHA for $url_pattern to $sha"
+              python3 .github/scripts/update_cask_sha.py "$CASK_FILE" "$sha" "$url_pattern"
+            else
+              echo "Unknown filename pattern: $filename"
+            fi
+          done
+
+          # Update version
+          echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
+          sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
+
+          # Show the changes
+          git diff "$CASK_FILE"
+
+      - name: Commit and push cask update
+        run: |
+          CASK_FILE="Casks/emacs-plus-app@next.rb"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CASK_FILE"
+          # Only commit if there are changes
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(emacs-plus-app@next): update cask to build ${{ github.run_number }}"
+            # Retry push with exponential backoff (handles race with other release jobs)
+            for i in 1 2 3 4 5; do
+              git pull --rebase origin master && git push && break
+              echo "Push failed, retrying in $((i * 2)) seconds..."
+              sleep $((i * 2))
+            done
+          fi
 
   release-32:
     needs: build-32

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -45,6 +45,7 @@ cask "emacs-plus-app" do
     "emacs-mac",
     "emacs-mac-spacemacs-icon",
     "emacs-plus-app@master",
+    "emacs-plus-app@next",
   ]
 
   # Install the app

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -1,36 +1,36 @@
-cask "emacs-plus-app@master" do
+cask "emacs-plus-app@next" do
   # Version format: <emacs-version>-<build-number>
   # Build number corresponds to GitHub Actions run number
-  version "32.0.50-291"
+  version "31.0.91-291"
 
-  # Base URL for release assets (versioned releases: cask-32-<build>)
-  base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-32-#{version.sub(/^[\d.]+-/, "")}"
+  # Base URL for release assets (versioned releases: cask-31-<build>)
+  base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-31-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
   on_intel do
-    sha256 "6f218b04fe2c8f705768e0c6656a5cc668136c8e4c15f4bd0797f3735b18da56"
+    sha256 "e76ef664e30b25a5a46f43a21d9c7214ddd429301f7b330ef57c172cc9281bf4"
     url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
         verified: "github.com/d12frosted/homebrew-emacs-plus"
   end
 
   on_arm do
     if MacOS.version >= :tahoe # macOS 26
-      sha256 "c7732b0cfa8a8484a73d7c50130e5071df94ac16a03148e1738b8905fb471fac"
+      sha256 "cafbb16843818d350ef7e565a16fe76bda02874e2fa96d933868c5e5493d0418"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     elsif MacOS.version >= :sequoia # macOS 15
-      sha256 "aa70e5946e3c18df9d9fb0f2759fadc61dd51262925e21673c87a50fc2958718"
+      sha256 "c3c58b81e68a666a796e02983507f90bba11445ae8b421fbd0b41afc06220fb3"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     else # macOS 14 (Sonoma) and 13 (Ventura)
-      sha256 "2e348e341a13b0d2a8a773565c00f4fa97dbea16039207b7e9b2de533e52384d"
+      sha256 "09a7d0dfc9c73a0c31fc64bfb387112ab0f70fb37575a2d5b894533f7d1c2697"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
 
-  name "Emacs+ (Development)"
-  desc "GNU Emacs text editor with patches for macOS (development version)"
+  name "Emacs+ (Pre-release)"
+  desc "GNU Emacs text editor with patches for macOS (next stable release)"
   homepage "https://github.com/d12frosted/homebrew-emacs-plus"
 
   # Required for native compilation (JIT) at runtime
@@ -45,7 +45,7 @@ cask "emacs-plus-app@master" do
     "emacs-mac",
     "emacs-mac-spacemacs-icon",
     "emacs-plus-app",
-    "emacs-plus-app@next",
+    "emacs-plus-app@master",
   ]
 
   # Install the app
@@ -73,6 +73,7 @@ cask "emacs-plus-app@master" do
   # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
   # Note: emacs is symlinked manually in postflight because the wrapper script
   # is created there and binary stanzas run before postflight
+  # Note: no ctags symlink; the ctags program was removed in Emacs 31
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
@@ -92,17 +93,19 @@ cask "emacs-plus-app@master" do
   ]
 
   caveats <<~EOS
-    Emacs+ (development) has been installed to /Applications.
+    Emacs+ (pre-release) has been installed to /Applications.
 
-    This is a pre-built binary from the Emacs master branch (Emacs 32).
+    This is a pre-built binary from the Emacs release branch (currently
+    Emacs 31, pretest). It tracks the next stable release: less bleeding
+    edge than @master, newer than the stable cask.
     For custom patches or build options, use the formula instead:
-      brew install emacs-plus@master --with-...
+      brew install emacs-plus@31 --with-...
 
     Custom icons can be configured via ~/.config/emacs-plus/build.yml:
       icon: dragon-plus
 
     To re-apply an icon after changing build.yml:
-      brew reinstall --cask emacs-plus-app@master
+      brew reinstall --cask emacs-plus-app@next
 
     Note: Emacs Client.app requires Emacs to be running as a daemon.
     Add to your Emacs config: (server-start)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #   make postinstall-formula      Re-run formula post_install
 #   make postinstall-cask         Re-run cask postflight
 
-.PHONY: test validate postinstall-formula postinstall-cask cask cask@master help
+.PHONY: test validate postinstall-formula postinstall-cask cask cask@next cask@master help
 
 # Capture extra args (everything after the target)
 EXTRA_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -34,6 +34,7 @@ help:
 	@echo ""
 	@echo "Cask (pre-built binary, tests local Cask/ and Library/ changes):"
 	@echo "  make cask                     Install emacs-plus-app cask"
+	@echo "  make cask@next                Install emacs-plus-app@next cask"
 	@echo "  make cask@master              Install emacs-plus-app@master cask"
 	@echo ""
 	@echo "Post-install (test on existing installation):"
@@ -130,6 +131,19 @@ cask:
 	    -e 's|#{tap.path}|#{local_path}|g' \
 	    "$$BACKUP" > "$$TAP_CASK"; \
 	brew reinstall --cask emacs-plus-app $(EXTRA_ARGS)
+
+cask@next:
+	@echo "==> Installing emacs-plus-app@next cask (with local Library/ changes)"
+	@LOCAL_PATH=$$(pwd); \
+	TAP_CASK="$$(brew --repository d12frosted/emacs-plus)/Casks/emacs-plus-app@next.rb"; \
+	BACKUP="$$TAP_CASK.backup"; \
+	cleanup() { [ -f "$$BACKUP" ] && mv "$$BACKUP" "$$TAP_CASK"; }; \
+	trap cleanup EXIT INT TERM; \
+	cp "$$TAP_CASK" "$$BACKUP"; \
+	sed -e "s|tap = Tap.fetch.*|local_path = \"$$LOCAL_PATH\"|" \
+	    -e 's|#{tap.path}|#{local_path}|g' \
+	    "$$BACKUP" > "$$TAP_CASK"; \
+	brew reinstall --cask emacs-plus-app@next $(EXTRA_ARGS)
 
 cask@master:
 	@echo "==> Installing emacs-plus-app@master cask (with local Library/ changes)"

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,22 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-08-12
+
+** New Features
+
+*** =emacs-plus-app@next= cask
+
+New cask that tracks the Emacs release branch (currently =emacs-31=, the Emacs 31 pretest). It fills the gap between the stable cask and the =@master= nightly: newer than stable, less bleeding edge than master. Built and updated nightly, same as =@master=. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/978][#978]].
+
+#+begin_src bash
+  $ brew install --cask emacs-plus-app           # latest stable
+  $ brew install --cask emacs-plus-app@next      # nightly from release branch (next stable)
+  $ brew install --cask emacs-plus-app@master    # nightly from master
+#+end_src
+
+Note for users switching from the stable cask: there is no =emacs-ctags= symlink, since the =ctags= program was removed in Emacs 31 (same as =@master=).
+
 * 2026-07-12
 
 ** New Features

--- a/README.org
+++ b/README.org
@@ -31,6 +31,7 @@ Emacs+ is [[https://www.gnu.org/software/emacs/emacs.html][→ GNU Emacs]] formu
 
   # Pre-built binaries (fast, ~1 min)
   $ brew install --cask emacs-plus-app          # latest stable
+  $ brew install --cask emacs-plus-app@next     # nightly from release branch (next stable)
   $ brew install --cask emacs-plus-app@master   # nightly from master
 
   # Build from source (customizable, ~30 min)
@@ -105,6 +106,7 @@ For fast installation without compilation (~1 min), pre-built binaries are avail
 #+begin_src bash
   $ brew tap d12frosted/emacs-plus
   $ brew install --cask emacs-plus-app           # latest stable
+  $ brew install --cask emacs-plus-app@next      # nightly from release branch (next stable)
   $ brew install --cask emacs-plus-app@master    # nightly from master
 #+end_src
 

--- a/docs/development-guidelines.org
+++ b/docs/development-guidelines.org
@@ -106,6 +106,7 @@ Install casks from pre-built binaries (tests local Cask/ and Library/ changes):
 
 #+begin_src bash
   $ make cask                    # Install emacs-plus-app cask
+  $ make cask@next               # Install emacs-plus-app@next cask
   $ make cask@master             # Install emacs-plus-app@master cask
 #+end_src
 


### PR DESCRIPTION
New cask built from the Emacs release branch (currently emacs-31, the Emacs 31 pretest): newer than the stable cask, less bleeding edge than @master. The 31 binaries were already built and published nightly by the release-31 job; this wires them to a cask and makes the job update it, same as release-32 does for @master. No ctags symlink, the program was removed in Emacs 31.

Closes #978