### PR TITLE
fix(emacs-plus@31,32): fix NS scroll crash on macOS (bug#81585)

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -74,6 +74,7 @@ class EmacsPlusAT31 < EmacsBase
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "c9430a1ead81e313b3d2877ff6f8044fb29441eecc7cc42000515d7c8ec6380f"
+  local_patch "fix-ns-scroll-crash", sha: "3250bf6e45cdcb3f4cbc0ace2d2d3200464331cbfb34613980554e31ec45fe6c"
 
   #
   # Install

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -72,6 +72,7 @@ class EmacsPlusAT32 < EmacsBase
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "c9430a1ead81e313b3d2877ff6f8044fb29441eecc7cc42000515d7c8ec6380f"
+  local_patch "fix-ns-scroll-crash", sha: "3250bf6e45cdcb3f4cbc0ace2d2d3200464331cbfb34613980554e31ec45fe6c"
 
   #
   # Install

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,20 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-08-18
+
+** Bug Fixes
+
+*** Crash on macOS when hiding the header-line with =pixel-scroll-precision-mode=
+
+With =pixel-scroll-precision-mode= enabled, scrolling so a line is only partially visible and then hiding the header-line crashed Emacs with a bus error. Redisplay can send negative coordinates to the NS scroll code, which passes them straight to the pixel buffer copy. Without the fix, a fragment of the header-line is also painted over the mode-line of the window above (or over the tab-bar).
+
+This is Alan Third's patch from [[https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81585][bug#81585]], which did not make it into the Emacs 31.1 release candidate. It is applied to =emacs-plus@31= and =emacs-plus@32= and will be dropped once it lands upstream.
+
+#+begin_src bash
+  brew reinstall emacs-plus@31
+#+end_src
+
 * 2026-08-12
 
 ** New Features

--- a/patches/emacs-31/fix-ns-scroll-crash.patch
+++ b/patches/emacs-31/fix-ns-scroll-crash.patch
@@ -1,0 +1,68 @@
+Fix crash in NS scroll code (bug#81585).
+
+On macOS, toggling off the header-line while pixel-scroll-precision-mode
+is enabled and the window is scrolled so a line is only partially visible
+crashes Emacs with a bus error in memmove, called from
+[EmacsView copyRect:to:].  Redisplay can send negative values to
+ns_scroll_run, which then passes invalid coordinates down to the pixel
+buffer copy.  Without the ns_scroll_run part of the fix, the crash is
+gone but a fragment of the header-line is painted over the mode-line of
+the window above (or over the tab-bar).
+
+This is Alan Third's v2 patch from the bug thread, not yet in the
+emacs-31 branch as of the 31.1 rc1 tarball.  Drop it once it lands
+upstream.
+See: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81585#29
+
+diff --git a/src/nsterm.m b/src/nsterm.m
+--- a/src/nsterm.m
++++ b/src/nsterm.m
+@@ -2857,7 +2857,6 @@ Hide the window (X11 semantics)
+ 
+   NSTRACE ("ns_scroll_run");
+ 
+-  /* begin copy from other terms */
+   /* Get frame-relative bounding box of the text display area of W,
+      without mode lines.  Include in this box the left and right
+      fringe of W.  */
+@@ -2875,6 +2874,15 @@ Hide the window (X11 semantics)
+ 	height = bottom_y - from_y;
+       else
+ 	height = run->height;
++
++      /* If the destination is off the top of the current window, don't
++	 draw over the window above.  */
++      if (to_y < y) {
++	int d = y - to_y;
++	height -= d;
++	to_y += d;
++	from_y += d;
++      }
+     }
+   else
+     {
+@@ -2885,7 +2893,6 @@ Hide the window (X11 semantics)
+       else
+ 	height = run->height;
+     }
+-  /* end copy from other terms */
+ 
+   if (height == 0)
+       return;
+@@ -9316,6 +9323,16 @@ - (void)copyRect:(NSRect)srcRect to:(NSPoint)dest
+   NSTRACE_RECT ("Source", srcRect);
+   NSTRACE_POINT ("Destination", dest);
+ 
++  /* If the destination is off the top of the pixel buffer, fix the
++     source and destination to copy only to y = 0.  */
++  if (dest.y < 0)
++    {
++      int d = dest.y;
++      dest.y = 0;
++      srcRect.origin.y -= d;
++      srcRect.size.height += d;
++    }
++
+   NSRect dstRect = NSMakeRect (dest.x, dest.y, NSWidth (srcRect),
+                                NSHeight (srcRect));
+ 

--- a/patches/emacs-32/fix-ns-scroll-crash.patch
+++ b/patches/emacs-32/fix-ns-scroll-crash.patch
@@ -1,0 +1,1 @@
+../emacs-31/fix-ns-scroll-crash.patch


### PR DESCRIPTION
On macOS, hiding the header-line with `pixel-scroll-precision-mode` enabled, while a line is only partially visible, crashes Emacs with a bus error. Redisplay sends negative coordinates to the NS scroll code, which passes them straight to the pixel buffer copy.

This adds Alan Third's patch from [bug#81585](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81585#29), which did not make it into the 31.1 release candidate and is not on `emacs-31` or `master` yet. Applies to `@31` and `@32`. Drop it once it lands upstream, otherwise the build breaks.

The crash also reproduces on Emacs 30 and the patch applies there too, but `@30` is left alone for now.