### PR TITLE
docs: warn about mixing formula and cask installs in caveats

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -111,5 +111,10 @@ cask "emacs-plus-app" do
 
     Note: Emacs Client.app requires Emacs to be running as a daemon.
     Add to your Emacs config: (server-start)
+
+    Note: installing this cask alongside an emacs-plus@N formula is not
+    supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+    and Homebrew cannot declare a conflict between a cask and a formula.
+    Keep one or the other installed.
   EOS
 end

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -110,5 +110,10 @@ cask "emacs-plus-app@master" do
 
     Note: Emacs Client.app requires Emacs to be running as a daemon.
     Add to your Emacs config: (server-start)
+
+    Note: installing this cask alongside an emacs-plus@N formula is not
+    supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+    and Homebrew cannot declare a conflict between a cask and a formula.
+    Keep one or the other installed.
   EOS
 end

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -114,5 +114,10 @@ cask "emacs-plus-app@next" do
 
     Note: Emacs Client.app requires Emacs to be running as a daemon.
     Add to your Emacs config: (server-start)
+
+    Note: installing this cask alongside an emacs-plus@N formula is not
+    supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+    and Homebrew cannot declare a conflict between a cask and a formula.
+    Keep one or the other installed.
   EOS
 end

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -317,6 +317,11 @@ class EmacsPlusAT29 < EmacsBase
       dependencies (e.g., tree-sitter, libgccjit), reinstall emacs-plus:
         brew reinstall emacs-plus@29
 
+      Note: installing this formula alongside an emacs-plus-app cask is not
+      supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+      and Homebrew cannot declare a conflict between a formula and a cask.
+      Keep one or the other installed.
+
       Report any issues to https://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -323,6 +323,11 @@ class EmacsPlusAT30 < EmacsBase
       dependencies (e.g., tree-sitter, libgccjit), reinstall emacs-plus:
         brew reinstall emacs-plus@30
 
+      Note: installing this formula alongside an emacs-plus-app cask is not
+      supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+      and Homebrew cannot declare a conflict between a formula and a cask.
+      Keep one or the other installed.
+
       Report any issues to https://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -311,6 +311,11 @@ class EmacsPlusAT31 < EmacsBase
       dependencies (e.g., tree-sitter, libgccjit), reinstall emacs-plus:
         brew reinstall emacs-plus@31
 
+      Note: installing this formula alongside an emacs-plus-app cask is not
+      supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+      and Homebrew cannot declare a conflict between a formula and a cask.
+      Keep one or the other installed.
+
       Report any issues to https://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -295,6 +295,11 @@ class EmacsPlusAT32 < EmacsBase
       dependencies (e.g., tree-sitter, libgccjit), reinstall emacs-plus:
         brew reinstall emacs-plus@32
 
+      Note: installing this formula alongside an emacs-plus-app cask is not
+      supported. Both provide emacs and emacsclient in $(brew --prefix)/bin,
+      and Homebrew cannot declare a conflict between a formula and a cask.
+      Keep one or the other installed.
+
       Report any issues to https://github.com/d12frosted/homebrew-emacs-plus
     EOS
   end

--- a/NEWS.org
+++ b/NEWS.org
@@ -5,6 +5,12 @@ This file documents notable changes to Emacs Plus.
 
 * 2026-08-27
 
+** Improvements
+
+*** Caveats warn about mixing formula and cask installs
+
+The =emacs-plus@N= formulas and the =emacs-plus-app= casks both provide =emacs= and =emacsclient= in =$(brew --prefix)/bin=, but Homebrew cannot declare a conflict between a formula and a cask, so nothing stops you from installing both and ending up with commands that do not match the app you launch. The caveats on both sides now say to keep one or the other.
+
 ** Changes
 
 *** Service logs move from =/tmp= to =var/log=, one pair per version


### PR DESCRIPTION
The formulas and the emacs-plus-app casks both provide emacs and emacsclient in $(brew --prefix)/bin, but the cask DSL only supports conflicts_with cask: and formulas cannot conflict with casks at all, so Homebrew cannot prevent installing both. The caveats on both sides (casks and emacs-plus@29 through @32) now warn to keep one or the other. Follow-up to #995.