### PR TITLE
fix(cask): keep the url outside on_arm so brew tap validates on Intel

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,12 @@ jobs:
           brew style --except-cops Cask/NoOverrides,Cask/OnSystemConditionals \
             "$TAP_DIR/Formula" "$TAP_DIR/Casks"
 
+      # brew tap loads every formula and cask on every OS/arch pair and refuses
+      # the tap when one fails, so run the same check here. Casks that only
+      # declare a url inside on_arm break it on Intel (#1005).
+      - name: Run brew readall on every OS and arch
+        run: brew readall --os=all --arch=all d12frosted/emacs-plus
+
       - name: Validate icons
         run: ruby scripts/validate-icons.rb
 

--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -7,24 +7,19 @@ cask "emacs-plus-app" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-stable-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_arm do
-    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
-    # runner), so Ventura cannot run it
-    depends_on macos: :sonoma
-
-    if MacOS.version >= :tahoe # macOS 26
-      sha256 "ab63f753bdd30b77664dff9c593f37b179bb3bf16c2960bb6db90499e9a97fbe"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    elsif MacOS.version >= :sequoia # macOS 15
-      sha256 "a81c2224b0f9a714c9bd59fbd8190289f8b0ad672d18717bd853fc21e16fcb99"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma)
-      sha256 "ab493fcb480ef48fc6aba05c28d6ccc8c43dfc65100680063b71f4a9dfdc40f9"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    end
+  # The url lives at the top level on purpose. `brew tap` loads every cask
+  # on every OS/arch pair, and a cask with no url on Intel fails that
+  # check, which broke tapping (#1005). `depends_on arch:` below is what
+  # refuses the install on Intel.
+  if MacOS.version >= :tahoe # macOS 26
+    sha256 "ab63f753bdd30b77664dff9c593f37b179bb3bf16c2960bb6db90499e9a97fbe"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip"
+  elsif MacOS.version >= :sequoia # macOS 15
+    sha256 "a81c2224b0f9a714c9bd59fbd8190289f8b0ad672d18717bd853fc21e16fcb99"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip"
+  else # macOS 14 (Sonoma)
+    sha256 "ab493fcb480ef48fc6aba05c28d6ccc8c43dfc65100680063b71f4a9dfdc40f9"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip"
   end
 
   name "Emacs+"
@@ -44,7 +39,9 @@ cask "emacs-plus-app" do
   # - gcc: provides toolchain and libemutls_w.a runtime library
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
-  depends_on :macos
+  # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+  # runner), so Ventura cannot run it
+  depends_on macos: :sonoma
   # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
   # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
   depends_on arch: :arm64

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -7,24 +7,19 @@ cask "emacs-plus-app@master" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-master-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_arm do
-    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
-    # runner), so Ventura cannot run it
-    depends_on macos: :sonoma
-
-    if MacOS.version >= :tahoe # macOS 26
-      sha256 "7e8a6aa31233c4a6e7293ffc311ab418ae62c8a9e3fc30f1e147088d3ee3bbbb"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    elsif MacOS.version >= :sequoia # macOS 15
-      sha256 "f6b3cb4e0754d12d0922ea094deded700bdfacd2bad3d44bae4181b3e44d1763"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma)
-      sha256 "d7c73c8f4a66e3c379689b4e5c0a31e01d325bafd2099c77d4f527fb7a01ce37"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    end
+  # The url lives at the top level on purpose. `brew tap` loads every cask
+  # on every OS/arch pair, and a cask with no url on Intel fails that
+  # check, which broke tapping (#1005). `depends_on arch:` below is what
+  # refuses the install on Intel.
+  if MacOS.version >= :tahoe # macOS 26
+    sha256 "7e8a6aa31233c4a6e7293ffc311ab418ae62c8a9e3fc30f1e147088d3ee3bbbb"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip"
+  elsif MacOS.version >= :sequoia # macOS 15
+    sha256 "f6b3cb4e0754d12d0922ea094deded700bdfacd2bad3d44bae4181b3e44d1763"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip"
+  else # macOS 14 (Sonoma)
+    sha256 "d7c73c8f4a66e3c379689b4e5c0a31e01d325bafd2099c77d4f527fb7a01ce37"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip"
   end
 
   name "Emacs+ (Development)"
@@ -44,7 +39,9 @@ cask "emacs-plus-app@master" do
   # - gcc: provides toolchain and libemutls_w.a runtime library
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
-  depends_on :macos
+  # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+  # runner), so Ventura cannot run it
+  depends_on macos: :sonoma
   # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
   # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
   depends_on arch: :arm64

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -7,24 +7,19 @@ cask "emacs-plus-app@next" do
   base_url = "https://github.com/d12frosted/homebrew-emacs-plus/releases/download/cask-next-#{version.sub(/^[\d.]+-/, "")}"
   emacs_ver = version.sub(/-\d+$/, "")
 
