### PR TITLE
fix: stop zapping ~/.emacs.d on cask uninstall

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -89,7 +89,6 @@ cask "emacs-plus-app" do
     "~/Library/Caches/org.gnu.Emacs",
     "~/Library/Preferences/org.gnu.Emacs.plist",
     "~/Library/Saved Application State/org.gnu.Emacs.savedState",
-    "~/.emacs.d",
   ]
 
   caveats <<~EOS

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -88,7 +88,6 @@ cask "emacs-plus-app@master" do
     "~/Library/Caches/org.gnu.Emacs",
     "~/Library/Preferences/org.gnu.Emacs.plist",
     "~/Library/Saved Application State/org.gnu.Emacs.savedState",
-    "~/.emacs.d",
   ]
 
   caveats <<~EOS

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -89,7 +89,6 @@ cask "emacs-plus-app@next" do
     "~/Library/Caches/org.gnu.Emacs",
     "~/Library/Preferences/org.gnu.Emacs.plist",
     "~/Library/Saved Application State/org.gnu.Emacs.savedState",
-    "~/.emacs.d",
   ]
 
   caveats <<~EOS

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,14 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-08-27
+
+** Bug Fixes
+
+*** Cask =zap= no longer trashes =~/.emacs.d=
+
+=brew uninstall --zap --cask emacs-plus-app= (and the =@next= / =@master= variants) moved =~/.emacs.d= to the Trash along with the app caches. That directory is your own Emacs configuration, not something the cask created, so zap now leaves it alone and only removes the app state under =~/Library=.
+
 * 2026-08-25
 
 ** Releases


### PR DESCRIPTION
The zap stanza in all three emacs-plus-app casks listed ~/.emacs.d, so brew uninstall --zap moved the user's own Emacs config to the Trash. That directory is user-authored, not app state; the official emacs cask does not touch it either. Zap now only removes the app state under ~/Library.