### PR TITLE
refactor(cask): move postflight to postflight_steps

### DIFF
--- a/Casks/emacs-plus-app.rb
+++ b/Casks/emacs-plus-app.rb
@@ -49,9 +49,8 @@ cask "emacs-plus-app" do
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
+  # Symlink binaries. emacs itself is a symlink step in postflight_steps:
+  # the wrapper it points at is generated there, after binary stanzas ran
   # Note: no ctags symlink; the ctags program was removed in Emacs 31
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
@@ -62,26 +61,31 @@ cask "emacs-plus-app" do
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
-  # Remove quarantine attribute, inject PATH, and apply custom icon
-  # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
-  postflight do
-    tap = Tap.fetch("d12frosted", "emacs-plus")
-    load "#{tap.path}/Library/CaskPostflight.rb"
-    CaskPostflight.run(self,
-                       emacs_app:        "#{appdir}/Emacs.app",
-                       emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version:          version.major,
-                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
-  end
-
-  # Clean up emacs symlink on uninstall (since we create it manually in postflight)
-  # Only remove it when it points into this cask's Emacs.app: the formulas
-  # link bin/emacs too, and that symlink is not ours to delete
-  uninstall_postflight do
-    emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
-    if File.symlink?(emacs_symlink) &&
-       File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm(emacs_symlink)
+  # Post-install setup: quarantine removal, environment injection, custom
+  # icon and re-signing. postflight_steps only takes literal steps, so the
+  # Ruby in Library/ runs through scripts/cask-postflight as a `run` step.
+  # The step runs in Homebrew's sandbox with a scratch HOME; the build.yml
+  # locations are declared so the script can still read them, and network
+  # access is for icons pulled from a URL.
+  postflight_steps do
+    run "{{HOMEBREW_PREFIX}}/Library/Taps/d12frosted/homebrew-emacs-plus/scripts/cask-postflight",
+        args:           ["--emacs-app", "{{appdir}}/Emacs.app",
+                         "--emacs-client-app", "{{appdir}}/Emacs Client.app",
+                         "--version", "{{version.major}}",
+                         "--homebrew-prefix", "{{HOMEBREW_PREFIX}}"],
+        writable_paths: ["~/.config/emacs-plus", "~/.emacs-plus-build.yml"],
+        network_access: true,
+        print_stdout:   true
+    # bin/emacs points at the wrapper the script generates, which is why it
+    # is not a `binary` stanza (those run before postflight). An existing
+    # link, such as the one from an emacs-plus formula, is left alone (the
+    # step would fail on it otherwise), and uninstall only removes a link
+    # that points into this Emacs.app.
+    unless_path_exists "bin/emacs", base: :homebrew_prefix do
+      symlink "Emacs.app/Contents/MacOS/bin/emacs", "bin/emacs",
+              source_base:         :appdir,
+              target_base:         :homebrew_prefix,
+              remove_on_uninstall: true
     end
   end
 

--- a/Casks/emacs-plus-app@master.rb
+++ b/Casks/emacs-plus-app@master.rb
@@ -49,9 +49,8 @@ cask "emacs-plus-app@master" do
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
+  # Symlink binaries. emacs itself is a symlink step in postflight_steps:
+  # the wrapper it points at is generated there, after binary stanzas ran
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
@@ -61,26 +60,31 @@ cask "emacs-plus-app@master" do
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
-  # Remove quarantine attribute, inject PATH, and apply custom icon
-  # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
-  postflight do
-    tap = Tap.fetch("d12frosted", "emacs-plus")
-    load "#{tap.path}/Library/CaskPostflight.rb"
-    CaskPostflight.run(self,
-                       emacs_app:        "#{appdir}/Emacs.app",
-                       emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version:          version.major,
-                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
-  end
-
-  # Clean up emacs symlink on uninstall (since we create it manually in postflight)
-  # Only remove it when it points into this cask's Emacs.app: the formulas
-  # link bin/emacs too, and that symlink is not ours to delete
-  uninstall_postflight do
-    emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
-    if File.symlink?(emacs_symlink) &&
-       File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm(emacs_symlink)
+  # Post-install setup: quarantine removal, environment injection, custom
+  # icon and re-signing. postflight_steps only takes literal steps, so the
+  # Ruby in Library/ runs through scripts/cask-postflight as a `run` step.
+  # The step runs in Homebrew's sandbox with a scratch HOME; the build.yml
+  # locations are declared so the script can still read them, and network
+  # access is for icons pulled from a URL.
+  postflight_steps do
+    run "{{HOMEBREW_PREFIX}}/Library/Taps/d12frosted/homebrew-emacs-plus/scripts/cask-postflight",
+        args:           ["--emacs-app", "{{appdir}}/Emacs.app",
+                         "--emacs-client-app", "{{appdir}}/Emacs Client.app",
+                         "--version", "{{version.major}}",
+                         "--homebrew-prefix", "{{HOMEBREW_PREFIX}}"],
+        writable_paths: ["~/.config/emacs-plus", "~/.emacs-plus-build.yml"],
+        network_access: true,
+        print_stdout:   true
+    # bin/emacs points at the wrapper the script generates, which is why it
+    # is not a `binary` stanza (those run before postflight). An existing
+    # link, such as the one from an emacs-plus formula, is left alone (the
+    # step would fail on it otherwise), and uninstall only removes a link
+    # that points into this Emacs.app.
+    unless_path_exists "bin/emacs", base: :homebrew_prefix do
+      symlink "Emacs.app/Contents/MacOS/bin/emacs", "bin/emacs",
+              source_base:         :appdir,
+              target_base:         :homebrew_prefix,
+              remove_on_uninstall: true
     end
   end
 

--- a/Casks/emacs-plus-app@next.rb
+++ b/Casks/emacs-plus-app@next.rb
@@ -49,9 +49,8 @@ cask "emacs-plus-app@next" do
   # Install the app
   app "Emacs.app"
   app "Emacs Client.app"
-  # Symlink binaries (emacs symlink created in postflight after wrapper is generated)
-  # Note: emacs is symlinked manually in postflight because the wrapper script
-  # is created there and binary stanzas run before postflight
+  # Symlink binaries. emacs itself is a symlink step in postflight_steps:
+  # the wrapper it points at is generated there, after binary stanzas ran
   # Note: no ctags symlink; the ctags program was removed in Emacs 31
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
@@ -62,26 +61,31 @@ cask "emacs-plus-app@next" do
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1"
   manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1"
 
-  # Remove quarantine attribute, inject PATH, and apply custom icon
-  # (shared logic for all emacs-plus-app casks lives in Library/CaskPostflight.rb)
-  postflight do
-    tap = Tap.fetch("d12frosted", "emacs-plus")
-    load "#{tap.path}/Library/CaskPostflight.rb"
-    CaskPostflight.run(self,
-                       emacs_app:        "#{appdir}/Emacs.app",
-                       emacs_client_app: "#{appdir}/Emacs Client.app",
-                       version:          version.major,
-                       homebrew_prefix:  HOMEBREW_PREFIX.to_s)
-  end
-
-  # Clean up emacs symlink on uninstall (since we create it manually in postflight)
-  # Only remove it when it points into this cask's Emacs.app: the formulas
-  # link bin/emacs too, and that symlink is not ours to delete
-  uninstall_postflight do
-    emacs_symlink = "#{HOMEBREW_PREFIX}/bin/emacs"
-    if File.symlink?(emacs_symlink) &&
-       File.readlink(emacs_symlink).start_with?("#{appdir}/Emacs.app/")
-      FileUtils.rm(emacs_symlink)
+  # Post-install setup: quarantine removal, environment injection, custom
+  # icon and re-signing. postflight_steps only takes literal steps, so the
+  # Ruby in Library/ runs through scripts/cask-postflight as a `run` step.
+  # The step runs in Homebrew's sandbox with a scratch HOME; the build.yml
+  # locations are declared so the script can still read them, and network
+  # access is for icons pulled from a URL.
+  postflight_steps do
+    run "{{HOMEBREW_PREFIX}}/Library/Taps/d12frosted/homebrew-emacs-plus/scripts/cask-postflight",
+        args:           ["--emacs-app", "{{appdir}}/Emacs.app",
+                         "--emacs-client-app", "{{appdir}}/Emacs Client.app",
+                         "--version", "{{version.major}}",
+                         "--homebrew-prefix", "{{HOMEBREW_PREFIX}}"],
+        writable_paths: ["~/.config/emacs-plus", "~/.emacs-plus-build.yml"],
+        network_access: true,
+        print_stdout:   true
+    # bin/emacs points at the wrapper the script generates, which is why it
+    # is not a `binary` stanza (those run before postflight). An existing
+    # link, such as the one from an emacs-plus formula, is left alone (the
+    # step would fail on it otherwise), and uninstall only removes a link
+    # that points into this Emacs.app.
+    unless_path_exists "bin/emacs", base: :homebrew_prefix do
+      symlink "Emacs.app/Contents/MacOS/bin/emacs", "bin/emacs",
+              source_base:         :appdir,
+              target_base:         :homebrew_prefix,
+              remove_on_uninstall: true
     end
   end
 

--- a/Library/CaskEnv.rb
+++ b/Library/CaskEnv.rb
@@ -210,8 +210,7 @@ module CaskEnv
       plist = "#{app_path}/Contents/Info.plist"
 
       # Check if already injected
-      existing = `defaults read "#{plist}" LSEnvironment 2>/dev/null`.strip
-      return wrapper_created unless existing.empty? || existing.include?("does not exist")
+      return wrapper_created if plist_value(plist, "LSEnvironment")
 
       # Note: For cask, we can only inject native compilation paths (not user PATH)
       # due to Homebrew limitation - cask postflight doesn't have user's shell environment
@@ -294,8 +293,7 @@ module CaskEnv
 
       # Check if we need to recompile (look for our marker in Info.plist)
       plist = "#{app_path}/Contents/Info.plist"
-      marker_check = `defaults read "#{plist}" EmacsPlusPathInjected 2>/dev/null`.strip
-      return false if marker_check == "1"
+      return false if client_injected?(plist)
 
       # Note: For cask, we can only inject native compilation paths (not user PATH)
       puts "Injecting native compilation environment into #{app_path}"
@@ -378,7 +376,7 @@ module CaskEnv
       end
 
       # Mark as injected
-      system("defaults", "write", plist, "EmacsPlusPathInjected", "-bool", "true")
+      mark_client_injected(plist)
 
       # Restore plist settings that osacompile might have overwritten
       system("/usr/libexec/PlistBuddy", "-c", "Set :CFBundleIdentifier org.gnu.EmacsClient", plist)
@@ -446,6 +444,29 @@ module CaskEnv
       File.write(site_start, content)
       puts "Updated site-start.el"
       true
+    end
+
+    # Read one plist key with PlistBuddy; nil when the key is missing.
+    # PlistBuddy edits the file directly, unlike `defaults`, which goes
+    # through cfprefsd and is not something to rely on inside the cask
+    # steps sandbox.
+    def plist_value(plist, key)
+      value = IO.popen(["/usr/libexec/PlistBuddy", "-c", "Print :#{key}", plist],
+                       err: File::NULL, &:read)
+      $?.success? ? value.chomp : nil
+    end
+
+    def client_injected?(plist)
+      plist_value(plist, "EmacsPlusPathInjected") == "true"
+    end
+
+    def mark_client_injected(plist)
+      command = if plist_value(plist, "EmacsPlusPathInjected").nil?
+                  "Add :EmacsPlusPathInjected bool true"
+                else
+                  "Set :EmacsPlusPathInjected true"
+                end
+      system("/usr/libexec/PlistBuddy", "-c", command, plist)
     end
 
     # Escape a string for embedding in an AppleScript double-quoted string

--- a/Library/CaskPostflight.rb
+++ b/Library/CaskPostflight.rb
@@ -9,12 +9,13 @@
 # 1. Removing the quarantine attribute from both app bundles
 # 2. Environment injection (CaskEnv) and custom icon (IconApplier)
 # 3. Re-signing the bundles if they were modified
-# 4. Symlinking bin/emacs into HOMEBREW_PREFIX
 #
-# The matching cleanup (removing the emacs symlink) stays inline in each
-# cask's uninstall_postflight so uninstall does not depend on this file.
+# The bin/emacs symlink is a `symlink` step in the cask's postflight_steps
+# (it runs after this module has generated the wrapper), so Homebrew
+# creates and removes it without any help from here.
 #
-# ctx is the cask's postflight block (self), which provides system_command.
+# ctx provides system_command(cmd, args:, sudo:); the casks run this module
+# through scripts/cask-postflight, which supplies a shell-backed one.
 
 require 'fileutils'
 require_relative 'CaskEnv'
@@ -22,7 +23,7 @@ require_relative 'IconApplier'
 
 module CaskPostflight
   class << self
-    def run(ctx, emacs_app:, emacs_client_app:, version:, homebrew_prefix:)
+    def run(ctx, emacs_app:, emacs_client_app:, version:)
       remove_quarantine(ctx, emacs_app)
       remove_quarantine(ctx, emacs_client_app)
 
@@ -32,12 +33,10 @@ module CaskPostflight
       # Apply custom icon from ~/.config/emacs-plus/build.yml if configured
       needs_resign = IconApplier.apply(emacs_app, emacs_client_app, version: version) || needs_resign
 
-      if needs_resign
-        resign(ctx, emacs_app)
-        resign(ctx, emacs_client_app)
-      end
+      return unless needs_resign
 
-      link_emacs(emacs_app, homebrew_prefix)
+      resign(ctx, emacs_app)
+      resign(ctx, emacs_client_app)
     end
 
     private
@@ -52,16 +51,6 @@ module CaskPostflight
       ctx.system_command "/usr/bin/codesign",
                          args: ["--force", "--deep", "--sign", "-", app],
                          sudo: false
-    end
-
-    # Create the emacs symlink manually: the wrapper script is generated
-    # by CaskEnv during postflight, and binary stanzas run before that.
-    def link_emacs(emacs_app, homebrew_prefix)
-      emacs_wrapper = "#{emacs_app}/Contents/MacOS/bin/emacs"
-      emacs_symlink = "#{homebrew_prefix}/bin/emacs"
-      if File.exist?(emacs_wrapper) && !File.exist?(emacs_symlink)
-        FileUtils.ln_sf(emacs_wrapper, emacs_symlink)
-      end
     end
   end
 end

--- a/Library/CaskPostflightCLI.rb
+++ b/Library/CaskPostflightCLI.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# CaskPostflightCLI - Command-line entry point for the cask postflight
+#
+# Homebrew's `postflight_steps` only accepts literal step calls, no Ruby,
+# so the casks run scripts/cask-postflight (which execs this module) as a
+# `run` step. It parses the arguments the cask passes, provides the
+# `system_command` interface CaskPostflight expects from a cask context,
+# and reports errors with a non-zero exit status so Homebrew aborts the
+# install instead of leaving a half-configured bundle behind.
+#
+# Usage:
+#   cask-postflight --emacs-app PATH --emacs-client-app PATH \
+#                   --version MAJOR --homebrew-prefix PATH
+
+require_relative 'CaskPostflight'
+
+module CaskPostflightCLI
+  class UsageError < StandardError; end
+
+  OPTIONS = {
+    '--emacs-app'        => :emacs_app,
+    '--emacs-client-app' => :emacs_client_app,
+    '--version'          => :version,
+    '--homebrew-prefix'  => :homebrew_prefix,
+  }.freeze
+
+  USAGE = "Usage: cask-postflight #{OPTIONS.keys.map { |o| "#{o} VALUE" }.join(' ')}"
+
+  # Stand-in for the cask block's system_command. Failures are reported
+  # but do not abort: quarantine removal and re-signing were best effort
+  # in the legacy postflight too, and a missing xattr must not block the
+  # rest of the setup.
+  class ShellContext
+    def system_command(cmd, args: [], sudo: false)
+      raise ArgumentError, "sudo is not available in the cask postflight" if sudo
+
+      return true if system(cmd, *args)
+
+      warn "Warning: #{([cmd] + args).join(' ')} failed with status #{$?.exitstatus}"
+      false
+    end
+  end
+
+  class << self
+    def parse(argv)
+      options = {}
+      args = argv.dup
+      until args.empty?
+        flag = args.shift
+        key = OPTIONS[flag]
+        raise UsageError, "unknown option #{flag}" unless key
+        raise UsageError, "#{flag} needs a value" if args.empty?
+
+        options[key] = args.shift
+      end
+
+      missing = OPTIONS.values - options.keys
+      raise UsageError, "missing #{OPTIONS.key(missing.first)}" unless missing.empty?
+
+      options
+    end
+
+    # Returns the process exit status
+    def run(argv)
+      options = parse(argv)
+      # CaskEnv reads the prefix from the environment outside Homebrew
+      ENV['HOMEBREW_PREFIX'] = options[:homebrew_prefix]
+      CaskPostflight.run(ShellContext.new,
+                         emacs_app:        options[:emacs_app],
+                         emacs_client_app: options[:emacs_client_app],
+                         version:          options[:version])
+      0
+    rescue UsageError => e
+      warn "Error: #{e.message}"
+      warn USAGE
+      2
+    rescue BuildConfig::ConfigurationError => e
+      warn "Error: #{e.message}"
+      1
+    end
+  end
+end

--- a/NEWS.org
+++ b/NEWS.org
@@ -5,6 +5,14 @@ This file documents notable changes to Emacs Plus.
 
 * 2026-09-08
 
+** Improvements
+
+*** Casks use =postflight_steps=
+
+Homebrew 6.0.22 deprecated the =postflight= and =uninstall_postflight= blocks casks used to run arbitrary Ruby after install, and warns about them on every load ("Calling =postflight= is deprecated! Use =postflight_steps= instead"). The replacement is a fixed list of literal steps that Homebrew runs in a sandbox, so the three casks now run the same setup (quarantine removal, environment injection, custom icon, re-signing) through =scripts/cask-postflight= as a =run= step, and the =bin/emacs= symlink is a declarative =symlink= step that Homebrew also cleans up on uninstall. Nothing changes for users: =build.yml= icons still apply, =brew reinstall --cask= still re-applies them.
+
+One consequence of the sandbox: the postflight can only read =~/.config/emacs-plus= and =~/.emacs-plus-build.yml= from your home directory, so a =HOMEBREW_EMACS_PLUS_BUILD_CONFIG= pointing elsewhere under =$HOME= is not visible to cask installs.
+
 ** Bug fixes
 
 *** =brew tap d12frosted/emacs-plus= works again

--- a/README.org
+++ b/README.org
@@ -213,7 +213,7 @@ This section used to advise against =reinstall= altogether, because =brew= would
 Emacs+ can be configured using =~/.config/emacs-plus/build.yml=. This file controls options that are applied during installation (formula) or post-installation (cask).
 
 The configuration file is searched in this order:
-1. Path specified by =HOMEBREW_EMACS_PLUS_BUILD_CONFIG= environment variable
+1. Path specified by =HOMEBREW_EMACS_PLUS_BUILD_CONFIG= environment variable (formula installs only: the cask postflight runs in Homebrew's sandbox and can read just the two paths below)
 2. =~/.config/emacs-plus/build.yml=
 3. =~/.emacs-plus-build.yml= (fallback)
 

--- a/scripts/cask-postflight
+++ b/scripts/cask-postflight
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Entry point the emacs-plus-app casks run from postflight_steps.
+#
+# postflight_steps cannot run Ruby, only a fixed set of literal steps, and
+# one of them is `run`, so the cask runs this script and the Ruby logic in
+# Library/ stays where it is. Homebrew executes it inside the cask steps
+# sandbox: writes go to the app bundle and the Homebrew link directories,
+# HOME is a scratch directory, and the real build.yml paths are readable
+# only because the cask declares them.
+#
+# Homebrew's own Ruby is the one that is always there; the system ruby is
+# a fallback for exotic layouts where the portable one is missing.
+set -euo pipefail
+
+tap_dir="$(cd "$(dirname "$0")/.." && pwd)"
+
+ruby=""
+for candidate in \
+  "${HOMEBREW_PREFIX:-/opt/homebrew}/Library/Homebrew/vendor/portable-ruby/current/bin/ruby" \
+  "$(dirname "$(dirname "$tap_dir")")/../../Homebrew/vendor/portable-ruby/current/bin/ruby" \
+  /usr/bin/ruby; do
+  if [[ -x "$candidate" ]]; then
+    ruby="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$ruby" ]]; then
+  echo "Error: no ruby found to run the emacs-plus cask postflight" >&2
+  exit 1
+fi
+
+exec "$ruby" -r "$tap_dir/Library/CaskPostflightCLI" -e 'exit CaskPostflightCLI.run(ARGV)' -- "$@"

--- a/tests/test_cask_env.rb
+++ b/tests/test_cask_env.rb
@@ -834,4 +834,61 @@ class TestCaskEnv < Minitest::Test
       assert PlistExtras.usage_descriptions_current?("#{app_path}/Contents/Info.plist")
     end
   end
+
+  # ===========================================
+  # Plist helpers: PlistBuddy instead of `defaults`, which talks to cfprefsd
+  # and is not something to rely on inside the cask steps sandbox
+  # ===========================================
+
+  def write_minimal_plist(path)
+    File.write(path, <<~PLIST)
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleIdentifier</key>
+        <string>org.gnu.Emacs</string>
+      </dict>
+      </plist>
+    PLIST
+  end
+
+  def test_plist_value_reads_existing_key_and_nil_for_missing
+    Dir.mktmpdir do |dir|
+      plist = "#{dir}/Info.plist"
+      write_minimal_plist(plist)
+      assert_equal "org.gnu.Emacs", CaskEnv.send(:plist_value, plist, "CFBundleIdentifier")
+      assert_nil CaskEnv.send(:plist_value, plist, "LSEnvironment")
+    end
+  end
+
+  def test_inject_emacs_app_adds_library_path_once
+    Dir.mktmpdir do |dir|
+      app_path = "#{dir}/Emacs.app"
+      FileUtils.mkdir_p("#{app_path}/Contents/MacOS/bin")
+      plist = "#{app_path}/Contents/Info.plist"
+      write_minimal_plist(plist)
+      CaskEnv.stub(:build_library_path, "/opt/homebrew/lib/gcc/current") do
+        assert CaskEnv.send(:inject_emacs_app, app_path)
+        assert_equal "/opt/homebrew/lib/gcc/current",
+                     CaskEnv.send(:plist_value, plist, "LSEnvironment:LIBRARY_PATH")
+        # Second run: wrapper and LSEnvironment are already in place
+        refute CaskEnv.send(:inject_emacs_app, app_path)
+      end
+      assert File.executable?("#{app_path}/Contents/MacOS/bin/emacs")
+    end
+  end
+
+  def test_client_injected_marker_round_trips
+    Dir.mktmpdir do |dir|
+      plist = "#{dir}/Info.plist"
+      write_minimal_plist(plist)
+      refute CaskEnv.send(:client_injected?, plist)
+      CaskEnv.send(:mark_client_injected, plist)
+      assert CaskEnv.send(:client_injected?, plist)
+      # Marking twice must not fail: PlistBuddy's Add errors on existing keys
+      CaskEnv.send(:mark_client_injected, plist)
+      assert CaskEnv.send(:client_injected?, plist)
+    end
+  end
 end

--- a/tests/test_cask_postflight.rb
+++ b/tests/test_cask_postflight.rb
@@ -46,10 +46,8 @@ class TestCaskPostflight < Minitest::Test
     @tmpdir = Dir.mktmpdir
     @emacs_app = File.join(@tmpdir, 'Emacs.app')
     @client_app = File.join(@tmpdir, 'Emacs Client.app')
-    @prefix = File.join(@tmpdir, 'prefix')
     FileUtils.mkdir_p(File.join(@emacs_app, 'Contents/MacOS/bin'))
     FileUtils.mkdir_p(@client_app)
-    FileUtils.mkdir_p(File.join(@prefix, 'bin'))
     @ctx = FakeContext.new
   end
 
@@ -71,8 +69,7 @@ class TestCaskPostflight < Minitest::Test
         CaskPostflight.run(@ctx,
                            emacs_app: @emacs_app,
                            emacs_client_app: @client_app,
-                           version: '31',
-                           homebrew_prefix: @prefix)
+                           version: '31')
       end
     end
     { inject_args: inject_args, icon_args: icon_args }
