### PR TITLE
fix: prefer formula's own Emacs.app in the emacs wrapper

### DIFF
--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -213,17 +213,20 @@ class EmacsPlusAT29 < EmacsBase
       inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
-      # Check multiple locations so users can copy Emacs.app to /Applications
-      # for better Spotlight integration.
+      # Prefer the bundle this formula built; fall back to /Applications and
+      # ~/Applications for users who moved Emacs.app there for better
+      # Spotlight integration. The fallbacks come last so an Emacs.app
+      # installed by the emacs-plus-app cask is never picked up instead of
+      # this formula's own build.
       (bin/"emacs").unlink # Kill the existing symlink
       (bin/"emacs").write <<~EOS
         #!/bin/bash
-        for app in "/Applications/Emacs.app" "$HOME/Applications/Emacs.app" "#{prefix}/Emacs.app"; do
+        for app in "#{prefix}/Emacs.app" "/Applications/Emacs.app" "$HOME/Applications/Emacs.app"; do
           if [ -x "$app/Contents/MacOS/Emacs" ]; then
             exec "$app/Contents/MacOS/Emacs" "$@"
           fi
         done
-        echo "Error: Emacs.app not found in /Applications, ~/Applications, or #{prefix}" >&2
+        echo "Error: Emacs.app not found in #{prefix}, /Applications, or ~/Applications" >&2
         exit 1
       EOS
     else
@@ -301,7 +304,8 @@ class EmacsPlusAT29 < EmacsBase
       For best Spotlight integration, copy the app to /Applications:
         cp -r #{prefix}/Emacs.app /Applications/
 
-      The `emacs` command will automatically find the app in /Applications.
+      The `emacs` command always runs this formula's own Emacs.app; copies
+      in /Applications are only used if the original is removed.
 
       Alternatively, create a Finder alias (less reliable with Spotlight):
         osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -212,17 +212,20 @@ class EmacsPlusAT30 < EmacsBase
       inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
-      # Check multiple locations so users can copy Emacs.app to /Applications
-      # for better Spotlight integration.
+      # Prefer the bundle this formula built; fall back to /Applications and
+      # ~/Applications for users who moved Emacs.app there for better
+      # Spotlight integration. The fallbacks come last so an Emacs.app
+      # installed by the emacs-plus-app cask is never picked up instead of
+      # this formula's own build.
       (bin/"emacs").unlink # Kill the existing symlink
       (bin/"emacs").write <<~EOS
         #!/bin/bash
-        for app in "/Applications/Emacs.app" "$HOME/Applications/Emacs.app" "#{prefix}/Emacs.app"; do
+        for app in "#{prefix}/Emacs.app" "/Applications/Emacs.app" "$HOME/Applications/Emacs.app"; do
           if [ -x "$app/Contents/MacOS/Emacs" ]; then
             exec "$app/Contents/MacOS/Emacs" "$@"
           fi
         done
-        echo "Error: Emacs.app not found in /Applications, ~/Applications, or #{prefix}" >&2
+        echo "Error: Emacs.app not found in #{prefix}, /Applications, or ~/Applications" >&2
         exit 1
       EOS
     else
@@ -307,7 +310,8 @@ class EmacsPlusAT30 < EmacsBase
         cp -r #{prefix}/Emacs.app /Applications/
         cp -r "#{prefix}/Emacs Client.app" /Applications/
 
-      The `emacs` command will automatically find the app in /Applications.
+      The `emacs` command always runs this formula's own Emacs.app; copies
+      in /Applications are only used if the original is removed.
 
       Alternatively, create Finder aliases (less reliable with Spotlight):
         osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -211,17 +211,20 @@ class EmacsPlusAT31 < EmacsBase
       inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
-      # Check multiple locations so users can copy Emacs.app to /Applications
-      # for better Spotlight integration.
+      # Prefer the bundle this formula built; fall back to /Applications and
+      # ~/Applications for users who moved Emacs.app there for better
+      # Spotlight integration. The fallbacks come last so an Emacs.app
+      # installed by the emacs-plus-app cask is never picked up instead of
+      # this formula's own build.
       (bin/"emacs").unlink # Kill the existing symlink
       (bin/"emacs").write <<~EOS
         #!/bin/bash
-        for app in "/Applications/Emacs.app" "$HOME/Applications/Emacs.app" "#{prefix}/Emacs.app"; do
+        for app in "#{prefix}/Emacs.app" "/Applications/Emacs.app" "$HOME/Applications/Emacs.app"; do
           if [ -x "$app/Contents/MacOS/Emacs" ]; then
             exec "$app/Contents/MacOS/Emacs" "$@"
           fi
         done
