### PR TITLE
chore: drop Intel (x86_64) cask builds

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -37,7 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # ARM64 builds
           - runner: macos-26
             arch: arm64
             os_name: tahoe
@@ -47,10 +46,6 @@ jobs:
           - runner: macos-14
             arch: arm64
             os_name: sonoma
-          # Intel build (macos-15-intel is the only Intel runner available)
-          - runner: macos-15-intel
-            arch: x86_64
-            os_name: sequoia-intel
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -62,23 +57,13 @@ jobs:
           echo "OS_VER=$(sw_vers -productVersion)" >> $GITHUB_ENV
           echo "OS_NAME=${{ matrix.platform.os_name }}" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
-          if [ "${{ matrix.platform.arch }}" = "arm64" ]; then
-            echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
-          else
-            echo "HOMEBREW_PREFIX=/usr/local" >> $GITHUB_ENV
-          fi
+          echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            gcc libgccjit pkg-config webp
-          # Homebrew stopped shipping x86_64 macOS bottles for tree-sitter
-          # (Intel is Tier 3 now), and refuses to build Tier 3 configurations
-          # from source unless asked explicitly. It is a small C library, so
-          # the source build is cheap. Try the bottle first so this goes back
-          # to being a no-op if x86_64 bottles ever come back.
-          brew install tree-sitter || brew install --build-from-source tree-sitter
+            gcc libgccjit pkg-config webp tree-sitter
 
       - name: Clone Emacs source
         run: |
@@ -221,7 +206,7 @@ jobs:
                 return 0
               fi
             done
-            # Search in Cellar (both ARM and Intel Homebrew prefixes)
+            # Search in Cellar
             for cellar in /opt/homebrew/Cellar /usr/local/Cellar; do
               if [[ -d "$cellar" ]]; then
                 local found=$(find "$cellar" -name "$dylib_name" -type f 2>/dev/null | head -1)
@@ -481,7 +466,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # ARM64 builds
           - runner: macos-26
             arch: arm64
             os_name: tahoe
@@ -491,10 +475,6 @@ jobs:
           - runner: macos-14
             arch: arm64
             os_name: sonoma
-          # Intel build (macos-15-intel is the only Intel runner available)
-          - runner: macos-15-intel
-            arch: x86_64
-            os_name: sequoia-intel
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -506,23 +486,13 @@ jobs:
           echo "OS_VER=$(sw_vers -productVersion)" >> $GITHUB_ENV
           echo "OS_NAME=${{ matrix.platform.os_name }}" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
-          if [ "${{ matrix.platform.arch }}" = "arm64" ]; then
-            echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
-          else
-            echo "HOMEBREW_PREFIX=/usr/local" >> $GITHUB_ENV
-          fi
+          echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            gcc libgccjit pkg-config webp
-          # Homebrew stopped shipping x86_64 macOS bottles for tree-sitter
-          # (Intel is Tier 3 now), and refuses to build Tier 3 configurations
-          # from source unless asked explicitly. It is a small C library, so
-          # the source build is cheap. Try the bottle first so this goes back
-          # to being a no-op if x86_64 bottles ever come back.
-          brew install tree-sitter || brew install --build-from-source tree-sitter
+            gcc libgccjit pkg-config webp tree-sitter
 
       - name: Clone Emacs source
         run: |
@@ -665,7 +635,7 @@ jobs:
                 return 0
               fi
             done
-            # Search in Cellar (both ARM and Intel Homebrew prefixes)
+            # Search in Cellar
             for cellar in /opt/homebrew/Cellar /usr/local/Cellar; do
               if [[ -d "$cellar" ]]; then
                 local found=$(find "$cellar" -name "$dylib_name" -type f 2>/dev/null | head -1)
@@ -925,7 +895,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # ARM64 builds
           - runner: macos-26
             arch: arm64
             os_name: tahoe
@@ -935,10 +904,6 @@ jobs:
           - runner: macos-14
             arch: arm64
             os_name: sonoma
-          # Intel build (macos-15-intel is the only Intel runner available)
-          - runner: macos-15-intel
-            arch: x86_64
-            os_name: sequoia-intel
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -950,23 +915,13 @@ jobs:
           echo "OS_VER=$(sw_vers -productVersion)" >> $GITHUB_ENV
           echo "OS_NAME=${{ matrix.platform.os_name }}" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