@@ -136,39 +133,5 @@ class TestCaskPostflight < Minitest::Test
   def test_resigns_both_apps_after_icon_application
     run_postflight(inject: false, icon: true)
     assert_equal 2, commands_for('/usr/bin/codesign').size
-  end
-
-  # ===========================================
-  # emacs symlink
-  # ===========================================
-
-  def wrapper_path
-    File.join(@emacs_app, 'Contents/MacOS/bin/emacs')
-  end
-
-  def symlink_path
-    File.join(@prefix, 'bin/emacs')
-  end
-
-  def test_creates_emacs_symlink_when_wrapper_exists
-    FileUtils.touch(wrapper_path)
-    run_postflight
-    assert File.symlink?(symlink_path)
-    assert_equal wrapper_path, File.readlink(symlink_path)
-  end
-
-  def test_keeps_existing_emacs_symlink
-    FileUtils.touch(wrapper_path)
-    other_target = File.join(@tmpdir, 'other-emacs')
-    FileUtils.touch(other_target)
-    File.symlink(other_target, symlink_path)
-    run_postflight
-    assert_equal other_target, File.readlink(symlink_path)
-  end
-
-  def test_no_symlink_when_wrapper_missing
-    run_postflight
-    refute File.exist?(symlink_path)
-    refute File.symlink?(symlink_path)
   end
 end

