### PR TITLE
Declare usage descriptions for all class-based TCC services

### DIFF
--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -24,6 +24,7 @@
 # Native compilation works via LIBRARY_PATH without needing PATH.
 
 require_relative 'BuildConfig'
+require_relative 'PlistExtras'
 
 module CaskEnv
   class << self
@@ -41,6 +42,7 @@ module CaskEnv
 
       modified = false
       modified |= run_step("Emacs.app environment injection") { inject_emacs_app(emacs_app) }
+      modified |= run_step("Emacs.app usage descriptions") { declare_usage_descriptions(emacs_app) }
       modified |= run_step("Emacs Client.app environment injection") { inject_emacs_client_app(emacs_client_app) }
       modified |= run_step("site-start.el update") { update_site_start_el(emacs_app) }
       modified
@@ -228,6 +230,32 @@ module CaskEnv
 
       native_comp_env.each do |key, value|
         system("/usr/libexec/PlistBuddy", "-c", "Add :LSEnvironment:#{key} string '#{value}'", plist)
+      end
+
+      # Touch the app to update LaunchServices cache
+      system("touch", app_path)
+
+      true
+    end
+
+    # Declare the usage descriptions for the class-based TCC privacy services
+    # in Emacs.app's Info.plist. The prebuilt bundles carry only what upstream
+    # Emacs declares, so without this a process started from within Emacs is
+    # killed with SIGABRT when it touches one of those frameworks. See
+    # Library/PlistExtras.rb.
+    #
+    # Returns true when the plist changed, so the caller re-signs the bundle.
+    def declare_usage_descriptions(app_path)
+      return false unless File.exist?(app_path)
+
+      plist = "#{app_path}/Contents/Info.plist"
+      return false if PlistExtras.usage_descriptions_current?(plist)
+
+      puts "Declaring privacy usage descriptions in #{app_path}"
+      failed = PlistExtras.set_usage_descriptions(plist)
+      unless failed.empty?
+        message = "Could not declare usage descriptions: #{failed.join(", ")}"
+        defined?(opoo) ? opoo(message) : warn("Warning: #{message}")
       end
 
       # Touch the app to update LaunchServices cache

--- a/Library/EmacsBase.rb
+++ b/Library/EmacsBase.rb
@@ -1,5 +1,6 @@
 require_relative "UrlResolver"
 require_relative "BuildConfig"
+require_relative "PlistExtras"
 
 class CopyDownloadStrategy < AbstractFileDownloadStrategy
   def initialize(url, name, version, **meta)
@@ -660,19 +661,15 @@ class EmacsBase < Formula
   end
 
   # Inject Emacs Plus customizations into Emacs.app Info.plist: usage
-  # descriptions for protected resources (camera, microphone, speech
-  # recognition) and AutoFill opt-out.
+  # descriptions for the class-based TCC privacy services and AutoFill
+  # opt-out. See Library/PlistExtras.rb for what is declared and why.
   def inject_plist_extras
     ohai "Injecting Info.plist extras"
     app = "#{prefix}/Emacs.app"
     plist = "#{app}/Contents/Info.plist"
 
-    system "/usr/libexec/PlistBuddy -c 'Add NSCameraUsageDescription string' '#{plist}'"
-    system "/usr/libexec/PlistBuddy -c 'Set NSCameraUsageDescription Emacs requires permission to access the Camera.' '#{plist}'"
-    system "/usr/libexec/PlistBuddy -c 'Add NSMicrophoneUsageDescription string' '#{plist}'"
-    system "/usr/libexec/PlistBuddy -c 'Set NSMicrophoneUsageDescription Emacs requires permission to access the Microphone.' '#{plist}'"
-    system "/usr/libexec/PlistBuddy -c 'Add NSSpeechRecognitionUsageDescription string' '#{plist}' || true"
-    system "/usr/libexec/PlistBuddy -c 'Set NSSpeechRecognitionUsageDescription Emacs requires permission to handle any speech recognition.' '#{plist}' || true"
+    failed = PlistExtras.set_usage_descriptions(plist)
+    opoo "Could not declare usage descriptions: #{failed.join(", ")}" unless failed.empty?
 
     # Prevent macOS from heuristically offering one-time-code AutoFill in Emacs text fields
     plist_set plist, "NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac", "bool", true