-          if [ "${{ matrix.platform.arch }}" = "arm64" ]; then
-            echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
-          else
-            echo "HOMEBREW_PREFIX=/usr/local" >> $GITHUB_ENV
-          fi
+          echo "HOMEBREW_PREFIX=/opt/homebrew" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
           brew update
           brew install autoconf automake texinfo gnutls librsvg libxml2 \
-            gcc libgccjit pkg-config webp
-          # Homebrew stopped shipping x86_64 macOS bottles for tree-sitter
-          # (Intel is Tier 3 now), and refuses to build Tier 3 configurations
-          # from source unless asked explicitly. It is a small C library, so
-          # the source build is cheap. Try the bottle first so this goes back
-          # to being a no-op if x86_64 bottles ever come back.
-          brew install tree-sitter || brew install --build-from-source tree-sitter
+            gcc libgccjit pkg-config webp tree-sitter
 
       - name: Clone Emacs source
         run: |
@@ -1109,7 +1064,7 @@ jobs:
                 return 0
               fi
             done
-            # Search in Cellar (both ARM and Intel Homebrew prefixes)
+            # Search in Cellar
             for cellar in /opt/homebrew/Cellar /usr/local/Cellar; do
               if [[ -d "$cellar" ]]; then
                 local found=$(find "$cellar" -name "$dylib_name" -type f 2>/dev/null | head -1)
@@ -1363,11 +1318,6 @@ jobs:
 
   release-stable:
     needs: build-stable
-    # Run even when a build leg failed, so a broken Intel build cannot hold
-    # back the arm64 artifacts. The required-artifact check below still fails
-    # this job when an arm64 build is missing. A skipped build means the lane
-    # was not selected for this event, so stay skipped in that case.
-    if: needs.build-stable.result == 'success' || needs.build-stable.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1388,12 +1338,8 @@ jobs:
 
       - name: Check required artifacts
         run: |
-          # arm64 covers every Mac Apple still ships a macOS for, so a missing
-          # arm64 build is a hard failure. Intel is optional: Homebrew treats
-          # x86_64 macOS as a tier 3 configuration and its runner retires in
-          # August 2027, so that build breaks on its own schedule. When it is
-          # absent the cask keeps its Intel pin on the last release that did
-          # produce a binary, and the arm64 artifacts still ship.
+          # Every build leg must have uploaded its binary; a release with a
+          # missing asset would leave the cask pointing at a dead URL.
           missing=""
           for target in arm64-14 arm64-15 arm64-26; do
             if ! ls artifacts/*/emacs-plus-*-"$target".zip >/dev/null 2>&1; then
@@ -1403,12 +1349,6 @@ jobs:
           if [ -n "$missing" ]; then
             echo "::error::missing required arm64 artifacts:$missing"
             exit 1
-          fi
-          if ls artifacts/*/emacs-plus-*-x86_64-15.zip >/dev/null 2>&1; then
-            echo "HAVE_INTEL=1" >> $GITHUB_ENV
-          else
-            echo "::warning::no Intel artifact in this run, the cask keeps its current Intel pin"
-            echo "HAVE_INTEL=0" >> $GITHUB_ENV
           fi
 
       - name: Create Release for the stable lane
@@ -1453,7 +1393,7 @@ jobs:
             echo "Found: $filename -> $sha"
 
             # Determine arch and OS from filename (emacs-plus-30.1-arm64-26.zip)
-            if [[ "$filename" =~ (arm64|x86_64)-([0-9]+)\.zip$ ]]; then
+            if [[ "$filename" =~ (arm64)-([0-9]+)\.zip$ ]]; then
               arch="${BASH_REMATCH[1]}"
               os_ver="${BASH_REMATCH[2]}"
               url_pattern="${arch}-${os_ver}.zip"
@@ -1469,17 +1409,6 @@ jobs:
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
 
