### PR TITLE
chore(emacs-plus@31): update to 31.1

### DIFF
--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT31 < EmacsBase
-  init "31.0.91", branch: "emacs-31"
+  init "31.1", branch: "emacs-31"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"


### PR DESCRIPTION
The `emacs-31` branch declares 31.1 since [emacs-31.1-rc1](https://alpha.gnu.org/gnu/emacs/pretest/emacs-31.1-rc1.tar.xz). The formula builds from that branch anyway, so this is just the version label catching up.