### PR TITLE
fix: per-version service logs in var/log instead of shared /tmp files

### DIFF
--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -119,8 +119,8 @@ class EmacsPlusAT26 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@26.stdout.log"
+    error_log_path var/"log/emacs-plus@26.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -242,8 +242,8 @@ class EmacsPlusAT27 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@27.stdout.log"
+    error_log_path var/"log/emacs-plus@27.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -295,8 +295,8 @@ class EmacsPlusAT28 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@28.stdout.log"
+    error_log_path var/"log/emacs-plus@28.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -324,8 +324,8 @@ class EmacsPlusAT29 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@29.stdout.log"
+    error_log_path var/"log/emacs-plus@29.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -330,8 +330,8 @@ class EmacsPlusAT30 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@30.stdout.log"
+    error_log_path var/"log/emacs-plus@30.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -318,8 +318,8 @@ class EmacsPlusAT31 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@31.stdout.log"
+    error_log_path var/"log/emacs-plus@31.stderr.log"
   end
 
   test do

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -302,8 +302,8 @@ class EmacsPlusAT32 < EmacsBase
   service do
     run [opt_bin/"emacs", "--fg-daemon"]
     keep_alive true
-    log_path "/tmp/homebrew.mxcl.emacs-plus.stdout.log"
-    error_log_path "/tmp/homebrew.mxcl.emacs-plus.stderr.log"
+    log_path var/"log/emacs-plus@32.stdout.log"
+    error_log_path var/"log/emacs-plus@32.stderr.log"
   end
 
   test do

--- a/NEWS.org
+++ b/NEWS.org
@@ -5,6 +5,16 @@ This file documents notable changes to Emacs Plus.
 
 * 2026-08-27
 
+** Changes
+
+*** Service logs move from =/tmp= to =var/log=, one pair per version
+
+Every =emacs-plus@N= service wrote to the same =/tmp/homebrew.mxcl.emacs-plus.{stdout,stderr}.log=, so running two versions interleaved their output, and the logs vanished on reboot. Each formula now logs to =$(brew --prefix)/var/log/emacs-plus@N.{stdout,stderr}.log=. Restart the service after upgrading to pick up the new paths:
+
+#+begin_src bash
+  brew services restart emacs-plus@31
+#+end_src
+
 ** Bug Fixes
 
 *** Formula =emacs= wrapper prefers its own =Emacs.app=


### PR DESCRIPTION
All seven formulas pointed their service at the same /tmp/homebrew.mxcl.emacs-plus.{stdout,stderr}.log, so two versions running services interleaved output in one file, and /tmp is world-writable and cleared on reboot. Each formula now logs to var/log/emacs-plus@N.{stdout,stderr}.log, the usual Homebrew location. Restart the service to pick up the new paths.