-          # The Intel pin moves only when there is a fresh Intel binary to
-          # point it at, so the cask never links to an asset that was not
-          # published. Note the pattern matches the assignment, so it cannot
-          # collide with the version stanza updated above.
-          if [ "$HAVE_INTEL" = "1" ]; then
-            echo "Updating intel_version to ${EMACS_VER}-${BUILD_NUM}"
-            sed -i "s/intel_version = \"[0-9.]*-[0-9]*\"/intel_version = \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
-          else
-            echo "No Intel artifact, leaving intel_version as is"
-          fi
-
           # Point the cask at this lane's release tag
           sed -i -e "s|cask-[a-z0-9]*-<build>|cask-stable-<build>|" \
                  -e "s|/download/cask-[a-z0-9]*-#|/download/cask-stable-#|" "$CASK_FILE"
@@ -1491,8 +1420,8 @@ jobs:
         run: |
           # Every artifact this run published has to appear in the cask. The
           # update script walks back from a url to its sha256 stanza, and a
-          # cask restructure once put a blank line in the way, so Intel kept
-          # a stale sha while its url moved on. Fail here instead of shipping
+          # cask restructure once put a blank line in the way, so one block
+          # kept a stale sha while its url moved on. Fail here instead of shipping
           # a cask that cannot verify.
           CASK_FILE="Casks/emacs-plus-app.rb"
           for sha_file in artifacts/*/*.sha256; do
@@ -1527,11 +1456,6 @@ jobs:
     # Publish artifacts and update the emacs-plus-app@next cask, which
     # tracks the Emacs release branch.
     needs: build-next
-    # Run even when a build leg failed, so a broken Intel build cannot hold
-    # back the arm64 artifacts. The required-artifact check below still fails
-    # this job when an arm64 build is missing. A skipped build means the lane
-    # was not selected for this event, so stay skipped in that case.
-    if: needs.build-next.result == 'success' || needs.build-next.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1552,12 +1476,8 @@ jobs:
 
       - name: Check required artifacts
         run: |
-          # arm64 covers every Mac Apple still ships a macOS for, so a missing
-          # arm64 build is a hard failure. Intel is optional: Homebrew treats
-          # x86_64 macOS as a tier 3 configuration and its runner retires in
-          # August 2027, so that build breaks on its own schedule. When it is
-          # absent the cask keeps its Intel pin on the last release that did
-          # produce a binary, and the arm64 artifacts still ship.
+          # Every build leg must have uploaded its binary; a release with a
+          # missing asset would leave the cask pointing at a dead URL.
           missing=""
           for target in arm64-14 arm64-15 arm64-26; do
             if ! ls artifacts/*/emacs-plus-*-"$target".zip >/dev/null 2>&1; then
@@ -1567,12 +1487,6 @@ jobs:
           if [ -n "$missing" ]; then
             echo "::error::missing required arm64 artifacts:$missing"
             exit 1
-          fi
-          if ls artifacts/*/emacs-plus-*-x86_64-15.zip >/dev/null 2>&1; then
-            echo "HAVE_INTEL=1" >> $GITHUB_ENV
-          else
-            echo "::warning::no Intel artifact in this run, the cask keeps its current Intel pin"
-            echo "HAVE_INTEL=0" >> $GITHUB_ENV
           fi
 
       - name: Create Release for the next lane
@@ -1622,7 +1536,7 @@ jobs:
             echo "Found: $filename -> $sha"
 
             # Determine arch and OS from filename (emacs-plus-31.0.91-arm64-26.zip)
-            if [[ "$filename" =~ (arm64|x86_64)-([0-9]+)\.zip$ ]]; then
+            if [[ "$filename" =~ (arm64)-([0-9]+)\.zip$ ]]; then
               arch="${BASH_REMATCH[1]}"
               os_ver="${BASH_REMATCH[2]}"
               url_pattern="${arch}-${os_ver}.zip"
@@ -1638,17 +1552,6 @@ jobs:
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
 
-          # The Intel pin moves only when there is a fresh Intel binary to
-          # point it at, so the cask never links to an asset that was not
-          # published. Note the pattern matches the assignment, so it cannot
-          # collide with the version stanza updated above.
-          if [ "$HAVE_INTEL" = "1" ]; then
-            echo "Updating intel_version to ${EMACS_VER}-${BUILD_NUM}"
-            sed -i "s/intel_version = \"[0-9.]*-[0-9]*\"/intel_version = \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
-          else
-            echo "No Intel artifact, leaving intel_version as is"
-          fi
-
           # Point the cask at this lane's release tag
           sed -i -e "s|cask-[a-z0-9]*-<build>|cask-next-<build>|" \
                  -e "s|/download/cask-[a-z0-9]*-#|/download/cask-next-#|" "$CASK_FILE"
@@ -1660,8 +1563,8 @@ jobs:
         run: |
           # Every artifact this run published has to appear in the cask. The
           # update script walks back from a url to its sha256 stanza, and a
-          # cask restructure once put a blank line in the way, so Intel kept
-          # a stale sha while its url moved on. Fail here instead of shipping
+          # cask restructure once put a blank line in the way, so one block
+          # kept a stale sha while its url moved on. Fail here instead of shipping
           # a cask that cannot verify.
           CASK_FILE="Casks/emacs-plus-app@next.rb"
           for sha_file in artifacts/*/*.sha256; do
