### PR TITLE
feat: promote Emacs 31.1 to default

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -22,8 +22,8 @@ on:
   push:
     branches: [master]
     paths:
-      - 'Formula/emacs-plus@30.rb'
-      - 'patches/emacs-30/**'
+      - 'Formula/emacs-plus@31.rb'
+      - 'patches/emacs-31/**'
       - 'Library/**'
 
 jobs:
@@ -57,7 +57,7 @@ jobs:
 
       - name: Set environment
         run: |
-          echo "EMACS_VERSION=30" >> $GITHUB_ENV
+          echo "EMACS_VERSION=31" >> $GITHUB_ENV
           echo "MAC_ARCH=${{ matrix.platform.arch }}" >> $GITHUB_ENV
           echo "OS_VER=$(sw_vers -productVersion)" >> $GITHUB_ENV
           echo "OS_NAME=${{ matrix.platform.os_name }}" >> $GITHUB_ENV
@@ -72,14 +72,12 @@ jobs:
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            gcc libgccjit tree-sitter@0.25 pkg-config webp
-          # tree-sitter@0.25 is keg-only, set up paths
-          echo "PKG_CONFIG_PATH=$(brew --prefix tree-sitter@0.25)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+            gcc libgccjit tree-sitter pkg-config webp
 
       - name: Clone Emacs source
         run: |
-          # Emacs 30 uses the latest release tag (update when new version is released)
-          BRANCH="emacs-30.2"
+          # Stable lane builds the latest release tag (update on new releases)
+          BRANCH="emacs-31.1"
           git clone --depth 1 --branch "$BRANCH" \
             https://github.com/emacs-mirror/emacs.git emacs-src
           cd emacs-src
@@ -91,11 +89,10 @@ jobs:
           cd emacs-src
           # Only apply patches that are unconditionally applied in the formula
           PATCHES=(
-            "fix-window-role"
             "system-appearance"
             "round-undecorated-frame"
-            "fix-macos-tahoe-scrolling"
             "fix-ns-x-colors"
+            "fix-ns-scroll-crash"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"
@@ -186,7 +183,7 @@ jobs:
         run: |
           ls -la emacs-src/nextstep/
           ./emacs-src/nextstep/Emacs.app/Contents/MacOS/Emacs --version
-          # Capture full Emacs version (e.g., 30.1 or 30.0.92)
+          # Capture full Emacs version (e.g., 31.1)
           FULL_VER=$(./emacs-src/nextstep/Emacs.app/Contents/MacOS/Emacs --version | head -1 | sed 's/GNU Emacs //' | cut -d' ' -f1)
           echo "EMACS_FULL_VERSION=$FULL_VER" >> $GITHUB_ENV
           echo "Full Emacs version: $FULL_VER"
@@ -1377,10 +1374,10 @@ jobs:
             artifacts/*/*.zip
             artifacts/*/*.sha256
           body: |
-            Pre-built Emacs+ 30 for cask installation.
+            Pre-built Emacs+ 31 for cask installation.
 
             **Build info:**
-            - Emacs version: 30
+            - Emacs version: 31
             - Workflow run: ${{ github.run_number }}
             - Commit: ${{ github.sha }}
 

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -514,7 +514,7 @@ jobs:
 
       - name: Clone Emacs source
         run: |
-          # Emacs 31 uses emacs-31 branch (pre-release)
+          # Next lane builds the active Emacs release branch
           BRANCH="emacs-31"
           git clone --depth 1 --branch "$BRANCH" \
             https://github.com/emacs-mirror/emacs.git emacs-src
@@ -1480,7 +1480,7 @@ jobs:
             artifacts/*/*.zip
             artifacts/*/*.sha256
           body: |
-            Pre-built Emacs+ 31 (pre-release, from `emacs-31` branch).
+            Pre-built Emacs+ from the `emacs-31` release branch.
 
             **Build info:**
             - Emacs version: 31
@@ -1495,7 +1495,7 @@ jobs:
 
             For source builds, use the formula:
             ```
-            brew install emacs-plus@31
+            brew install emacs-plus --HEAD
             ```
 
       - name: Update cask file

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -532,6 +532,7 @@ jobs:
             "system-appearance"
             "round-undecorated-frame"
             "fix-ns-x-colors"
+            "fix-ns-scroll-crash"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"
@@ -969,6 +970,7 @@ jobs:
             "system-appearance"
             "round-undecorated-frame"
             "fix-ns-x-colors"
+            "fix-ns-scroll-crash"
           )
           for patch_name in "${PATCHES[@]}"; do
             patch_file="../patches/emacs-$EMACS_VERSION/${patch_name}.patch"

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -4,21 +4,21 @@ on:
   # Manual trigger
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Emacs version to build'
+      lane:
+        description: 'Lane to build'
         required: true