@@ -682,10 +679,7 @@ class EmacsBase < Formula
 
   # Helper method to add or set a plist key (handles both cases)
   def plist_set(plist, key, type, value)
-    # Try to add first; if it exists, set it instead
-    # Use double quotes for the command to allow proper escaping
-    escaped_value = value.to_s.gsub('"', '\\"')
-    system "/usr/libexec/PlistBuddy -c \"Add :#{key} #{type} #{escaped_value}\" \"#{plist}\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Set :#{key} #{escaped_value}\" \"#{plist}\""
+    opoo "Could not set #{key} in #{plist}" unless PlistExtras.set(plist, key, type, value)
   end
 
   # Escape a string for embedding in an AppleScript double-quoted string

--- a/Library/PlistExtras.rb
+++ b/Library/PlistExtras.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# PlistExtras - Info.plist customizations injected into Emacs.app
+#
+# Emacs Plus edits the Info.plist of the bundle it builds (or ships in the
+# cask) before signing it. Two kinds of edits live here:
+#
+# 1. Usage descriptions for the class-based TCC privacy services. macOS
+#    attributes a privacy check to the responsible process, which for
+#    anything started from within Emacs (M-x shell, eshell, term, compile,
+#    org-babel, ...) is Emacs.app itself. Without a matching key in
+#    Info.plist such a process is killed with SIGABRT the moment it touches
+#    the framework. Declaring a key grants nothing on its own: it only
+#    carries the string macOS shows in the permission dialog, and the user
+#    still answers allow or deny per service.
+#
+#    Upstream Emacs declines to ship these (bug#81526), and users cannot add
+#    them after the fact: Info.plist is sealed by the code signature, so the
+#    keys have to be in place before the bundle is signed.
+#
+# 2. The AutoFill opt-out, which stops macOS 26 (Tahoe) and later from
+#    spawning an "AutoFill (Emacs)" helper that scans text fields for
+#    one-time codes.
+#
+# Kept free of Homebrew dependencies so it can be unit tested directly.
+
+require "English"
+
+module PlistExtras
+  PLIST_BUDDY = "/usr/libexec/PlistBuddy"
+
+  # Usage descriptions for class-based TCC privacy services.
+  #
+  # Photos, camera, microphone, contacts, calendars, reminders, Bluetooth and
+  # speech recognition are hard crashers: TCC kills the process when the key
+  # is missing. Location and local network are not, but without the keys a
+  # location request is silently ignored and the local network prompt shows
+  # generic text, so they are declared too.
+  #
+  # Where Apple introduced replacement keys (calendars and reminders on macOS
+  # 14), both generations are declared so older systems keep working.
+  #
+  # Emacs itself never uses these frameworks, so the wording attributes the
+  # request to whatever the user started from within Emacs. The exception is
+  # speech recognition, which upstream ships since Emacs 31 in its own voice;
+  # that string is kept as upstream has it.
+  USAGE_DESCRIPTIONS = {
+    "NSBluetoothAlwaysUsageDescription" =>
+      "An application in Emacs requires permission to use Bluetooth.",
+    "NSCalendarsUsageDescription" =>
+      "An application in Emacs requires permission to access your calendars.",
+    "NSCalendarsFullAccessUsageDescription" =>
+      "An application in Emacs requires full access to your calendars.",
+    "NSCalendarsWriteOnlyAccessUsageDescription" =>
+      "An application in Emacs requires permission to add events to your calendars.",
+    "NSCameraUsageDescription" =>
+      "An application in Emacs requires permission to use the camera.",
+    "NSContactsUsageDescription" =>
+      "An application in Emacs requires permission to access your contacts.",
+    "NSLocalNetworkUsageDescription" =>
+      "An application in Emacs requires permission to access the local network.",
+    "NSLocationUsageDescription" =>
+      "An application in Emacs requires permission to access your location.",
+    "NSLocationWhenInUseUsageDescription" =>
+      "An application in Emacs requires permission to access your location.",
+    "NSMicrophoneUsageDescription" =>
+      "An application in Emacs requires permission to use the microphone.",
+    "NSPhotoLibraryUsageDescription" =>
+      "An application in Emacs requires permission to access your photo library.",
+    "NSPhotoLibraryAddUsageDescription" =>
+      "An application in Emacs requires permission to add photos to your photo library.",
+    "NSRemindersUsageDescription" =>
+      "An application in Emacs requires permission to access your reminders.",
+    "NSRemindersFullAccessUsageDescription" =>
+      "An application in Emacs requires full access to your reminders.",
+    "NSSpeechRecognitionUsageDescription" =>
+      "Emacs requires permission to handle any speech recognition.",
+  }.freeze
+
+  class << self
+    # Add a key, or set it when the bundle already declares it (Emacs 31 and
+    # later ship some of these themselves). Returns true on success.
+    #
+    # PlistBuddy is invoked without a shell, so values may contain spaces,
+    # quotes and non-ASCII characters. A failing Add is expected whenever the
+    # key exists, so its output is discarded.
+    #
+    # The missing file is checked here because PlistBuddy still exits 0 when
+    # it cannot open its destination.
+    def set(plist, key, type, value)
+      return false unless File.file?(plist.to_s)
+      return true if run("Add :#{key} #{type} #{value}", plist, quiet: true)
+
+      run("Set :#{key} #{value}", plist)
+    end
+
+    # Declare every usage description. Returns the keys that could not be
+    # written, empty when all of them landed.
+    def set_usage_descriptions(plist)
+      USAGE_DESCRIPTIONS.reject { |key, description| set(plist, key, "string", description) }.keys
+    end
+
+    # Whether the bundle already declares every usage description with the
+    # current wording. Lets callers skip a write (and the re-signing that
+    # follows it) when there is nothing to change.
+    def usage_descriptions_current?(plist)
+      return false unless File.file?(plist.to_s)
+
+      USAGE_DESCRIPTIONS.all? { |key, description| read(plist, key) == description }
+    end
+
+    # Read a string value, or nil when the key is absent.
+    def read(plist, key)
+      return nil unless File.file?(plist.to_s)
+
+      output = IO.popen([PLIST_BUDDY, "-c", "Print :#{key}", plist.to_s], err: File::NULL, &:read)
+      return nil unless $CHILD_STATUS.success?
+
+      output.chomp.force_encoding(Encoding::UTF_8)
+    end
+
+    private
+
+    def run(command, plist, quiet: false)
+      options = quiet ? { out: File::NULL, err: File::NULL } : {}
+      system(PLIST_BUDDY, "-c", command, plist.to_s, **options)
+    end
+  end
+end