@@ -1694,11 +1597,6 @@ jobs:
 
   release-master:
     needs: build-master
-    # Run even when a build leg failed, so a broken Intel build cannot hold
-    # back the arm64 artifacts. The required-artifact check below still fails
-    # this job when an arm64 build is missing. A skipped build means the lane
-    # was not selected for this event, so stay skipped in that case.
-    if: needs.build-master.result == 'success' || needs.build-master.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1719,12 +1617,8 @@ jobs:
 
       - name: Check required artifacts
         run: |
-          # arm64 covers every Mac Apple still ships a macOS for, so a missing
-          # arm64 build is a hard failure. Intel is optional: Homebrew treats
-          # x86_64 macOS as a tier 3 configuration and its runner retires in
-          # August 2027, so that build breaks on its own schedule. When it is
-          # absent the cask keeps its Intel pin on the last release that did
-          # produce a binary, and the arm64 artifacts still ship.
+          # Every build leg must have uploaded its binary; a release with a
+          # missing asset would leave the cask pointing at a dead URL.
           missing=""
           for target in arm64-14 arm64-15 arm64-26; do
             if ! ls artifacts/*/emacs-plus-*-"$target".zip >/dev/null 2>&1; then
@@ -1734,12 +1628,6 @@ jobs:
           if [ -n "$missing" ]; then
             echo "::error::missing required arm64 artifacts:$missing"
             exit 1
-          fi
-          if ls artifacts/*/emacs-plus-*-x86_64-15.zip >/dev/null 2>&1; then
-            echo "HAVE_INTEL=1" >> $GITHUB_ENV
-          else
-            echo "::warning::no Intel artifact in this run, the cask keeps its current Intel pin"
-            echo "HAVE_INTEL=0" >> $GITHUB_ENV
           fi
 
       - name: Create Release for the master lane
@@ -1784,7 +1672,7 @@ jobs:
             echo "Found: $filename -> $sha"
 
             # Determine arch and OS from filename (emacs-plus-32.1-arm64-26.zip)
-            if [[ "$filename" =~ (arm64|x86_64)-([0-9]+)\.zip$ ]]; then
+            if [[ "$filename" =~ (arm64)-([0-9]+)\.zip$ ]]; then
               arch="${BASH_REMATCH[1]}"
               os_ver="${BASH_REMATCH[2]}"
               url_pattern="${arch}-${os_ver}.zip"
@@ -1800,17 +1688,6 @@ jobs:
           echo "Updating version to ${EMACS_VER}-${BUILD_NUM}"
           sed -i "s/version \"[0-9.]*-[0-9]*\"/version \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
 
-          # The Intel pin moves only when there is a fresh Intel binary to
-          # point it at, so the cask never links to an asset that was not
-          # published. Note the pattern matches the assignment, so it cannot
-          # collide with the version stanza updated above.
-          if [ "$HAVE_INTEL" = "1" ]; then
-            echo "Updating intel_version to ${EMACS_VER}-${BUILD_NUM}"
-            sed -i "s/intel_version = \"[0-9.]*-[0-9]*\"/intel_version = \"${EMACS_VER}-${BUILD_NUM}\"/" "$CASK_FILE"
-          else
-            echo "No Intel artifact, leaving intel_version as is"
-          fi
-
           # Point the cask at this lane's release tag
           sed -i -e "s|cask-[a-z0-9]*-<build>|cask-master-<build>|" \
                  -e "s|/download/cask-[a-z0-9]*-#|/download/cask-master-#|" "$CASK_FILE"