-  on_arm do
-    # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
-    # runner), so Ventura cannot run it
-    depends_on macos: :sonoma
-
-    if MacOS.version >= :tahoe # macOS 26
-      sha256 "c2a8863afd2f0fd6a928764729500bc37d9b26f5ba5a1d80590f7e47d0c187e2"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    elsif MacOS.version >= :sequoia # macOS 15
-      sha256 "868964d81a2de11a12eb3d07a433437ecb8c20b06fe4d57145a57b25a736aa32"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    else # macOS 14 (Sonoma)
-      sha256 "8202f0a2623fe00648f87af1c11a31b1412cc8b748998d7fe27e585fb4cfa676"
-      url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip",
-          verified: "github.com/d12frosted/homebrew-emacs-plus"
-    end
+  # The url lives at the top level on purpose. `brew tap` loads every cask
+  # on every OS/arch pair, and a cask with no url on Intel fails that
+  # check, which broke tapping (#1005). `depends_on arch:` below is what
+  # refuses the install on Intel.
+  if MacOS.version >= :tahoe # macOS 26
+    sha256 "c2a8863afd2f0fd6a928764729500bc37d9b26f5ba5a1d80590f7e47d0c187e2"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-26.zip"
+  elsif MacOS.version >= :sequoia # macOS 15
+    sha256 "868964d81a2de11a12eb3d07a433437ecb8c20b06fe4d57145a57b25a736aa32"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-15.zip"
+  else # macOS 14 (Sonoma)
+    sha256 "8202f0a2623fe00648f87af1c11a31b1412cc8b748998d7fe27e585fb4cfa676"
+    url "#{base_url}/emacs-plus-#{emacs_ver}-arm64-14.zip"
   end
 
   name "Emacs+ (Next)"
@@ -44,7 +39,9 @@ cask "emacs-plus-app@next" do
   # - gcc: provides toolchain and libemutls_w.a runtime library
   depends_on formula: "libgccjit"
   depends_on formula: "gcc"
-  depends_on :macos
+  # Oldest prebuilt arm64 binary targets macOS 14 (built on the macos-14
+  # runner), so Ventura cannot run it
+  depends_on macos: :sonoma
   # Prebuilt binaries are arm64 only; on Intel use the formula, which builds
   # from source. See https://github.com/d12frosted/homebrew-emacs-plus/issues/1002
   depends_on arch: :arm64

--- a/NEWS.org
+++ b/NEWS.org
@@ -3,6 +3,16 @@
 
 This file documents notable changes to Emacs Plus.
 
+* 2026-09-08
+
+** Bug fixes
+
+*** =brew tap d12frosted/emacs-plus= works again
+
+Dropping the Intel cask builds on 2026-09-05 left the cask =url= only inside the =on_arm= block. =brew tap= loads every cask on every OS and architecture pair before it accepts a tap, and on Intel the casks had no url, so tapping failed with "Invalid cask (macOS N on intel)" and "invalid syntax in tap". Existing checkouts kept working, which is why this went unnoticed for a few days. The url now lives at the top level and =depends_on arch: :arm64= is what refuses the install on Intel. CI runs the same readall check now. See [[https://github.com/d12frosted/homebrew-emacs-plus/issues/1005][#1005]].
+
+The casks also stop passing the =verified:= parameter to =url= and declare =depends_on macos: :sonoma= at the top level instead of a bare =depends_on :macos=: Homebrew 6.0.22 deprecated the former and disabled combining the latter two. The =postflight= deprecation warning from the same release is still there; that migration is a separate change.
+
 * 2026-09-05
 
 ** Breaking changes


### PR DESCRIPTION
Since I dropped the Intel cask builds (#1004), the cask url only existed inside `on_arm`. `brew tap` loads every cask on every OS/arch pair and on Intel there was no url, so tapping failed with "Invalid cask (macOS N on intel)" / "invalid syntax in tap". Existing checkouts kept working, which is why nobody noticed for a few days.

Fix: url at the top level, `depends_on arch: :arm64` does the refusing. While here: drop the `verified:` url parameter (deprecated in Homebrew 6.0.22) and use `depends_on macos: :sonoma` instead of a bare `depends_on :macos` (combining both is disabled in 6.0.22). CI runs `brew readall --os=all --arch=all` now.

The `postflight` deprecation warning from 6.0.22 is a separate, bigger change and comes next.

Closes #1005