-        default: '30'
+        default: 'stable'
         type: choice
         options:
-          - '30'
-          - '31'
-          - '32'
+          - 'stable'
+          - 'next'
+          - 'master'
 
-  # Nightly builds at 3 AM UTC (for Emacs 31 pre-release and Emacs 32 development version)
+  # Nightly builds at 3 AM UTC (next and master lanes)
   schedule:
     - cron: '0 3 * * *'
 
-  # Rebuild Emacs 30 when formula, patches, or build logic changes
+  # Rebuild the stable lane when formula, patches, or build logic changes
   push:
     branches: [master]
     paths:
@@ -27,11 +27,12 @@ on:
       - 'Library/**'
 
 jobs:
-  build-30:
-    # Emacs 30 (stable): build on formula/patch changes or manual trigger.
+  build-stable:
+    # Stable lane (latest Emacs release): build on formula/patch changes or
+    # manual trigger.
     # Restricted to the upstream repo so forks don't publish releases or
     # auto-commit cask updates pointing at fork-specific assets.
-    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.version == '30'))
+    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.lane == 'stable'))
     strategy:
       fail-fast: false
       matrix:
@@ -463,16 +464,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
+          name: stable-emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
           path: |
             emacs-plus-*.zip
             emacs-plus-*.sha256
             emacs-version.txt
 
-  build-31:
-    # Emacs 31 (pre-release): build nightly or on manual trigger.
-    # Restricted to the upstream repo (see build-30).
-    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version == '31'))
+  build-next:
+    # Next lane (Emacs release branch): build nightly or on manual trigger.
+    # Restricted to the upstream repo (see build-stable).
+    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.lane == 'next'))
     strategy:
       fail-fast: false
       matrix:
@@ -901,16 +902,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
+          name: next-emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
           path: |
             emacs-plus-*.zip
             emacs-plus-*.sha256
             emacs-version.txt
 
-  build-32:
-    # Emacs 32 (development): build nightly or on manual trigger.
-    # Restricted to the upstream repo (see build-30).
-    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version == '32'))
+  build-master:
+    # Master lane (Emacs master): build nightly or on manual trigger.
+    # Restricted to the upstream repo (see build-stable).
+    if: github.repository == 'd12frosted/homebrew-emacs-plus' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.lane == 'master'))
     strategy:
       fail-fast: false
       matrix:
@@ -1339,14 +1340,14 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
+          name: master-emacs-plus-${{ env.EMACS_FULL_VERSION }}-${{ env.MAC_ARCH }}-${{ env.OS_MAJOR }}
           path: |
             emacs-plus-*.zip
             emacs-plus-*.sha256
             emacs-version.txt
 
-  release-30:
-    needs: build-30
+  release-stable:
+    needs: build-stable
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1354,22 +1355,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Download artifacts for Emacs 30
+      - name: Download artifacts for the stable lane
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: emacs-plus-30.*
+          pattern: stable-emacs-plus-*
 
       - name: Display structure
         run: |
           ls -laR artifacts/
           cat artifacts/*/*.sha256 || echo "No sha256 files found"
 
-      - name: Create Release for Emacs 30
+      - name: Create Release for the stable lane
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: cask-30-${{ github.run_number }}
-          name: Emacs+ 30 Cask Build ${{ github.run_number }}
+          tag_name: cask-stable-${{ github.run_number }}
+          name: Emacs+ Stable Cask Build ${{ github.run_number }}
           draft: false
           prerelease: false
           files: |
@@ -1423,6 +1424,10 @@ jobs:
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
 
+          # Point the cask at this lane's release tag
+          sed -i -e "s|cask-[a-z0-9]*-<build>|cask-stable-<build>|" \
+                 -e "s|/download/cask-[a-z0-9]*-#|/download/cask-stable-#|" "$CASK_FILE"
+
           # Show the changes
           git diff "$CASK_FILE"
 
@@ -1445,10 +1450,10 @@ jobs:
             done
           fi
 
-  release-31:
-    # Emacs 31 (pre-release): publish artifacts and update the
-    # emacs-plus-app@next cask, which tracks the release branch.
-    needs: build-31
+  release-next:
+    # Publish artifacts and update the emacs-plus-app@next cask, which
+    # tracks the Emacs release branch.
+    needs: build-next
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1456,22 +1461,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Download artifacts for Emacs 31
+      - name: Download artifacts for the next lane
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: emacs-plus-31.*
+          pattern: next-emacs-plus-*
 
       - name: Display structure
         run: |
           ls -laR artifacts/
           cat artifacts/*/*.sha256 || echo "No sha256 files found"
 
