### PR TITLE
ci: run brew style on Formula and Casks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,19 @@ jobs:
             ruby "$test"
           done
 
+      # brew style requires the files to live inside a tap, so link the
+      # checkout into the tap location. Cask/NoOverrides and
+      # Cask/OnSystemConditionals are excluded: they demand restructuring
+      # the casks into on_{macos_version} blocks, which does not fit how
+      # the casks pick one of several prebuilt binaries per macOS version.
+      - name: Run brew style on Formula and Casks
+        run: |
+          TAP_DIR="$(brew --repository)/Library/Taps/d12frosted/homebrew-emacs-plus"
+          mkdir -p "$(dirname "$TAP_DIR")"
+          ln -s "$GITHUB_WORKSPACE" "$TAP_DIR"
+          brew style --except-cops Cask/NoOverrides,Cask/OnSystemConditionals \
+            "$TAP_DIR/Formula" "$TAP_DIR/Casks"
+
       - name: Validate icons
         run: ruby scripts/validate-icons.rb
 

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -7,12 +7,6 @@ cask "emacs-plus-app" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-stable-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_intel do
-    sha256 "72b74efb175758185392ff232686541acf4d56f2856dd0e98850d64be072f018"
-    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-  end
-
   on_arm do
     if MacOS.version >= :tahoe # macOS 26
       sha256 "ee974066f3527fbe444d9a176e124fdbfd8b3ee678bece9fc52218e07eeea0c8"
@@ -28,16 +22,16 @@ cask "emacs-plus-app" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
+  on_intel do
+    sha256 "72b74efb175758185392ff232686541acf4d56f2856dd0e98850d64be072f018"
+
+    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
+        verified: "github.com/d12frosted/homebrew-emacs-plus"
+  end
 
   name "Emacs+"
-  desc "GNU Emacs text editor with patches for macOS"
+  desc "GNU Emacs text editor with patches"
   homepage "https://github.com/d12frosted/homebrew-emacs-plus"
-
-  # Required for native compilation (JIT) at runtime
-  # - libgccjit: JIT compilation library
-  # - gcc: provides toolchain and libemutls_w.a runtime library
-  depends_on formula: "libgccjit"
-  depends_on formula: "gcc"
 
   # Conflict with other Emacs cask installations
   conflicts_with cask: [
@@ -47,10 +41,28 @@ cask "emacs-plus-app" do
     "emacs-plus-app@master",
     "emacs-plus-app@next",
   ]
+  # Required for native compilation (JIT) at runtime
+  # - libgccjit: JIT compilation library
+  # - gcc: provides toolchain and libemutls_w.a runtime library
+  depends_on formula: "libgccjit"
+  depends_on formula: "gcc"
+  depends_on :macos
 
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
+  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
+  # Note: emacs is symlinked manually in postflight because the wrapper script
+  # is created there and binary stanzas run before postflight
+  # Note: no ctags symlink; the ctags program was removed in Emacs 31
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+  # Man pages (not gzipped in the build)
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Remove quarantine attribute, inject PATH, and apply custom icon
   # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
@@ -58,10 +70,10 @@ cask "emacs-plus-app" do
     tap = Tap.fetch("d12frosted", "emacs-plus")
     load "#{tap.path}/Library/CaskPostflight.rb"
     CaskPostflight.run(self,
-                       emacs_app: "#{appdir}/Emacs.app",
+                       emacs_app:        "#{appdir}/Emacs.app",
                        emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version: version.major,
-                       homebrew_prefix: HOMEBREW_PREFIX.to_s)
+                       version:          version.major,
+                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
   end
 
   # Clean up emacs symlink on uninstall (since we create it manually in postflight)
@@ -71,23 +83,9 @@ cask "emacs-plus-app" do
     emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
     if File.symlink?(emacs_symlink) &&
        File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm_f(emacs_symlink)
+      FileUtils.rm(emacs_symlink)
     end
   end