--- a/NEWS.org
+++ b/NEWS.org
@@ -7,6 +7,16 @@ This file documents notable changes to Emacs Plus.
 
 ** Improvements
 
+*** Emacs.app declares usage descriptions for all class-based privacy services
+
+macOS attributes a privacy check to the responsible process, and for anything started from within Emacs (=M-x shell=, eshell, =M-x compile=, org-babel, vterm) that is Emacs.app. When =Info.plist= does not declare a usage description for the service, macOS never asks: it kills the process with =SIGABRT= as soon as it touches the framework. Emacs Plus declared three of these keys (camera, microphone, speech recognition), and now declares all of them: photo library (read and add), contacts, calendars (including the macOS 14+ full access and write only variants), reminders, Bluetooth, location and local network.
+
+Declaring a key grants nothing by itself. It only carries the text macOS shows in the permission dialog, and the allow or deny decision stays yours, per service, in the prompt or later in System Settings > Privacy & Security. The wording is now "An application in Emacs requires permission to ...", because Emacs itself never touches these frameworks; the prompt is always about something you started from within Emacs.
+
+The casks never declared any of these keys, only the formula did, so cask users were missing even the camera and microphone ones. Both install paths declare them now.
+
+I proposed this upstream as [[https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81526][bug#81526]] and it was not accepted: the position there is that declaring the keys is not the upstream project's business and adds maintenance burden for whatever Apple does next. So it stays a downstream fix.
+
 *** README explains how to run Emacs as a daemon, for formula and cask
 
 The formula has =brew services= support, but the cask cannot have it: =brew services= only works with formulas, and the cask =service= stanza means something unrelated in the cask DSL. The README now has a [[https://github.com/d12frosted/homebrew-emacs-plus#running-emacs-as-a-daemon][Running Emacs as a daemon]] section covering =brew services= for the formula and a LaunchAgent recipe for the cask, plus a reminder that =emacsclient -c -a ''= starts a daemon on demand and may be all you need. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/937][#937]].

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -24,6 +24,7 @@ module Hardware
 end
 
 require_relative '../Library/CaskEnv'
+require_relative '../Library/PlistExtras'
 
 class TestCaskEnv < Minitest::Test
   def setup
@@ -763,5 +764,74 @@ class TestCaskEnv < Minitest::Test
   def test_escape_for_applescript_shell_handles_normal_path
     result = CaskEnv.send(:escape_for_applescript_shell, "/usr/bin:/opt/homebrew/bin")
     assert_equal "/usr/bin:/opt/homebrew/bin", result
+  end
+  # ===========================================
+  # Tests for privacy usage descriptions
+  # ===========================================
+
+  # The prebuilt bundles ship with whatever upstream Emacs declares, so the
+  # cask has to declare the class-based TCC keys itself, the way the formula
+  # does at build time.
+  def make_app_with_plist(dir)
+    app_path = "#{dir}/Emacs.app"
+    FileUtils.mkdir_p("#{app_path}/Contents")
+    File.write("#{app_path}/Contents/Info.plist", <<~PLIST)
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      	<key>CFBundleName</key>
+      	<string>Emacs</string>
+      </dict>
+      </plist>
+    PLIST
+    app_path
+  end
+
+  def test_declare_usage_descriptions_writes_the_keys
+    Dir.mktmpdir do |dir|
+      app_path = make_app_with_plist(dir)
+
+      assert_output(/usage descriptions/i, nil) do
+        assert_equal true, CaskEnv.send(:declare_usage_descriptions, app_path)
+      end
+
+      plist = "#{app_path}/Contents/Info.plist"
+      assert PlistExtras.usage_descriptions_current?(plist)
+    end
+  end
+
+  def test_declare_usage_descriptions_is_idempotent
+    # Re-signing is driven by the return value, so a second postflight run
+    # must report that it changed nothing
+    Dir.mktmpdir do |dir|
+      app_path = make_app_with_plist(dir)
+
+      capture_io { CaskEnv.send(:declare_usage_descriptions, app_path) }
+      assert_equal false, CaskEnv.send(:declare_usage_descriptions, app_path)
+    end
+  end
+
+  def test_declare_usage_descriptions_handles_missing_app
+    Dir.mktmpdir do |dir|
+      assert_equal false, CaskEnv.send(:declare_usage_descriptions, "#{dir}/Emacs.app")
+    end
+  end
+
+  def test_inject_declares_usage_descriptions
+    Dir.mktmpdir do |dir|
+      app_path = make_app_with_plist(dir)
+      make_site_start(dir)
+
+      with_empty_build_config do
+        CaskEnv.stub(:inject_emacs_app, false) do
+          CaskEnv.stub(:inject_emacs_client_app, false) do
+            capture_io { CaskEnv.inject(app_path, "#{dir}/Emacs Client.app") }
+          end
+        end
+      end
+
+      assert PlistExtras.usage_descriptions_current?("#{app_path}/Contents/Info.plist")
+    end
   end
 end

--- a/tests/test_plist_extras.rb
+++ b/tests/test_plist_extras.rb
@@ -1,0 +1,202 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test suite for PlistExtras, the Info.plist customizations injected into
+# Emacs.app (usage descriptions for TCC privacy services, AutoFill opt-out).
+#
+# Run with: ruby tests/test_plist_extras.rb
+
+require 'minitest/autorun'
+require 'tmpdir'
+
+require_relative '../Library/PlistExtras'
+
+class TestPlistExtras < Minitest::Test
+  EMPTY_PLIST = <<~PLIST
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+    	<key>CFBundleName</key>
+    	<string>Emacs</string>
+    </dict>
+    </plist>
+  PLIST
+
+  def with_plist(contents = EMPTY_PLIST)
+    Dir.mktmpdir do |dir|
+      plist = File.join(dir, "Info.plist")
+      File.write(plist, contents)
+      yield plist
+    end
+  end
+
+  def read_key(plist, key)
+    out = `/usr/libexec/PlistBuddy -c "Print :#{key}" "#{plist}" 2>/dev/null`
+    $?.success? ? out.chomp.force_encoding(Encoding::UTF_8) : nil
+  end
+
+  # ===========================================
+  # Usage description data
+  # ===========================================
+
+  # Every class-based TCC service a process started from within Emacs can
+  # touch. Photos, camera, microphone, contacts, calendars, reminders,
+  # Bluetooth and speech recognition kill the process with SIGABRT when the
+  # key is missing; location and local network only misbehave.
+  EXPECTED_KEYS = %w[
+    NSBluetoothAlwaysUsageDescription
+    NSCalendarsUsageDescription
+    NSCalendarsFullAccessUsageDescription
+    NSCalendarsWriteOnlyAccessUsageDescription
+    NSCameraUsageDescription
+    NSContactsUsageDescription
+    NSLocalNetworkUsageDescription
+    NSLocationUsageDescription
+    NSLocationWhenInUseUsageDescription
+    NSMicrophoneUsageDescription
+    NSPhotoLibraryUsageDescription
+    NSPhotoLibraryAddUsageDescription
+    NSRemindersUsageDescription
+    NSRemindersFullAccessUsageDescription
+    NSSpeechRecognitionUsageDescription
+  ].freeze
+
+  def test_declares_every_class_based_service
+    assert_equal EXPECTED_KEYS.sort, PlistExtras::USAGE_DESCRIPTIONS.keys.sort
+  end
+
+  def test_descriptions_are_sentences
+    PlistExtras::USAGE_DESCRIPTIONS.each do |key, description|
+      assert_kind_of String, description, "#{key} must have a string description"
+      refute_empty description, "#{key} must have a non-empty description"
+      assert description.end_with?("."), "#{key} description must end with a period"
+    end
+  end
+
+  def test_subprocess_services_speak_for_the_subprocess
+    # Emacs itself never touches these frameworks: the prompt is always about
+    # something the user started from within Emacs.
+    PlistExtras::USAGE_DESCRIPTIONS.each do |key, description|
+      next if key == "NSSpeechRecognitionUsageDescription"
+
+      assert description.start_with?("An application in Emacs "),
+             "#{key} should attribute the request to a program running in Emacs"
+    end
+  end
+
+  def test_speech_recognition_keeps_upstream_wording
+    # Upstream Emacs ships this key (and this string) since Emacs 31, so keep
+    # it byte-identical instead of rewording it.
+    assert_equal "Emacs requires permission to handle any speech recognition.",
+                 PlistExtras::USAGE_DESCRIPTIONS["NSSpeechRecognitionUsageDescription"]
+  end
+
+  # ===========================================
+  # set
+  # ===========================================
+
+  def test_set_adds_missing_key
+    with_plist do |plist|
+      assert PlistExtras.set(plist, "NSCameraUsageDescription", "string", "Say cheese.")
+      assert_equal "Say cheese.", read_key(plist, "NSCameraUsageDescription")
+    end
+  end
+
+  def test_set_overwrites_existing_key
+    with_plist do |plist|
+      PlistExtras.set(plist, "NSCameraUsageDescription", "string", "Old wording.")
+      assert PlistExtras.set(plist, "NSCameraUsageDescription", "string", "New wording.")
+      assert_equal "New wording.", read_key(plist, "NSCameraUsageDescription")
+    end
+  end
+
+  def test_set_preserves_untouched_keys
+    with_plist do |plist|
+      PlistExtras.set(plist, "NSCameraUsageDescription", "string", "Say cheese.")
+      assert_equal "Emacs", read_key(plist, "CFBundleName")
+    end
+  end
+
+  def test_set_handles_punctuation_and_unicode
+    value = "Copyright © 1989-2026 Free Software Foundation, Inc."
+    with_plist do |plist|
+      assert PlistExtras.set(plist, "NSHumanReadableCopyright", "string", value)
+      assert_equal value, read_key(plist, "NSHumanReadableCopyright")
+    end
+  end
+
+  def test_set_writes_booleans
+    with_plist do |plist|
+      assert PlistExtras.set(plist, "NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac", "bool", true)
+      assert_equal "true", read_key(plist, "NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac")
+    end
+  end
+
+  def test_set_reports_a_missing_plist_instead_of_raising
+    refute PlistExtras.set("/nonexistent/Info.plist", "NSCameraUsageDescription", "string", "Say cheese.")
+  end
+
+  def test_set_reports_an_unreadable_plist_instead_of_raising
+    with_plist("not a plist at all") do |plist|
+      refute PlistExtras.set(plist, "NSCameraUsageDescription", "string", "Say cheese.")
+    end
+  end
+
+  # ===========================================
+  # set_usage_descriptions
+  # ===========================================
+
+  def test_set_usage_descriptions_declares_every_key
+    with_plist do |plist|
+      assert_empty PlistExtras.set_usage_descriptions(plist)
+      PlistExtras::USAGE_DESCRIPTIONS.each do |key, description|
+        assert_equal description, read_key(plist, key)
+      end
+    end
+  end
+
+  def test_set_usage_descriptions_replaces_keys_the_bundle_already_has
+    # Emacs 31 and later ship NSSpeechRecognitionUsageDescription themselves.
+    with_plist do |plist|
+      PlistExtras.set(plist, "NSSpeechRecognitionUsageDescription", "string", "Something else.")
+      assert_empty PlistExtras.set_usage_descriptions(plist)
+      assert_equal PlistExtras::USAGE_DESCRIPTIONS["NSSpeechRecognitionUsageDescription"],
+                   read_key(plist, "NSSpeechRecognitionUsageDescription")
+    end
+  end
+
+  # ===========================================
+  # usage_descriptions_current?
+  # ===========================================
+
+  def test_usage_descriptions_are_not_current_in_a_stock_bundle
+    with_plist do |plist|
+      refute PlistExtras.usage_descriptions_current?(plist)
+    end
+  end
+
+  def test_usage_descriptions_are_current_after_declaring_them
+    with_plist do |plist|
+      PlistExtras.set_usage_descriptions(plist)
+      assert PlistExtras.usage_descriptions_current?(plist)
+    end
+  end
+
+  def test_usage_descriptions_are_not_current_when_one_is_stale
+    with_plist do |plist|
+      PlistExtras.set_usage_descriptions(plist)
+      PlistExtras.set(plist, "NSCameraUsageDescription", "string", "Old wording.")
+      refute PlistExtras.usage_descriptions_current?(plist)
+    end
+  end
+
+  def test_usage_descriptions_are_not_current_without_a_plist
+    refute PlistExtras.usage_descriptions_current?("/nonexistent/Info.plist")
+  end
+
+  def test_set_usage_descriptions_reports_failed_keys
+    failed = PlistExtras.set_usage_descriptions("/nonexistent/Info.plist")
+    assert_equal PlistExtras::USAGE_DESCRIPTIONS.keys.sort, failed.sort
+  end
+end


### PR DESCRIPTION
Anything started from within Emacs (`M-x shell`, eshell, `M-x compile`, org-babel) runs under Emacs.app's identity as far as macOS privacy checks are concerned. When `Info.plist` does not declare a usage description for the service, macOS does not prompt: it kills the process with `SIGABRT`.

We declared camera, microphone and speech recognition. This adds the rest: photo library (read and add), contacts, calendars (including the macOS 14+ full access and write only variants), reminders, Bluetooth, location and local network. Declaring a key grants nothing, it only carries the text shown in the permission dialog.

Two other things in here:

- the casks declared none of these keys, since the prebuilt bundles are not built through the formula, so cask users did not even get camera and microphone. The postflight declares them now, and skips the write (and the re-sign) when they are already current.
- the keys and the PlistBuddy calls move to `Library/PlistExtras.rb`, shared by the formula and the cask, with tests.

I proposed the same change upstream in [bug#81526](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81526) and it was not accepted: the position there is that this is not the upstream project's business and it adds maintenance burden for whatever Apple does next. So it stays downstream.