-      - name: Create Release for Emacs 31
+      - name: Create Release for the next lane
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: cask-31-${{ github.run_number }}
-          name: Emacs+ 31 Cask Build ${{ github.run_number }}
+          tag_name: cask-next-${{ github.run_number }}
+          name: Emacs+ Next Cask Build ${{ github.run_number }}
           draft: false
           prerelease: true
           files: |
@@ -1530,6 +1535,10 @@ jobs:
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
 
+          # Point the cask at this lane's release tag
+          sed -i -e "s|cask-[a-z0-9]*-<build>|cask-next-<build>|" \
+                 -e "s|/download/cask-[a-z0-9]*-#|/download/cask-next-#|" "$CASK_FILE"
+
           # Show the changes
           git diff "$CASK_FILE"
 
@@ -1552,8 +1561,8 @@ jobs:
             done
           fi
 
-  release-32:
-    needs: build-32
+  release-master:
+    needs: build-master
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1561,22 +1570,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Download artifacts for Emacs 32
+      - name: Download artifacts for the master lane
         uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: emacs-plus-32.*
+          pattern: master-emacs-plus-*
 
       - name: Display structure
         run: |
           ls -laR artifacts/
           cat artifacts/*/*.sha256 || echo "No sha256 files found"
 
-      - name: Create Release for Emacs 32
+      - name: Create Release for the master lane
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: cask-32-${{ github.run_number }}
-          name: Emacs+ 32 Cask Build ${{ github.run_number }}
+          tag_name: cask-master-${{ github.run_number }}
+          name: Emacs+ Master Cask Build ${{ github.run_number }}
           draft: false
           prerelease: true
           files: |
@@ -1629,6 +1638,10 @@ jobs:
           # Update version
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
+
+          # Point the cask at this lane's release tag
+          sed -i -e "s|cask-[a-z0-9]*-<build>|cask-master-<build>|" \
+                 -e "s|/download/cask-[a-z0-9]*-#|/download/cask-master-#|" "$CASK_FILE"
 
           # Show the changes
           git diff "$CASK_FILE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Update Homebrew
         run: brew update
 
-      - name: Build emacs-plus@30
+      - name: Build emacs-plus@31
         run: |
           export HOMEBREW_DEVELOPER=1
-          brew install --formula Formula/emacs-plus@30.rb --verbose
+          brew install --formula Formula/emacs-plus@31.rb --verbose
 
       - name: Test installation
         run: $(brew --prefix)/bin/emacs --batch --eval='(print (+ 2 2))'
@@ -48,9 +48,9 @@ jobs:
       - name: Pack up build logs
         if: always()
         run: |
-          LOG_DIR=~/Library/Logs/Homebrew/emacs-plus@30
+          LOG_DIR=~/Library/Logs/Homebrew/emacs-plus@31
           if [ -d "$LOG_DIR" ]; then
-            tar -C "$LOG_DIR" -czvf emacs-plus@30-build.tar.gz .
+            tar -C "$LOG_DIR" -czvf emacs-plus@31-build.tar.gz .
           fi
 
       - name: Upload logs
@@ -58,5 +58,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-logs
-          path: emacs-plus@30-build.tar.gz
+          path: emacs-plus@31-build.tar.gz
           if-no-files-found: ignore

--- a/Aliases/emacs-plus
+++ b/Aliases/emacs-plus
@@ -1,1 +1,1 @@
-../Formula/emacs-plus@30.rb
+../Formula/emacs-plus@31.rb

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -73,10 +73,10 @@ cask "emacs-plus-app" do
   # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
   # Note: emacs is symlinked manually in postflight because the wrapper script
   # is created there and binary stanzas run before postflight
+  # Note: no ctags symlink; the ctags program was removed in Emacs 31
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags", target: "emacs-ctags"
 
   # Man pages (not gzipped in the build)
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -3,7 +3,7 @@ cask "emacs-plus-app" do
   # Build number corresponds to GitHub Actions run number
   version "30.2-292"
 
-  # Base URL for release assets (versioned releases: cask-30-<build>)
+  # Base URL for release assets (lane releases: cask-30-<build>)
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-30-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -3,7 +3,7 @@ cask "emacs-plus-app@master" do
   # Build number corresponds to GitHub Actions run number
   version "32.0.50-305"
 
-  # Base URL for release assets (versioned releases: cask-32-<build>)
+  # Base URL for release assets (lane releases: cask-32-<build>)
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-32-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -3,7 +3,7 @@ cask "emacs-plus-app@next" do
   # Build number corresponds to GitHub Actions run number
   version "31.1.50-305"
 
-  # Base URL for release assets (versioned releases: cask-31-<build>)
+  # Base URL for release assets (lane releases: cask-31-<build>)
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-31-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -29,8 +29,8 @@ cask "emacs-plus-app@next" do
     end
   end
 
-  name "Emacs+ (Pre-release)"
-  desc "GNU Emacs text editor with patches for macOS (next stable release)"
+  name "Emacs+ (Next)"
+  desc "GNU Emacs text editor with patches for macOS (Emacs release branch)"
   homepage "https://github.com/d12frosted/homebrew-emacs-plus"
 
   # Required for native compilation (JIT) at runtime
@@ -93,13 +93,14 @@ cask "emacs-plus-app@next" do
   ]
 
   caveats <<~EOS
-    Emacs+ (pre-release) has been installed to /Applications.
+    Emacs+ (next) has been installed to /Applications.
 
     This is a pre-built binary from the Emacs release branch (currently
-    Emacs 31, pretest). It tracks the next stable release: less bleeding
-    edge than @master, newer than the stable cask.
+    emacs-31). It carries the fixes that land after the last release and
+    go into the next one: newer than the stable cask, less bleeding edge
+    than @master.
     For custom patches or build options, use the formula instead:
-      brew install emacs-plus@31 --with-...
+      brew install emacs-plus --HEAD --with-...
 
     Custom icons can be configured via ~/.config/emacs-plus/build.yml:
       icon: dragon-plus

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -1,7 +1,7 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsPlusAT31 < EmacsBase
-  init "31.1", branch: "emacs-31"
+  init "31.1", sha256: "1da5790d9580c81932b5bf700633114468da7b3412d69faa767daebf974f4586", branch: "emacs-31"
 
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"

--- a/NEWS.org
+++ b/NEWS.org
@@ -5,11 +5,42 @@ This file documents notable changes to Emacs Plus.
 
 * 2026-08-25
 
+** Releases
+
+*** Emacs 31.1 is the default
+
+Emacs 31.1 is out, so the default moves from Emacs 30 to Emacs 31. =brew install emacs-plus= builds =emacs-plus@31= from the release tarball, and the =emacs-plus-app= cask ships Emacs 31.1.
+
+#+begin_src bash
+  $ brew upgrade emacs-plus
+  $ brew upgrade --cask emacs-plus-app
+#+end_src
+
+Emacs 30 stays available as =emacs-plus@30=. The stable cask no longer creates the =emacs-ctags= symlink, since =ctags= was removed in Emacs 31.
+
+** Changes
+
+*** Cask lanes: stable, next and master
+
+Cask releases are tagged =cask-stable-<build>=, =cask-next-<build>= and =cask-master-<build>= instead of being numbered by Emacs version. Stable and next are both Emacs 31 now, so the version number no longer tells the lanes apart.
+
+=emacs-plus-app@next= keeps tracking the Emacs release branch. Right after a major release that means 31.1 plus the fixes going into 31.2, and later in the cycle it becomes the pretest for the next major version. The source equivalent is:
+
+#+begin_src bash
+  $ brew install emacs-plus --HEAD
+#+end_src
+
 ** Improvements
 
 *** Reinstall documentation matches the formula caveats
 
 The =Reinstall= section of the README advised against =brew reinstall=, while the formula caveats and the rest of the README tell you to use it (after editing =build.yml=, pinning a revision, or fixing =Library not loaded= errors). The old advice was about =brew= losing command line options, which =brew= fixed years ago. Reported in [[https://github.com/d12frosted/homebrew-emacs-plus/issues/986][#986]].
+
+** Bug Fixes
+
+*** Cask builds were missing the NS scroll crash fix
+
+The =fix-ns-scroll-crash= patch (bug#81585, see the 2026-08-18 entry) is applied by the formulas, but the cask build jobs skipped it, so =emacs-plus-app@next= and =emacs-plus-app@master= did not have it. Fixed with the next nightly build.
 
 * 2026-08-18
 

--- a/README.org
+++ b/README.org
@@ -30,12 +30,13 @@ Emacs+ is [[https://www.gnu.org/software/emacs/emacs.html][→ GNU Emacs]] formu
   # (or trust a single formula/cask) and retry. See https://docs.brew.sh/Tap-Trust.
 
   # Pre-built binaries (fast, ~1 min)
-  $ brew install --cask emacs-plus-app          # latest stable
-  $ brew install --cask emacs-plus-app@next     # nightly from release branch (next stable)
+  $ brew install --cask emacs-plus-app          # latest release
+  $ brew install --cask emacs-plus-app@next     # nightly from the release branch
   $ brew install --cask emacs-plus-app@master   # nightly from master
 
   # Build from source (customizable, ~30 min)
-  $ brew install emacs-plus        [options]    # latest stable
+  $ brew install emacs-plus        [options]    # latest release
+  $ brew install emacs-plus --HEAD [options]    # from the release branch
   $ brew install emacs-plus@master [options]    # from master
 #+end_src
 
@@ -114,14 +115,24 @@ Emacs+ is 10+ years old and the list of differences used to be much longer. Many
 
 ** Install
 
+Emacs+ comes in three lanes, each available as a cask (pre-built) and as a formula (built from source):
+
+| Lane   | Cask                    | Formula             | Source                    |
+|--------+-------------------------+---------------------+---------------------------|
+| stable | =emacs-plus-app=        | =emacs-plus=        | latest release (31.1)     |
+| next   | =emacs-plus-app@next=   | =emacs-plus --HEAD= | release branch (emacs-31) |
+| master | =emacs-plus-app@master= | =emacs-plus@master= | master (32.0.50)          |
+
+The =next= lane follows the active Emacs release branch. Right after a major release it is the stable version plus the fixes going into the next point release; later in the cycle it becomes the pretest for the next major version.
+
 *** Pre-built binaries (Cask)
 
 For fast installation without compilation (~1 min), pre-built binaries are available:
 
 #+begin_src bash
   $ brew tap d12frosted/emacs-plus
-  $ brew install --cask emacs-plus-app           # latest stable
-  $ brew install --cask emacs-plus-app@next      # nightly from release branch (next stable)
+  $ brew install --cask emacs-plus-app           # latest release
+  $ brew install --cask emacs-plus-app@next      # nightly from the release branch
   $ brew install --cask emacs-plus-app@master    # nightly from master
 #+end_src
 
@@ -151,11 +162,12 @@ For custom build options (~30 min compile time):
 
 #+begin_src bash
   $ brew tap d12frosted/emacs-plus
-  $ brew install emacs-plus        [options]    # latest stable
+  $ brew install emacs-plus        [options]    # latest release
+  $ brew install emacs-plus --HEAD [options]    # from the release branch
   $ brew install emacs-plus@master [options]    # from master
 #+end_src
 
-Versioned formulas are also available: =emacs-plus@32=, =emacs-plus@31=, =emacs-plus@30=, =emacs-plus@29=, etc. The =emacs-plus@master= alias points to the current development version (=emacs-plus@32=).
+Versioned formulas are also available: =emacs-plus@32=, =emacs-plus@31=, =emacs-plus@30=, =emacs-plus@29=, etc. The =emacs-plus= alias points to the latest release (=emacs-plus@31=) and =emacs-plus@master= to the development version (=emacs-plus@32=).
 
 By default, formulas build Cocoa Emacs with =gnutls=, =librsvg=, =libxml2=, =tree-sitter=, =webp=, native compilation, dynamic modules, and multicolor fonts. See [[#options][→ Options]] for customization.
 
@@ -696,7 +708,7 @@ Emacs 26 comes without any available options due to [[https://github.com/d12fros
 
 *** How to pin a specific commit
 
-Development versions (=emacs-plus@31=, =emacs-plus@32=) are built from their respective branches (=emacs-31=, =master=). Ordinarily, =brew= will update to the latest commit during installation.
+Development builds (=emacs-plus@32=, or =emacs-plus --HEAD=) are built from their respective branches (=master=, =emacs-31=). Ordinarily, =brew= will update to the latest commit during installation.
 
 As development versions are less stable than official releases, you may want to pin a specific commit. The recommended way is to use =~/.config/emacs-plus/build.yml=:
 


### PR DESCRIPTION
Emacs 31.1 is out, so 31 becomes the default.

- `emacs-plus@31` builds the release tarball instead of the `emacs-31` branch
- `emacs-plus` alias and the `emacs-plus-app` cask move from 30 to 31.1 (no more `emacs-ctags`, gone in Emacs 31)
- cask lanes are named now: `cask-stable-<build>`, `cask-next-<build>`, `cask-master-<build>`, and each release job repoints the cask base_url, so the first build flips a cask over in one go. Stable and next are both Emacs 31, version numbers no longer tell them apart
- `@next` keeps tracking the release branch: fixes going into 31.2 now, pretest for the next major later
- separate fix: cask builds never applied `fix-ns-scroll-crash`, so `@next` and `@master` users were missing the bug#81585 fix

Closes #988