--- a/tests/test_cask_postflight_cli.rb
+++ b/tests/test_cask_postflight_cli.rb
@@ -1,0 +1,163 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Test suite for CaskPostflightCLI, the entry point the casks run from
+# postflight_steps (through scripts/cask-postflight)
+#
+# Run with: ruby tests/test_cask_postflight_cli.rb
+
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'tmpdir'
+require 'fileutils'
+require 'stringio'
+
+# Mock Hardware::CPU for testing without Homebrew (CaskEnv depends on it)
+module Hardware
+  module CPU
+    class << self
+      attr_accessor :mock_arm
+
+      def arm?
+        @mock_arm.nil? ? false : @mock_arm
+      end
+    end
+  end
+end
+
+require_relative '../Library/CaskPostflightCLI'
+
+class TestCaskPostflightCLI < Minitest::Test
+  ARGS = [
+    '--emacs-app', '/Applications/Emacs.app',
+    '--emacs-client-app', '/Applications/Emacs Client.app',
+    '--version', '31',
+    '--homebrew-prefix', '/opt/homebrew',
+  ].freeze
+
+  def setup
+    Hardware::CPU.mock_arm = true
+    @saved_prefix = ENV['HOMEBREW_PREFIX']
+  end
+
+  def teardown
+    if @saved_prefix
+      ENV['HOMEBREW_PREFIX'] = @saved_prefix
+    else
+      ENV.delete('HOMEBREW_PREFIX')
+    end
+  end
+
+  def capture
+    out = StringIO.new
+    err = StringIO.new
+    orig_out, orig_err = $stdout, $stderr
+    $stdout, $stderr = out, err
+    yield
+    [out.string, err.string]
+  ensure
+    $stdout, $stderr = orig_out, orig_err
+  end
+
+  # ===========================================
+  # Argument parsing
+  # ===========================================
+
+  def test_parse_reads_all_options
+    options = CaskPostflightCLI.parse(ARGS)
+    assert_equal '/Applications/Emacs.app', options[:emacs_app]
+    assert_equal '/Applications/Emacs Client.app', options[:emacs_client_app]
+    assert_equal '31', options[:version]
+    assert_equal '/opt/homebrew', options[:homebrew_prefix]
+  end
+
+  def test_parse_rejects_missing_option
+    error = assert_raises(CaskPostflightCLI::UsageError) do
+      CaskPostflightCLI.parse(ARGS.reject.with_index { |_, i| [4, 5].include?(i) })
+    end
+    assert_includes error.message, '--version'
+  end
+
+  def test_parse_rejects_unknown_option
+    error = assert_raises(CaskPostflightCLI::UsageError) do
+      CaskPostflightCLI.parse(ARGS + ['--bogus', 'x'])
+    end
+    assert_includes error.message, '--bogus'
+  end
+
+  def test_parse_rejects_option_without_value
+    assert_raises(CaskPostflightCLI::UsageError) do
+      CaskPostflightCLI.parse(ARGS[0..-2])
+    end
+  end
+
+  # ===========================================
+  # ShellContext: the system_command the postflight expects from a cask
+  # ===========================================
+
+  def test_shell_context_runs_the_command
+    Dir.mktmpdir do |dir|
+      target = File.join(dir, 'touched')
+      ctx = CaskPostflightCLI::ShellContext.new
+      capture { ctx.system_command('/usr/bin/touch', args: [target], sudo: false) }
+      assert File.exist?(target)
+    end
+  end
+
+  def test_shell_context_warns_instead_of_raising_on_failure
+    ctx = CaskPostflightCLI::ShellContext.new
+    _out, err = capture { ctx.system_command('/usr/bin/false', args: [], sudo: false) }
+    assert_includes err, '/usr/bin/false'
+  end
+
+  def test_shell_context_refuses_sudo
+    ctx = CaskPostflightCLI::ShellContext.new
+    assert_raises(ArgumentError) do
+      ctx.system_command('/usr/bin/true', args: [], sudo: true)
+    end
+  end
+
+  # ===========================================
+  # run: wiring into CaskPostflight
+  # ===========================================
+
+  def test_run_calls_cask_postflight_with_parsed_options
+    received = nil
+    CaskPostflight.stub(:run, lambda { |ctx, **kwargs|
+      received = [ctx, kwargs]
+      nil
+    }) do
+      status = nil
+      capture { status = CaskPostflightCLI.run(ARGS) }
+      assert_equal 0, status
+    end
+    ctx, kwargs = received
+    assert_kind_of CaskPostflightCLI::ShellContext, ctx
+    assert_equal({ emacs_app: '/Applications/Emacs.app',
+                   emacs_client_app: '/Applications/Emacs Client.app',
+                   version: '31' }, kwargs)
+  end
+
+  def test_run_exports_homebrew_prefix_for_cask_env
+    CaskPostflight.stub(:run, ->(*) { nil }) do
+      capture { CaskPostflightCLI.run(ARGS) }
+    end
+    assert_equal '/opt/homebrew', ENV['HOMEBREW_PREFIX']
+  end
+
+  def test_run_reports_usage_errors
+    status = nil
+    _out, err = capture { status = CaskPostflightCLI.run(['--emacs-app']) }
+    assert_equal 2, status
+    assert_includes err, 'Usage'
+  end
+
+  def test_run_reports_configuration_errors
+    CaskPostflight.stub(:run, ->(*) { raise BuildConfig::ConfigurationError, 'bad icon' }) do
+      status = nil
+      _out, err = capture { status = CaskPostflightCLI.run(ARGS) }
+      assert_equal 1, status
+      assert_includes err, 'bad icon'
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #1007. Homebrew 6.0.22 deprecated the `postflight` / `uninstall_postflight` blocks (they will be disabled in a coming release, and the newest cask cops already flag them), so the three casks now use `postflight_steps`.

That DSL only takes literal steps run in a sandbox, no Ruby, so the existing logic in `Library/` runs through a new `scripts/cask-postflight` as a `run` step. The build.yml locations under `$HOME` are declared so the sandbox lets the script read them, and `bin/emacs` is a `symlink` step that Homebrew creates after the wrapper exists and removes on uninstall by itself, which replaces the old uninstall hook. `defaults` calls became PlistBuddy since `defaults` goes through cfprefsd.

Verified with a real install through the new steps: LIBRARY_PATH injection, wrapper, site-start.el, Emacs Client.app recompile, icon from `~/.config/emacs-plus/build.yml`, re-signing and quarantine removal all work inside the sandbox, and an existing formula `bin/emacs` link is left alone.

Known limitation: `HOMEBREW_EMACS_PLUS_BUILD_CONFIG` pointing elsewhere under `$HOME` is not visible to cask installs anymore (formula installs unaffected).