-
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
-  # Note: no ctags symlink; the ctags program was removed in Emacs 31
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
-
-  # Man pages (not gzipped in the build)
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Cleanup on uninstall
   zap trash: [

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -7,12 +7,6 @@ cask "emacs-plus-app@master" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-master-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_intel do
-    sha256 "54ec216a943567c4189cc24259a66c9209f95f0475d45d96dcf9dd4afe451c02"
-    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-  end
-
   on_arm do
     if MacOS.version >= :tahoe # macOS 26
       sha256 "1310c9b5b3c3b8794620a06156f90a91795cc993ba537521bccd21b5e7f16a4c"
@@ -28,16 +22,16 @@ cask "emacs-plus-app@master" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
+  on_intel do
+    sha256 "54ec216a943567c4189cc24259a66c9209f95f0475d45d96dcf9dd4afe451c02"
+
+    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
+        verified: "github.com/d12frosted/homebrew-emacs-plus"
+  end
 
   name "Emacs+ (Development)"
-  desc "GNU Emacs text editor with patches for macOS (development version)"
+  desc "GNU Emacs text editor with patches (development version)"
   homepage "https://github.com/d12frosted/homebrew-emacs-plus"
-
-  # Required for native compilation (JIT) at runtime
-  # - libgccjit: JIT compilation library
-  # - gcc: provides toolchain and libemutls_w.a runtime library
-  depends_on formula: "libgccjit"
-  depends_on formula: "gcc"
 
   # Conflict with other Emacs cask installations
   conflicts_with cask: [
@@ -47,10 +41,27 @@ cask "emacs-plus-app@master" do
     "emacs-plus-app",
     "emacs-plus-app@next",
   ]
+  # Required for native compilation (JIT) at runtime
+  # - libgccjit: JIT compilation library
+  # - gcc: provides toolchain and libemutls_w.a runtime library
+  depends_on formula: "libgccjit"
+  depends_on formula: "gcc"
+  depends_on :macos
 
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
+  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
+  # Note: emacs is symlinked manually in postflight because the wrapper script
+  # is created there and binary stanzas run before postflight
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+  # Man pages (not gzipped in the build)
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Remove quarantine attribute, inject PATH, and apply custom icon
   # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
@@ -58,10 +69,10 @@ cask "emacs-plus-app@master" do
     tap = Tap.fetch("d12frosted", "emacs-plus")
     load "#{tap.path}/Library/CaskPostflight.rb"
     CaskPostflight.run(self,
-                       emacs_app: "#{appdir}/Emacs.app",
+                       emacs_app:        "#{appdir}/Emacs.app",
                        emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version: version.major,
-                       homebrew_prefix: HOMEBREW_PREFIX.to_s)
+                       version:          version.major,
+                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
   end
 
   # Clean up emacs symlink on uninstall (since we create it manually in postflight)
@@ -71,22 +82,9 @@ cask "emacs-plus-app@master" do
     emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
     if File.symlink?(emacs_symlink) &&
        File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm_f(emacs_symlink)
+      FileUtils.rm(emacs_symlink)
     end
   end
-
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
-
-  # Man pages (not gzipped in the build)
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Cleanup on uninstall
   zap trash: [

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -7,12 +7,6 @@ cask "emacs-plus-app@next" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-next-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_intel do
-    sha256 "bece9edbe18fd468932b21ecca43ea606706df45eaab4c4e6af05cde362f699b"
-    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-  end
-
   on_arm do
     if MacOS.version >= :tahoe # macOS 26
       sha256 "eae20b81bfa161d7d85ecd0c32bf561ccc55c30685c6c29b5681b70dd1b5983a"
@@ -28,16 +22,16 @@ cask "emacs-plus-app@next" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
+  on_intel do
+    sha256 "bece9edbe18fd468932b21ecca43ea606706df45eaab4c4e6af05cde362f699b"
+
+    url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
+        verified: "github.com/d12frosted/homebrew-emacs-plus"
+  end
 
   name "Emacs+ (Next)"
-  desc "GNU Emacs text editor with patches for macOS (Emacs release branch)"
+  desc "GNU Emacs text editor with patches (Emacs release branch)"
   homepage "https://github.com/d12frosted/homebrew-emacs-plus"
-
-  # Required for native compilation (JIT) at runtime
-  # - libgccjit: JIT compilation library
-  # - gcc: provides toolchain and libemutls_w.a runtime library
-  depends_on formula: "libgccjit"
-  depends_on formula: "gcc"
 
   # Conflict with other Emacs cask installations
   conflicts_with cask: [
@@ -47,10 +41,28 @@ cask "emacs-plus-app@next" do
     "emacs-plus-app",
     "emacs-plus-app@master",
   ]
+  # Required for native compilation (JIT) at runtime
+  # - libgccjit: JIT compilation library
+  # - gcc: provides toolchain and libemutls_w.a runtime library
+  depends_on formula: "libgccjit"
+  depends_on formula: "gcc"
+  depends_on :macos
 
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
+  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
+  # Note: emacs is symlinked manually in postflight because the wrapper script
+  # is created there and binary stanzas run before postflight
+  # Note: no ctags symlink; the ctags program was removed in Emacs 31
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+  # Man pages (not gzipped in the build)
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Remove quarantine attribute, inject PATH, and apply custom icon
   # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
@@ -58,10 +70,10 @@ cask "emacs-plus-app@next" do
     tap = Tap.fetch("d12frosted", "emacs-plus")
     load "#{tap.path}/Library/CaskPostflight.rb"
     CaskPostflight.run(self,
-                       emacs_app: "#{appdir}/Emacs.app",
+                       emacs_app:        "#{appdir}/Emacs.app",
                        emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version: version.major,
-                       homebrew_prefix: HOMEBREW_PREFIX.to_s)
+                       version:          version.major,
+                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
   end
 
   # Clean up emacs symlink on uninstall (since we create it manually in postflight)
@@ -71,23 +83,9 @@ cask "emacs-plus-app@next" do
     emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
     if File.symlink?(emacs_symlink) &&
        File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm_f(emacs_symlink)
+      FileUtils.rm(emacs_symlink)
     end
   end
-
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
-  # Note: no ctags symlink; the ctags program was removed in Emacs 31
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
-
-  # Man pages (not gzipped in the build)
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
-  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
   # Cleanup on uninstall
   zap trash: [

--- a/Formula/emacs-plus@26.rb
+++ b/Formula/emacs-plus@26.rb
@@ -49,7 +49,7 @@ class EmacsPlusAT26 < EmacsBase
     # See: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=24455
     args << "--with-imagemagick"
 
-    imagemagick_lib_path = Formula["imagemagick@6"].opt_lib/"pkgconfig"
+    imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick@6")/"pkgconfig"
     ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
     ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     ENV.append "CFLAGS", "-O2 -DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT"
@@ -69,9 +69,7 @@ class EmacsPlusAT26 < EmacsBase
                                  .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                  .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                  .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-      File.open("src/config.h", "w") do |f|
-        f.write(configure_h_filtered)
-      end
+      File.write("src/config.h", configure_h_filtered)
     end
 
     system "make"

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -90,9 +90,7 @@ class EmacsPlusAT27 < EmacsBase
     args << "--with-gnutls"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -152,9 +150,7 @@ class EmacsPlusAT27 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "make", "install"
 
@@ -200,9 +196,7 @@ class EmacsPlusAT27 < EmacsBase
       system "make"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "make", "install"
     end

--- a/Formula/emacs-plus@27.rb
+++ b/Formula/emacs-plus@27.rb
@@ -47,10 +47,8 @@ class EmacsPlusAT27 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
   #
@@ -58,9 +56,18 @@ class EmacsPlusAT27 < EmacsBase
   # Patches
   #
 
-  local_patch "no-titlebar", sha: "fdf8dde63c2e1c4cb0b02354ce7f2102c5f8fd9e623f088860aee8d41d7ad38f" if build.with? "no-titlebar"
-  local_patch "xwidgets_webkit_in_cocoa", sha: "683b09c5f91d1ed3a550d10f409647e4ed236d4352464d15baef871546622e40" if build.with? "xwidgets"
-  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  if build.with? "no-titlebar"
+    local_patch "no-titlebar",
+                sha: "fdf8dde63c2e1c4cb0b02354ce7f2102c5f8fd9e623f088860aee8d41d7ad38f"
+  end
+  if build.with? "xwidgets"
+    local_patch "xwidgets_webkit_in_cocoa",
+                sha: "683b09c5f91d1ed3a550d10f409647e4ed236d4352464d15baef871546622e40"
+  end
+  if build.with? "no-frame-refocus"
+    local_patch "no-frame-refocus-cocoa",
+                sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd"
+  end
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
   local_patch "ligatures-freeze-fix", sha: "782a222505ceea31f9032ed55e24dcbd0357b1178b916b536d3eb222c9dc1225"
@@ -112,7 +119,7 @@ class EmacsPlusAT27 < EmacsBase
       end
 
     if build.with? "imagemagick"
-      imagemagick_lib_path = Formula["imagemagick"].opt_lib/"pkgconfig"
+      imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick")/"pkgconfig"
       ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     end
@@ -122,7 +129,7 @@ class EmacsPlusAT27 < EmacsBase
     args << "--without-pop" if build.with? "mailutils"
     args << "--with-xwidgets" if build.with? "xwidgets"
 
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
+    ENV.prepend_path "PATH", Utils::Path.formula_opt_libexec("gnu-sed")/"gnubin"
     system "./autogen.sh"
 
     if (build.with? "cocoa") && (build.without? "x11")
@@ -138,9 +145,7 @@ class EmacsPlusAT27 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "make"
@@ -189,9 +194,7 @@ class EmacsPlusAT27 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "make"

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -110,9 +110,7 @@ class EmacsPlusAT28 < EmacsBase
     args << "--with-native-compilation" if build.with? "native-comp"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -186,9 +184,7 @@ class EmacsPlusAT28 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "gmake", "install"
 
@@ -242,9 +238,7 @@ class EmacsPlusAT28 < EmacsBase
       system "gmake"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "gmake", "install"
     end

--- a/Formula/emacs-plus@28.rb
+++ b/Formula/emacs-plus@28.rb
@@ -64,25 +64,30 @@ class EmacsPlusAT28 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
-  if build.with? "no-titlebar"
-    if build.with? "no-titlebar-and-round-corners"
-      odie "--with-no-titlebar and --with-no-titlebar-and-round-corners are mutually exclusive"
-    end
+  if build.with?("no-titlebar") && build.with?("no-titlebar-and-round-corners")
+    odie "--with-no-titlebar and --with-no-titlebar-and-round-corners are mutually exclusive"
   end
 
   #
   # Patches
   #
 
-  local_patch "no-titlebar", sha: "2fa80efc5cda7e96d88a5d145c9313092a6e53d38825c41967c745f08778c41b" if build.with? "no-titlebar"
-  local_patch "no-titlebar-and-round-corners", sha: "ba7606186fe1b9e675147fed2c8080efa2824dc6679f6a9550b792533aec98be" if build.with? "no-titlebar-and-round-corners"
-  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  if build.with? "no-titlebar"
+    local_patch "no-titlebar",
+                sha: "2fa80efc5cda7e96d88a5d145c9313092a6e53d38825c41967c745f08778c41b"
+  end
+  if build.with? "no-titlebar-and-round-corners"
+    local_patch "no-titlebar-and-round-corners",
+                sha: "ba7606186fe1b9e675147fed2c8080efa2824dc6679f6a9550b792533aec98be"
+  end
+  if build.with? "no-frame-refocus"
+    local_patch "no-frame-refocus-cocoa",
+                sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd"
+  end
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
 
@@ -149,7 +154,7 @@ class EmacsPlusAT28 < EmacsBase
       end
 
     if build.with? "imagemagick"
-      imagemagick_lib_path = Formula["imagemagick"].opt_lib/"pkgconfig"
+      imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick")/"pkgconfig"
       ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     end
@@ -174,9 +179,7 @@ class EmacsPlusAT28 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"
@@ -233,9 +236,7 @@ class EmacsPlusAT28 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -109,9 +109,7 @@ class EmacsPlusAT29 < EmacsBase
     args << "--without-compress-install" if build.without? "compress-install"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -190,9 +188,7 @@ class EmacsPlusAT29 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "gmake", "install"
 
@@ -257,9 +253,7 @@ class EmacsPlusAT29 < EmacsBase
       system "gmake"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "gmake", "install"
     end

--- a/Formula/emacs-plus@29.rb
+++ b/Formula/emacs-plus@29.rb
@@ -66,17 +66,18 @@ class EmacsPlusAT29 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
   #
   # Patches
   #
 
-  local_patch "no-frame-refocus-cocoa", sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd" if build.with? "no-frame-refocus"
+  if build.with? "no-frame-refocus"
+    local_patch "no-frame-refocus-cocoa",
+                sha: "fb5777dc890aa07349f143ae65c2bcf43edad6febfd564b01a2235c5a15fcabd"
+  end
   local_patch "fix-window-role", sha: "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   local_patch "system-appearance", sha: "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   local_patch "round-undecorated-frame", sha: "7e39e694ce9dca50db72c09be442c1278d1900d69c2402f289742aeae8ea4c3e"
@@ -134,7 +135,7 @@ class EmacsPlusAT29 < EmacsBase
     end
 
     args << "CFLAGS=#{cflags.join(" ")}"
-    ENV.append "LDFLAGS", "-L#{Formula["sqlite"].opt_lib}"
+    ENV.append "LDFLAGS", "-L#{Utils::Path.formula_opt_lib("sqlite")}"
 
     args <<
       if build.with? "dbus"
@@ -154,7 +155,7 @@ class EmacsPlusAT29 < EmacsBase
       end
 
     if build.with? "imagemagick"
-      imagemagick_lib_path = Formula["imagemagick"].opt_lib/"pkgconfig"
+      imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick")/"pkgconfig"
       ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     end
@@ -182,9 +183,7 @@ class EmacsPlusAT29 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"
@@ -252,9 +251,7 @@ class EmacsPlusAT29 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -61,10 +61,8 @@ class EmacsPlusAT30 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
   #
@@ -123,7 +121,7 @@ class EmacsPlusAT30 < EmacsBase
     cflags << "-I#{Formula["libgccjit"].include}"
     args << "CFLAGS=#{cflags.join(" ")}"
 
-    ENV.append "LDFLAGS", "-L#{Formula["sqlite"].opt_lib}"
+    ENV.append "LDFLAGS", "-L#{Utils::Path.formula_opt_lib("sqlite")}"
     ENV.append "LDFLAGS", "-L#{gcc_lib}"
     ENV.append "LDFLAGS", "-Wl,-rpath,#{gcc_lib}"
 
@@ -145,7 +143,7 @@ class EmacsPlusAT30 < EmacsBase
       end
 
     if build.with? "imagemagick"
-      imagemagick_lib_path = Formula["imagemagick"].opt_lib/"pkgconfig"
+      imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick")/"pkgconfig"
       ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     end
@@ -174,9 +172,7 @@ class EmacsPlusAT30 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"
@@ -251,9 +247,7 @@ class EmacsPlusAT30 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"

--- a/Formula/emacs-plus@30.rb
+++ b/Formula/emacs-plus@30.rb
@@ -107,9 +107,7 @@ class EmacsPlusAT30 < EmacsBase
     gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -179,9 +177,7 @@ class EmacsPlusAT30 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "gmake", "install"
 
@@ -253,9 +249,7 @@ class EmacsPlusAT30 < EmacsBase
       system "gmake"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "gmake", "install"
     end
@@ -290,9 +284,7 @@ class EmacsPlusAT30 < EmacsBase
 
     # Also re-sign Emacs Client.app
     client_path = prefix/"Emacs Client.app"
-    if client_path.exist?
-      system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s
-    end
+    system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s if client_path.exist?
   end
 
   def caveats

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -110,9 +110,7 @@ class EmacsPlusAT31 < EmacsBase
     gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -182,9 +180,7 @@ class EmacsPlusAT31 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "gmake", "install"
 
@@ -256,9 +252,7 @@ class EmacsPlusAT31 < EmacsBase
       system "gmake"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "gmake", "install"
     end
@@ -282,9 +276,7 @@ class EmacsPlusAT31 < EmacsBase
 
     # Also re-sign Emacs Client.app
     client_path = prefix/"Emacs Client.app"
-    if client_path.exist?
-      system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s
-    end
+    system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s if client_path.exist?
   end
 
   def caveats

--- a/Formula/emacs-plus@31.rb
+++ b/Formula/emacs-plus@31.rb
@@ -60,17 +60,19 @@ class EmacsPlusAT31 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
   #
   # Patches
   #
 
-  opoo "The option --with-imagemagick is deprecated and will be removed in a future version. Modern Emacs has native support for most image formats (SVG via librsvg, WebP, PNG, JPEG, GIF). If you rely on ImageMagick, please open an issue describing your use case." if build.with? "imagemagick"
+  if build.with? "imagemagick"
+    opoo "The option --with-imagemagick is deprecated and will be removed in a future version. " \
+         "Modern Emacs has native support for most image formats (SVG via librsvg, WebP, PNG, JPEG, GIF). " \
+         "If you rely on ImageMagick, please open an issue describing your use case."
+  end
   local_patch "fix-ns-x-colors", sha: "9e5d3e26a8d388d3a000b697d582769645ca93ad597b4113744deba4b89a8b9e"
   local_patch "system-appearance", sha: "53283503db5ed2887e9d733baaaf80f2c810e668e782e988bda5855a0b1ebeb4"
   local_patch "round-undecorated-frame", sha: "c9430a1ead81e313b3d2877ff6f8044fb29441eecc7cc42000515d7c8ec6380f"
@@ -122,7 +124,7 @@ class EmacsPlusAT31 < EmacsBase
     cflags << "-I#{Formula["libgccjit"].include}"
     args << "CFLAGS=#{cflags.join(" ")}"
 
-    ENV.append "LDFLAGS", "-L#{Formula["sqlite"].opt_lib}"
+    ENV.append "LDFLAGS", "-L#{Utils::Path.formula_opt_lib("sqlite")}"
     ENV.append "LDFLAGS", "-L#{gcc_lib}"
     ENV.append "LDFLAGS", "-Wl,-rpath,#{gcc_lib}"
 
@@ -144,7 +146,7 @@ class EmacsPlusAT31 < EmacsBase
       end
 
     if build.with? "imagemagick"
-      imagemagick_lib_path = Formula["imagemagick"].opt_lib/"pkgconfig"
+      imagemagick_lib_path = Utils::Path.formula_opt_lib("imagemagick")/"pkgconfig"
       ohai "ImageMagick PKG_CONFIG_PATH: ", imagemagick_lib_path
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     end
@@ -173,9 +175,7 @@ class EmacsPlusAT31 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"
@@ -250,9 +250,7 @@ class EmacsPlusAT31 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -59,10 +59,8 @@ class EmacsPlusAT32 < EmacsBase
   # Incompatible options
   #
 
-  if build.with? "xwidgets"
-    unless (build.with? "cocoa") && (build.without? "x11")
-      odie "--with-xwidgets is not available when building --with-x11"
-    end
+  if build.with?("xwidgets") && !((build.with? "cocoa") && (build.without? "x11"))
+    odie "--with-xwidgets is not available when building --with-x11"
   end
 
   #
@@ -120,7 +118,7 @@ class EmacsPlusAT32 < EmacsBase
     cflags << "-I#{Formula["libgccjit"].include}"
     args << "CFLAGS=#{cflags.join(" ")}"
 
-    ENV.append "LDFLAGS", "-L#{Formula["sqlite"].opt_lib}"
+    ENV.append "LDFLAGS", "-L#{Utils::Path.formula_opt_lib("sqlite")}"
     ENV.append "LDFLAGS", "-L#{gcc_lib}"
     ENV.append "LDFLAGS", "-Wl,-rpath,#{gcc_lib}"
 
@@ -157,9 +155,7 @@ class EmacsPlusAT32 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"
@@ -234,9 +230,7 @@ class EmacsPlusAT32 < EmacsBase
                                    .gsub("#define HAVE_DECL_ALIGNED_ALLOC 1", "#undef HAVE_DECL_ALIGNED_ALLOC")
                                    .gsub("#define HAVE_ALLOCA 1", "#undef HAVE_ALLOCA")
                                    .gsub("#define HAVE_ALLOCA_H 1", "#undef HAVE_ALLOCA_H")
-        File.open("src/config.h", "w") do |f|
-          f.write(configure_h_filtered)
-        end
+        File.write("src/config.h", configure_h_filtered)
       end
 
       system "gmake"

--- a/Formula/emacs-plus@32.rb
+++ b/Formula/emacs-plus@32.rb
@@ -104,9 +104,7 @@ class EmacsPlusAT32 < EmacsBase
     gcc_lib="#{HOMEBREW_PREFIX}/lib/gcc/#{gcc_ver_major}"
 
     # Enable debug symbols in Homebrew's superenv
-    if build.with? "debug"
-      ENV.set_debug_symbols
-    end
+    ENV.set_debug_symbols if build.with? "debug"
 
     # Build CFLAGS - pass to configure for includes and defines
     # Note: Homebrew's superenv handles optimization (-O2) and debug (-g) flags
@@ -162,9 +160,7 @@ class EmacsPlusAT32 < EmacsBase
 
       # Generate dSYM bundle for debugging BEFORE install (clang stores symbols
       # in .o files, and dsymutil needs them to extract debug info)
-      if build.with? "debug"
-        system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs"
-      end
+      system "dsymutil", "nextstep/Emacs.app/Contents/MacOS/Emacs" if build.with? "debug"
 
       system "gmake", "install"
 
@@ -236,9 +232,7 @@ class EmacsPlusAT32 < EmacsBase
       system "gmake"
 
       # Generate dSYM bundle for debugging BEFORE install (non-Cocoa build)
-      if build.with? "debug"
-        system "dsymutil", "src/emacs"
-      end
+      system "dsymutil", "src/emacs" if build.with? "debug"
 
       system "gmake", "install"
     end
@@ -262,9 +256,7 @@ class EmacsPlusAT32 < EmacsBase
 
     # Also re-sign Emacs Client.app
     client_path = prefix/"Emacs Client.app"
-    if client_path.exist?
-      system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s
-    end
+    system "codesign", "--force", "--deep", "--sign", "-", client_path.to_s if client_path.exist?
   end
 
   def caveats

--- a/NEWS.org
+++ b/NEWS.org
@@ -7,6 +7,10 @@ This file documents notable changes to Emacs Plus.
 
 ** Improvements
 
+*** =brew style= runs in CI
+
+The formulas and casks are now checked with =brew style= on every push and pull request, and all existing style offenses are fixed. Two cask cops are excluded (=Cask/NoOverrides= and =Cask/OnSystemConditionals=): they demand restructuring the casks into =on_{macos_version}= blocks, which does not fit how the casks pick one of several prebuilt binaries per macOS version. As part of the cleanup the casks now declare =depends_on :macos= and their descriptions no longer name the platform.
+
 *** Caveats warn about mixing formula and cask installs
 
 The =emacs-plus@N= formulas and the =emacs-plus-app= casks both provide =emacs= and =emacsclient= in =$(brew --prefix)/bin=, but Homebrew cannot declare a conflict between a formula and a cask, so nothing stops you from installing both and ending up with commands that do not match the app you launch. The caveats on both sides now say to keep one or the other.


### PR DESCRIPTION
Nothing checked Homebrew style rules, so offenses piled up (129 across Formula and Casks). This fixes them all (mostly autocorrect: stanza order, hash alignment, Utils::Path helpers, File.write; plus a few manual rewrites) and adds a brew style step to the validate workflow. The checkout is symlinked into the tap location since brew style refuses files outside a tap. Cask/NoOverrides and Cask/OnSystemConditionals are excluded: they demand restructuring the casks into on_{macos_version} blocks, which does not fit picking one of several prebuilt binaries per macOS version. Along the way the casks gained depends_on :macos (required by Homebrew/OSDependsOn) and lost the platform mention in desc (required by Cask/Desc).