-        echo "Error: Emacs.app not found in /Applications, ~/Applications, or #{prefix}" >&2
+        echo "Error: Emacs.app not found in #{prefix}, /Applications, or ~/Applications" >&2
         exit 1
       EOS
     else
@@ -295,7 +298,8 @@ class EmacsPlusAT31 < EmacsBase
         cp -r #{prefix}/Emacs.app /Applications/
         cp -r "#{prefix}/Emacs Client.app" /Applications/
 
-      The `emacs` command will automatically find the app in /Applications.
+      The `emacs` command always runs this formula's own Emacs.app; copies
+      in /Applications are only used if the original is removed.
 
       Alternatively, create Finder aliases (less reliable with Spotlight):
         osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -195,17 +195,20 @@ class EmacsPlusAT32 < EmacsBase
       inject_plist_extras
 
       # Replace the symlink with one that avoids starting Cocoa.
-      # Check multiple locations so users can copy Emacs.app to /Applications
-      # for better Spotlight integration.
+      # Prefer the bundle this formula built; fall back to /Applications and
+      # ~/Applications for users who moved Emacs.app there for better
+      # Spotlight integration. The fallbacks come last so an Emacs.app
+      # installed by the emacs-plus-app cask is never picked up instead of
+      # this formula's own build.
       (bin/"emacs").unlink # Kill the existing symlink
       (bin/"emacs").write <<~EOS
         #!/bin/bash
-        for app in "/Applications/Emacs.app" "$HOME/Applications/Emacs.app" "#{prefix}/Emacs.app"; do
+        for app in "#{prefix}/Emacs.app" "/Applications/Emacs.app" "$HOME/Applications/Emacs.app"; do
           if [ -x "$app/Contents/MacOS/Emacs" ]; then
             exec "$app/Contents/MacOS/Emacs" "$@"
           fi
         done
-        echo "Error: Emacs.app not found in /Applications, ~/Applications, or #{prefix}" >&2
+        echo "Error: Emacs.app not found in #{prefix}, /Applications, or ~/Applications" >&2
         exit 1
       EOS
     else
@@ -279,7 +282,8 @@ class EmacsPlusAT32 < EmacsBase
         cp -r #{prefix}/Emacs.app /Applications/
         cp -r "#{prefix}/Emacs Client.app" /Applications/
 
-      The `emacs` command will automatically find the app in /Applications.
+      The `emacs` command always runs this formula's own Emacs.app; copies
+      in /Applications are only used if the original is removed.
 
       Alternatively, create Finder aliases (less reliable with Spotlight):
         osascript -e 'tell application "Finder" to make alias file to posix file "#{prefix}/Emacs.app" at posix file "/Applications" with properties {name:"Emacs.app"}'

--- a/NEWS.org
+++ b/NEWS.org
@@ -7,6 +7,10 @@ This file documents notable changes to Emacs Plus.
 
 ** Bug Fixes
 
+*** Formula =emacs= wrapper prefers its own =Emacs.app=
+
+The =emacs= wrapper installed by =emacs-plus@29= through =emacs-plus@32= looked for =Emacs.app= in =/Applications= first and only then in the formula's own prefix. That order predates the casks: with =emacs-plus-app= installed, a formula user running =emacs= in the terminal (or =brew services start emacs-plus@N=) silently got the cask's Emacs, possibly a different major version. The wrapper now runs the formula's own bundle first and falls back to =/Applications= and =~/Applications= only when it is missing, so copies made for Spotlight integration keep working. Reinstall the formula to get the fixed wrapper.
+
 *** Cask uninstall no longer deletes the formula's =emacs= symlink
 
 Uninstalling an =emacs-plus-app= cask removed any symlink at =$(brew --prefix)/bin/emacs=, including one created by a linked =emacs-plus@N= formula, silently leaving the formula unlinked. The cask now checks where the symlink points and only removes it when it leads into the cask's own =Emacs.app=.


### PR DESCRIPTION
The emacs wrapper in @29 through @32 checked /Applications/Emacs.app before the formula's own bundle. That order predates the casks: with emacs-plus-app installed, running emacs from the terminal or brew services start emacs-plus@N silently launched the cask's Emacs, possibly a different major version. The wrapper now tries the formula's own Emacs.app first, keeping /Applications and ~/Applications as fallbacks for users who moved the bundle there for Spotlight. Caveats updated to match. Related discussion in #937.