### PR TITLE
fix: gate casks on the macOS versions their binaries support

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -8,6 +8,10 @@ cask "emacs-plus-app" do
   emacs_ver = version.sub(/-\d+$/, "")
 
   on_arm do
+    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+    # runner), so Ventura cannot run it
+    depends_on macos: :sonoma
+
     if MacOS.version >= :tahoe # macOS 26
       sha256 "ee974066f3527fbe444d9a176e124fdbfd8b3ee678bece9fc52218e07eeea0c8"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
@@ -16,7 +20,7 @@ cask "emacs-plus-app" do
       sha256 "3209d55a056950a560fab3d2a0e81aba7c3372245c8ee9d80b49d4dbd4614c7b"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma) and 13 (Ventura)
+    else # macOS 14 (Sonoma)
       sha256 "68c713d633d08a3fc3d04a87cdad4510617ff75e1404e554335418120cc69a3b"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
@@ -27,6 +31,10 @@ cask "emacs-plus-app" do
 
     url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
         verified: "github.com/d12frosted/homebrew-emacs-plus"
+
+    # The only Intel build targets macOS 15 (built on the macos-15-intel
+    # runner, the sole Intel runner available)
+    depends_on macos: :sequoia
   end
 
   name "Emacs+"

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -8,6 +8,10 @@ cask "emacs-plus-app@master" do
   emacs_ver = version.sub(/-\d+$/, "")
 
   on_arm do
+    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+    # runner), so Ventura cannot run it
+    depends_on macos: :sonoma
+
     if MacOS.version >= :tahoe # macOS 26
       sha256 "1310c9b5b3c3b8794620a06156f90a91795cc993ba537521bccd21b5e7f16a4c"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
@@ -16,7 +20,7 @@ cask "emacs-plus-app@master" do
       sha256 "8cf3c54bfe9ac6d7c42dcab98a16127e97de309e85ec93047431f7fd9d321c01"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma) and 13 (Ventura)
+    else # macOS 14 (Sonoma)
       sha256 "340c118e1b56420f1d0be98653bbf0727a1d85256c6ddaf46911a3dfac19c334"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
@@ -27,6 +31,10 @@ cask "emacs-plus-app@master" do
 
     url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
         verified: "github.com/d12frosted/homebrew-emacs-plus"
+
+    # The only Intel build targets macOS 15 (built on the macos-15-intel
+    # runner, the sole Intel runner available)
+    depends_on macos: :sequoia
   end
 
   name "Emacs+ (Development)"

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -8,6 +8,10 @@ cask "emacs-plus-app@next" do
   emacs_ver = version.sub(/-\d+$/, "")
 
   on_arm do
+    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+    # runner), so Ventura cannot run it
+    depends_on macos: :sonoma
+
     if MacOS.version >= :tahoe # macOS 26
       sha256 "eae20b81bfa161d7d85ecd0c32bf561ccc55c30685c6c29b5681b70dd1b5983a"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
@@ -16,7 +20,7 @@ cask "emacs-plus-app@next" do
       sha256 "89f9b81c72d8745ec8282776ee757bd467676afe49f15812de35d8bea2f157b9"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma) and 13 (Ventura)
+    else # macOS 14 (Sonoma)
       sha256 "66f5ccb0ef0ad716d408982cac6488216163a0b400e4b3f05d595da087f37114"
       url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
           verified: "github.com/d12frosted/homebrew-emacs-plus"
@@ -27,6 +31,10 @@ cask "emacs-plus-app@next" do
 
     url "#{base_url}/emacs-plus-#{emacs_ver}-x86_64-15.zip",
         verified: "github.com/d12frosted/homebrew-emacs-plus"
+
+    # The only Intel build targets macOS 15 (built on the macos-15-intel
+    # runner, the sole Intel runner available)
+    depends_on macos: :sequoia
   end
 
   name "Emacs+ (Next)"

--- a/NEWS.org
+++ b/NEWS.org
@@ -27,6 +27,10 @@ Every =emacs-plus@N= service wrote to the same =/tmp/homebrew.mxcl.emacs-plus.{s
 
 ** Bug Fixes
 
+*** Casks refuse to install on macOS versions their binaries cannot run on
+
+The prebuilt binaries have a minimum macOS baked in by the build runner: the oldest arm64 build targets macOS 14 (Sonoma) and the only Intel build targets macOS 15 (Sequoia). The casks happily installed on older systems (the arm64 fallback even claimed to cover Ventura), and the app then refused to launch. The casks now declare =depends_on macos:= per architecture, so unsupported systems get a clear error at install time. On older macOS, build from source with the formula instead.
+
 *** Formula =emacs= wrapper prefers its own =Emacs.app=
 
 The =emacs= wrapper installed by =emacs-plus@29= through =emacs-plus@32= looked for =Emacs.app= in =/Applications= first and only then in the formula's own prefix. That order predates the casks: with =emacs-plus-app= installed, a formula user running =emacs= in the terminal (or =brew services start emacs-plus@N=) silently got the cask's Emacs, possibly a different major version. The wrapper now runs the formula's own bundle first and falls back to =/Applications= and =~/Applications= only when it is missing, so copies made for Spotlight integration keep working. Reinstall the formula to get the fixed wrapper.

--- a/README.org
+++ b/README.org
@@ -149,10 +149,10 @@ Cask builds are self-contained applications with all dependencies bundled. They 
 |----------------------+------------------------+---------------------------|
 | Install time         | ~1 minute (download)   | ~30 minutes (compile)     |
 | Custom build options | No                     | Yes (icons, patches, etc) |
-| macOS versions       | ARM64: 13+, Intel: 15+ | Any supported             |
+| macOS versions       | ARM64: 14+, Intel: 15+ | Any supported             |
 | Architectures        | ARM64 and Intel        | Any                       |
 
-*Note:* Cask builds are architecture and macOS version specific. ARM64 has dedicated builds for Sonoma (14), Sequoia (15), and Tahoe (26); Ventura (13) users get the Sonoma build. Intel has a single Sequoia (15) build.
+*Note:* Cask builds are architecture and macOS version specific. ARM64 has dedicated builds for Sonoma (14), Sequoia (15), and Tahoe (26). Intel has a single Sequoia (15) build. On older macOS versions the cask refuses to install; use the formula instead.
 
 Use the *formula* if you need custom icons, patches, or specific build options. Use the *cask* for quick installation with sensible defaults.
 


### PR DESCRIPTION
The prebuilt binaries carry a minimum macOS from their build runner: the oldest arm64 build has minos 14.0 (checked with otool -l on the released zips) and the sole Intel build has minos 15.0. The casks installed fine on older systems and the app then refused to launch; the arm64 fallback branch even claimed to cover Ventura. Each cask now declares depends_on macos: :sonoma for arm and :sequoia for intel, so unsupported systems fail at install time with a clear message. README support matrix updated to match (ARM64 is 14+, not 13+).