@@ -1822,8 +1699,8 @@ jobs:
         run: |
           # Every artifact this run published has to appear in the cask. The
           # update script walks back from a url to its sha256 stanza, and a
-          # cask restructure once put a blank line in the way, so Intel kept
-          # a stale sha while its url moved on. Fail here instead of shipping
+          # cask restructure once put a blank line in the way, so one block
+          # kept a stale sha while its url moved on. Fail here instead of shipping
           # a cask that cannot verify.
           CASK_FILE="Casks/emacs-plus-app@master.rb"
           for sha_file in artifacts/*/*.sha256; do

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -26,25 +26,6 @@ cask "emacs-plus-app" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
-  on_intel do
-    # Intel assets can lag behind the arm64 ones. Homebrew treats x86_64 macOS
-    # as a tier 3 configuration and stopped bottling some dependencies for it,
-    # so the Intel build breaks on its own schedule and a release can ship
-    # without it. This pin points at the last release that did produce an Intel
-    # binary, so it is expected to trail the version above from time to time.
-    intel_version = "31.1-319"
-    intel_emacs_ver = intel_version.sub(/-\d+$/, "")
-    intel_base_url = base_url.sub(/-\d+$/, "-#{intel_version.sub(/^[\d.]+-/, "")}")
-
-    sha256 "2ec1187a64ae71642a1fd29a81e1c90e13cdcc30fe403692356f6c58532f73c6"
-
-    url "#{intel_base_url}/emacs-plus-#{intel_emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-
-    # The only Intel build targets macOS 15 (built on the macos-15-intel
-    # runner, the sole Intel runner available)
-    depends_on macos: :sequoia
-  end
 
   name "Emacs+"
   desc "GNU Emacs text editor with patches"
@@ -64,6 +45,9 @@ cask "emacs-plus-app" do
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
   depends_on :macos
+  # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
+  # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
+  depends_on arch: :arm64
 
   # Install the app
   app "Emacs.app"

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -26,25 +26,6 @@ cask "emacs-plus-app@master" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
-  on_intel do
-    # Intel assets can lag behind the arm64 ones. Homebrew treats x86_64 macOS
-    # as a tier 3 configuration and stopped bottling some dependencies for it,
-    # so the Intel build breaks on its own schedule and a release can ship
-    # without it. This pin points at the last release that did produce an Intel
-    # binary, so it is expected to trail the version above from time to time.
-    intel_version = "32.0.50-321"
-    intel_emacs_ver = intel_version.sub(/-\d+$/, "")
-    intel_base_url = base_url.sub(/-\d+$/, "-#{intel_version.sub(/^[\d.]+-/, "")}")
-
-    sha256 "099bb4ba50cd2e5ed3c46b1cbce3a14192afc70466bf4bb07d7f8a5f521dc396"
-
-    url "#{intel_base_url}/emacs-plus-#{intel_emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-
-    # The only Intel build targets macOS 15 (built on the macos-15-intel
-    # runner, the sole Intel runner available)
-    depends_on macos: :sequoia
-  end
 
   name "Emacs+ (Development)"
   desc "GNU Emacs text editor with patches (development version)"
@@ -64,6 +45,9 @@ cask "emacs-plus-app@master" do
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
   depends_on :macos
+  # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
+  # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
+  depends_on arch: :arm64
 
   # Install the app
   app "Emacs.app"

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -26,25 +26,6 @@ cask "emacs-plus-app@next" do
           verified: "github.com/d12frosted/homebrew-emacs-plus"
     end
   end
-  on_intel do
-    # Intel assets can lag behind the arm64 ones. Homebrew treats x86_64 macOS
-    # as a tier 3 configuration and stopped bottling some dependencies for it,
-    # so the Intel build breaks on its own schedule and a release can ship
-    # without it. This pin points at the last release that did produce an Intel
-    # binary, so it is expected to trail the version above from time to time.
-    intel_version = "31.1.50-321"
-    intel_emacs_ver = intel_version.sub(/-\d+$/, "")
-    intel_base_url = base_url.sub(/-\d+$/, "-#{intel_version.sub(/^[\d.]+-/, "")}")
-
-    sha256 "bd05b26b913c717267f2594e007ed13ecf6827011d2173d62913fb96efc74ab5"
-
-    url "#{intel_base_url}/emacs-plus-#{intel_emacs_ver}-x86_64-15.zip",
-        verified: "github.com/d12frosted/homebrew-emacs-plus"
-
-    # The only Intel build targets macOS 15 (built on the macos-15-intel
-    # runner, the sole Intel runner available)
-    depends_on macos: :sequoia
-  end
 
   name "Emacs+ (Next)"
   desc "GNU Emacs text editor with patches (Emacs release branch)"
@@ -64,6 +45,9 @@ cask "emacs-plus-app@next" do
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
   depends_on :macos
+  # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
+  # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
+  depends_on arch: :arm64
 
   # Install the app
   app "Emacs.app"

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,16 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-09-05
+
+** Breaking changes
+
+*** Intel (x86_64) cask builds are gone
+
+Homebrew treats x86_64 macOS as a tier 3 configuration and has been dropping Intel bottles one dependency at a time: =tree-sitter= on 2026-09-01, =gcc= on 2026-09-03. The gcc one means a two hour source build on the Intel runner, and that build then fails in a way that has nothing to do with Emacs. Apple ships no new macOS for Intel after Tahoe, and GitHub retires =macos-15-intel=, the last x86_64 runner, in August 2027. Keeping the Intel leg alive had become a chore, so it is gone: the three casks are arm64 only (=depends_on arch: :arm64=) and the build matrix has no Intel leg.
+
+If you use Emacs+ on an Intel Mac, install the formula instead (=brew install emacs-plus@31=). It builds from source and needs no runner, though Homebrew's tier 3 status means some dependencies build from source too. The last Intel cask assets stay downloadable from the releases page. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/1002][#1002]].
+
 * 2026-09-01
 
 ** Improvements

--- a/README.org
+++ b/README.org
@@ -150,10 +150,10 @@ Cask builds are self-contained applications with all dependencies bundled. They 
 |----------------------+------------------------+---------------------------|
 | Install time         | ~1 minute (download)   | ~30 minutes (compile)     |
 | Custom build options | No                     | Yes (icons, patches, etc) |
-| macOS versions       | ARM64: 14+, Intel: 15+ | Any supported             |
-| Architectures        | ARM64 and Intel        | Any                       |
+| macOS versions       | 14+                    | Any supported             |
+| Architectures        | ARM64 only             | Any                       |
 
-*Note:* Cask builds are architecture and macOS version specific. ARM64 has dedicated builds for Sonoma (14), Sequoia (15), and Tahoe (26). Intel has a single Sequoia (15) build. On older macOS versions the cask refuses to install; use the formula instead.
+*Note:* Cask builds are macOS version specific, with dedicated builds for Sonoma (14), Sequoia (15), and Tahoe (26). On older macOS versions, and on Intel Macs, the cask refuses to install; use the formula instead. Intel builds were dropped in September 2026, see [[https://github.com/d12frosted/homebrew-emacs-plus/issues/1002][#1002]].
 
 Use the *formula* if you need custom icons, patches, or specific build options. Use the *cask* for quick installation with sensible defaults.
 


### PR DESCRIPTION
Homebrew is dropping Intel bottles one dependency at a time (tree-sitter, then gcc on 2026-09-03). The Intel leg now spends two hours building gcc from source, fails anyway, and the release jobs go down with it. With no new macOS for Intel after Tahoe and the last x86_64 runner retiring in August 2027, I am calling it here.

Removes the Intel leg from the build matrix, the optional-leg handling in the release jobs, and the `on_intel` block from the three casks, which now declare `depends_on arch: :arm64`. Intel users can install the formula, which builds from source.

Closes #1002
